### PR TITLE
Fixed being unable to read maps from the cycle

### DIFF
--- a/.publish/info.xml
+++ b/.publish/info.xml
@@ -1,6 +1,6 @@
 <options>
     <build>235</build>
-    <description>Shine is a modular administration mod for Natural Selection 2. It aims to be easy for admins to use and provide an easy to use framework for plugins.&#x0A;&#x0A;For server owners, the Mod ID is: 706d242&#x0A;&#x0A;Documentation (and the source code) can be found here:&#x0A;https://github.com/Person8880/Shine/wiki&#x0A;&#x0A;If you find bugs or have problems, put an issue in the issue tracker on GitHub. That&apos;s where I&apos;ll be watching for problems.&#x0A;&#x0A;If you&apos;re wondering about the name, well, so am I.</description>
+    <description>Shine is a modular administration mod for Natural Selection 2. It aims to be easy for admins to use and provide an easy to use framework for plugins.&#x0A;&#x0A;For server owners, the Mod ID is: 706d242&#x0A;&#x0A;Documentation (and the source code) can be found here:&#x0A;https://github.com/Person8880/Shine/wiki&#x0A;&#x0A;If you find bugs or have problems, put an issue in the issue tracker on GitHub. That&apos;s where I&apos;ll be watching for problems.&#x0A;&#x0A;If you&apos;re wondering about the name, well, so am I.&#x0A;&#x0A;Changes for revision 3 (last updated 04/01/2013):&#x0A;- Made Shine compatible with Combat mode. No Lua edits are required, just make sure to set CombatMode = true in the base config file. Note that I haven&apos;t been able to thoroughly test this, let me know of any bugs/conflicts that arise.</description>
     <id>117887554</id>
     <kind>Game</kind>
     <title>Shine Administration</title>

--- a/lua/extensions/mapvote.lua
+++ b/lua/extensions/mapvote.lua
@@ -45,8 +45,18 @@ function Plugin:Initialise()
 
 	local Cycle = MapCycle_GetMapCycle and MapCycle_GetMapCycle()
 
-	if self.Config.GetMapsFromMapCycle and not Shine.Config.CombatMode then
-		local Maps = Cycle.maps
+	if not Cycle then
+		local CycleFile = io.open( "config://MapCycle.json", "r" )
+
+		if CycleFile then
+			Cycle = Decode( CycleFile:read( "*all" ) )
+
+			CycleFile:close()
+		end
+	end
+
+	if self.Config.GetMapsFromMapCycle then
+		local Maps = Cycle and Cycle.maps
 
 		if Maps then
 			self.Config.Maps = {}


### PR DESCRIPTION
When combat mode is running, the mapvote plugin loads before the
mapcycle Lua file. It will now read the map cycle properly despite this.
