### PR TITLE
Possible fix for mouse cursor persisting

### DIFF
--- a/lua/core/sh_webpage.lua
+++ b/lua/core/sh_webpage.lua
@@ -29,6 +29,7 @@ Client.HookNetworkMessage( "Shine_Web", function( Message )
 	--Need to override this so the mouse is removed on close.
 	function WebWindow:SendKeyEvent(key, down)
 		if not self.background then
+			MouseTracker_SetIsVisible( false, "ui/Cursor_MenuDefault.dds", true )
 			return false
 		end
 		


### PR DESCRIPTION
This is the only thing I can see that may cause the mouse cursor to not
get hidden when closing the MotD.
