### PR TITLE
Fixed 404 or non-JSON data from causing havok

### DIFF
--- a/.publish/info.xml
+++ b/.publish/info.xml
@@ -1,6 +1,6 @@
 <options>
     <build>235</build>
-    <description>Shine is a modular administration mod for Natural Selection 2. It aims to be easy for admins to use and provide an easy to use framework for plugins.&#x0A;&#x0A;For server owners, the Mod ID is: 706d242&#x0A;&#x0A;Documentation (and the source code) can be found here:&#x0A;https://github.com/Person8880/Shine/wiki&#x0A;&#x0A;If you find bugs or have problems, put an issue in the issue tracker on GitHub. That&apos;s where I&apos;ll be watching for problems.&#x0A;&#x0A;If you&apos;re wondering about the name, well, so am I.&#x0A;&#x0A;Changes (last updated 11/01/2013):&#x0A;https://github.com/Person8880/Shine/wiki/Changelog</description>
+    <description>Shine is a modular administration mod for Natural Selection 2. It aims to be easy for admins to use and provide an easy to use framework for plugins.&#x0A;&#x0A;For server owners, the Mod ID is: 706d242&#x0A;&#x0A;Documentation (and the source code) can be found here:&#x0A;https://github.com/Person8880/Shine/wiki&#x0A;&#x0A;If you find bugs or have problems, put an issue in the issue tracker on GitHub. That&apos;s where I&apos;ll be watching for problems.&#x0A;&#x0A;If you&apos;re wondering about the name, well, so am I.&#x0A;&#x0A;Changes (last updated 12/01/2013):&#x0A;https://github.com/Person8880/Shine/wiki/Changelog</description>
     <id>117887554</id>
     <kind>Game</kind>
     <title>Shine Administration</title>

--- a/lua/core/config.lua
+++ b/lua/core/config.lua
@@ -62,6 +62,7 @@ function Shine:GenerateDefaultConfig( Save )
 		ActiveExtensions = { --Defines which plugins should be active.
 			adverts = false,
 			afkkick = false,
+			badges = false,
 			ban = true,
 			basecommands = true,
 			funcommands = false,

--- a/lua/core/permissions.lua
+++ b/lua/core/permissions.lua
@@ -25,7 +25,12 @@ function Shine:LoadUsers( Web )
 				return
 			end
 
-			self.UserData = Decode( Response )
+			self.UserData = Decode( Response ) or {}
+
+			if not next( self.UserData ) then
+				self:LoadUsers()
+				return
+			end
 
 			self:ConvertData( self.UserData, true )
 


### PR DESCRIPTION
When requesting the user file from the web, Shine no longer breaks
everything in a spectacular mess.
