### PR TITLE
Removed game_setup.xml

### DIFF
--- a/game_setup.xml
+++ b/game_setup.xml
@@ -1,6 +1,0 @@
-<game>
-	<name>ns2</name>
-	<description>Shine Admin</description>
-	<client>lua/cl_init.lua</client>
-	<server>lua/init.lua</server>
-</game>

--- a/lua/core/logging.lua
+++ b/lua/core/logging.lua
@@ -204,30 +204,32 @@ local OldServerAdminPrint = ServerAdminPrint
 
 local MaxPrintLength = 128
 
---[[
-	Rewrite ServerAdminPrint to not print to the server console when used, otherwise we'll get spammed with repeat prints when sending to lots of people at once.
-]]
-function ServerAdminPrint( Client, Message )
-	if not Client then return end
-	
-	local MessageList = {}
-	local Count = 1
+Shine.Hook.Add( "ClientConnect", "OverrideServerAdminPrint", function( Client )
+	--[[
+		Rewrite ServerAdminPrint to not print to the server console when used, otherwise we'll get spammed with repeat prints when sending to lots of people at once.
+	]]
+	function ServerAdminPrint( Client, Message )
+		if not Client then return end
+		
+		local MessageList = {}
+		local Count = 1
 
-	while #Message > MaxPrintLength do
-		local Part = Message:sub( 0, MaxPrintLength )
+		while #Message > MaxPrintLength do
+			local Part = Message:sub( 0, MaxPrintLength )
 
-		MessageList[ Count ] = Part
-		Count = Count + 1
+			MessageList[ Count ] = Part
+			Count = Count + 1
 
-		Message = Message:sub( MaxPrintLength + 1 )
+			Message = Message:sub( MaxPrintLength + 1 )
+		end
+
+		MessageList[ Count ] = Message
+		
+		for i = 1, #MessageList do
+			Server.SendNetworkMessage( Client:GetControllingPlayer(), "ServerAdminPrint", { message = MessageList[ i ] }, true )
+		end
 	end
-
-	MessageList[ Count ] = Message
-	
-	for i = 1, #MessageList do
-		Server.SendNetworkMessage( Client:GetControllingPlayer(), "ServerAdminPrint", { message = MessageList[ i ] }, true )
-	end
-end
+end )
 
 function Shine:AdminPrint( Client, String, Format, ... )
 	self:Print( String, Format, ... )

--- a/lua/extensions/badges.lua
+++ b/lua/extensions/badges.lua
@@ -30,6 +30,7 @@ function Plugin:Initialise()
 		if type( BadgeID ) == "number" then
 			return Server.GetIsDlcAuthorized( Client, BadgeID )
 		elseif UserData then
+			if not UserData.Users then return false end
 			local User = UserData.Users[ tostring( SteamID ) ]
 
 			if User and User.Group == BadgeID then return true end


### PR DESCRIPTION
This was causing conflicts with Combat. Shine now loads completely from
MedPack.lua as an odd but fun workaround to the one game_setup.xml file
only rule.
