### PR TITLE
Fixed bugs in the map vote plugin.

### DIFF
--- a/.publish/info.xml
+++ b/.publish/info.xml
@@ -2,7 +2,7 @@
     <description>Shine is a modular administration mod for Natural Selection 2. It aims to be easy for admins to use and provide an easy to use framework for plugins.&#x0A;&#x0A;For server owners, the Mod ID is: 706d242&#x0A;&#x0A;Documentation (and the source code) can be found here:&#x0A;https://github.com/Person8880/Shine/wiki&#x0A;&#x0A;If you find bugs or have problems, put an issue in the issue tracker on GitHub. That&apos;s where I&apos;ll be watching for problems.&#x0A;&#x0A;If you&apos;re wondering about the name, well, so am I.&#x0A;&#x0A;Changes (last updated 06/04/2013):&#x0A;https://github.com/Person8880/Shine/wiki/Changelog</description>
     <id>117887554</id>
     <kind>Game</kind>
-    <visibility>Public</visibility>
     <build>244</build>
+    <visibility>Public</visibility>
     <title>Shine Administration</title>
 </options>

--- a/lua/core/client/votemenu.lua
+++ b/lua/core/client/votemenu.lua
@@ -37,6 +37,10 @@ Client.HookNetworkMessage( "Shine_PluginData", function( Message )
 	end
 end )
 
+Client.HookNetworkMessage( "Shine_EndVote", function()
+	Shine.EndTime = 0
+end )
+
 local Menu
 
 --[[

--- a/lua/core/shared/votemenu.lua
+++ b/lua/core/shared/votemenu.lua
@@ -12,6 +12,8 @@ local NWMessage = {
 
 Shared.RegisterNetworkMessage( "Shine_VoteMenu", NWMessage )
 
+Shared.RegisterNetworkMessage( "Shine_EndVote", {} )
+
 local PluginMessage = {
 	Random = "integer (0 to 1)",
 	RTV = "integer (0 to 1)",


### PR DESCRIPTION
- RTV votes that extended the map would overwrite the current cycle time
  left and leave only the extension time left, rather than extending the
  cycle time.
- RTV votes that finished early would not remove the vote option from
  the vote menu until their full time was up.
- Next map votes taken part way through a map would also replace the
  remaining cycle time with the extension time, they now extend the
  remaining cycle time properly.
