### PR TITLE
Map vote improvements

### DIFF
--- a/lua/core/client/votemenu.lua
+++ b/lua/core/client/votemenu.lua
@@ -142,7 +142,7 @@ Client.HookNetworkMessage( "Shine_VoteMenu", function( Message )
 			Options ).." %s."
 	end
 
-	if NextMap then
+	if NextMap and TimeLeft > 0 then
 		VoteMessage = VoteMessage.."\nTime left on the current map: %s."
 	end
 
@@ -170,7 +170,9 @@ Client.HookNetworkMessage( "Shine_VoteMenu", function( Message )
 					self.Text = StringFormat( "Vote for the next map in progress.\nMaps: %s\nType !vote <map> to vote.\nTime left to vote:", Options ).." %s."
 				end
 
-				self.Text = self.Text.."\nTime left on the current map: %s."
+				if self.TimeLeft > 0 then
+					self.Text = self.Text.."\nTime left on the current map: %s."
+				end
 
 				self.Obj:SetText( StringFormat( self.Text, string.TimeToString( self.Duration ), string.TimeToString( self.TimeLeft ) ) )
 

--- a/lua/core/server/votemenu.lua
+++ b/lua/core/server/votemenu.lua
@@ -23,7 +23,7 @@ function Shine:BuildPluginData()
 
 	return {
 		Random = Plugins.voterandom and Plugins.voterandom.Enabled,
-		RTV = Plugins.mapvote and Plugins.mapvote.Enabled,
+		RTV = Plugins.mapvote and Plugins.mapvote.Enabled and Plugins.mapvote.Config.EnableRTV,
 		Scramble = Plugins.votescramble and Plugins.votescramble.Enabled,
 		Surrender = Plugins.votesurrender and Plugins.votesurrender.Enabled,
 		Unstuck = Plugins.unstuck and Plugins.unstuck.Enabled,


### PR DESCRIPTION
- You can now explicitly set the map vote to run on the end of the map
  rather than a fixed time through the map.
- Added !nextmap to see what the currently set next map is.
- Added the ability to disable RTV votes.
