### PR TITLE
A few small improvements

### DIFF
--- a/lua/shine/extensions/afkkick.lua
+++ b/lua/shine/extensions/afkkick.lua
@@ -15,56 +15,21 @@ Plugin.ConfigName = "AFKKick.json"
 
 Plugin.Users = {}
 
+Plugin.DefaultConfig = {
+	MinPlayers = 10,
+	Delay = 1,
+	WarnTime = 5,
+	KickTime = 15,
+	Warn = true,
+	OnlyCheckOnStarted = false
+}
+
+Plugin.CheckConfig = true
+
 function Plugin:Initialise()
 	self.Enabled = true
 
 	return true
-end
-
-function Plugin:GenerateDefaultConfig( Save )
-	self.Config = {
-		MinPlayers = 10,
-		Delay = 1,
-		WarnTime = 5,
-		KickTime = 15,
-		Warn = true
-	}
-
-	if Save then
-		local Success, Err = Shine.SaveJSONFile( self.Config, Shine.Config.ExtensionDir..self.ConfigName )
-
-		if not Success then
-			Notify( "Error writing afkkick config file: "..Err )	
-
-			return	
-		end
-
-		Notify( "Shine afkkick config file created." )
-	end
-end
-
-function Plugin:SaveConfig()
-	local Success, Err = Shine.SaveJSONFile( self.Config, Shine.Config.ExtensionDir..self.ConfigName )
-
-	if not Success then
-		Notify( "Error writing afkkick config file: "..Err )	
-
-		return	
-	end
-
-	Notify( "Shine afkkick config file saved." )
-end
-
-function Plugin:LoadConfig()
-	local PluginConfig = Shine.LoadJSONFile( Shine.Config.ExtensionDir..self.ConfigName )
-
-	if not PluginConfig then
-		self:GenerateDefaultConfig( true )
-
-		return
-	end
-
-	self.Config = PluginConfig
 end
 
 --[[
@@ -90,6 +55,10 @@ end
 	Hook into movement processing to help prevent false positive AFK kicking.
 ]]
 function Plugin:OnProcessMove( Player, Input )
+	local Gamerules = GetGamerules()
+
+	if self.Config.OnlyCheckOnStarted and not ( Gamerules and Gamerules:GetGameStarted() ) then return end
+
 	local Players = Shared.GetEntitiesWithClassname( "Player" ):GetSize()
 
 	if Players < self.Config.MinPlayers then return end

--- a/lua/shine/extensions/welcomemessages.lua
+++ b/lua/shine/extensions/welcomemessages.lua
@@ -7,12 +7,15 @@ local Shine = Shine
 local Notify = Shared.Message
 local Encode, Decode = json.encode, json.decode
 local StringFormat = string.format
+local TableEmpty = table.Empty
 
 local Plugin = {}
 Plugin.Version = "1.0"
 
 Plugin.HasConfig = true
 Plugin.ConfigName = "WelcomeMessages.json"
+
+Plugin.Welcomed = {}
 
 local DefaultConfig = {
 	MessageDelay = 5,
@@ -85,6 +88,8 @@ function Plugin:ClientConnect( Client )
 
 			MessageTable.Said = true
 
+			self.Welcomed[ Client ] = true
+
 			self:SaveConfig()
 		
 			return
@@ -96,11 +101,17 @@ function Plugin:ClientConnect( Client )
 
 		if not Player then return end
 
+		self.Welcomed[ Client ] = true
+
 		Shine:Notify( nil, "", "", "%s has joined the game.", true, Player:GetName() )
 	end )
 end
 
 function Plugin:ClientDisconnect( Client )
+	if not self.Welcomed[ Client ] then return end
+
+	self.Welcomed[ Client ] = nil
+	
 	local ID = Client:GetUserId()
 
 	local MessageTable = self.Config.Users[ tostring( ID ) ]
@@ -125,6 +136,8 @@ function Plugin:ClientDisconnect( Client )
 end
 
 function Plugin:Cleanup()
+	TableEmpty( self.Welcomed )
+
 	self.Enabled = false
 end
 


### PR DESCRIPTION
- AFK kicker can now be set to only check players when a game has
  started.
- The ready room plugin will remember the team players ended the last
  round on and, if possible, place them on the opposite team if they are
  forced next round.
- The welcome messages plugin should no longer display a disconnect
  message for a player who has not had a connect message displayed.
