### PR TITLE
Removed AFK commander eject

### DIFF
--- a/lua/shine/extensions/afkkick.lua
+++ b/lua/shine/extensions/afkkick.lua
@@ -20,7 +20,7 @@ Plugin.DefaultConfig = {
 	Delay = 1,
 	WarnTime = 5,
 	KickTime = 15,
-	CommanderTime = 0.5,
+	--CommanderTime = 0.5,
 	Warn = true,
 	OnlyCheckOnStarted = false
 }
@@ -101,7 +101,7 @@ function Plugin:OnProcessMove( Player, Input )
 	DataTable.LastPitch = Pitch
 	DataTable.LastYaw = Yaw
 
-	local CommanderTime = self.Config.CommanderTime * 60
+	--[[local CommanderTime = self.Config.CommanderTime * 60
 
 	if Player:isa( "Commander" ) and CommanderTime > 0 and Started then
 		if DataTable.LastMove + CommanderTime < Time then
@@ -116,7 +116,7 @@ function Plugin:OnProcessMove( Player, Input )
 				Player:Logout()
 			end
 		end
-	end
+	end]]
 
 	local KickTime = self.Config.KickTime * 60
 

--- a/lua/shine/extensions/mapvote.lua
+++ b/lua/shine/extensions/mapvote.lua
@@ -486,6 +486,16 @@ function Plugin:EndGame()
 
 				local Gamerules = GetGamerules()
 
+				local Players = Shine.GetAllPlayers()
+
+				for i = 1, #Players do
+					local Ply = Players[ i ]
+
+					if Ply then
+						Gamerules:JoinTeam( Ply, 0, nil, true )
+					end
+				end
+
 				self.CyclingMap = true
 
 				Gamerules.timeToCycleMap = Time + 30
@@ -496,6 +506,18 @@ function Plugin:EndGame()
 
 				if self.VoteOnEnd then
 					self:StartVote( true )
+
+					local Gamerules = GetGamerules()
+
+					local Players = Shine.GetAllPlayers()
+
+					for i = 1, #Players do
+						local Ply = Players[ i ]
+
+						if Ply then
+							Gamerules:JoinTeam( Ply, 0, nil, true )
+						end
+					end
 				end
 			end
 		end
@@ -529,6 +551,7 @@ function Plugin:JoinTeam( Gamerules, Player, NewTeam, Force, ShineForce )
 
 	if not ( self.CyclingMap or IsEndVote ) then return end
 	if not Player then return end
+	if ShineForce then return end
 	
 	local Time = Shared.GetTime()
 	local Message = IsEndVote and "You cannot join a team whilst the map vote is in progress." or 


### PR DESCRIPTION
- It wasn't working as intended, probably best to leave it to the eject
  vote.
- Added "FallbackMode" to voterandom, lets you specify which sorting
  mode to use if ELO fails.
- The map vote plugin will force everyone to the ready room on an end of
  map vote or when the map is set to cycle.
