### PR TITLE
Fixed that mapchange broke welcomemesagges

### DIFF
--- a/lua/shine/extensions/welcomemessages.lua
+++ b/lua/shine/extensions/welcomemessages.lua
@@ -15,7 +15,6 @@ Plugin.Version = "1.0"
 Plugin.HasConfig = true
 Plugin.ConfigName = "WelcomeMessages.json"
 
-Plugin.Welcomed = {}
 
 local DefaultConfig = {
 	MessageDelay = 5,
@@ -88,8 +87,6 @@ function Plugin:ClientConnect( Client )
 
 			MessageTable.Said = true
 
-			self.Welcomed[ Client ] = true
-
 			self:SaveConfig()
 		
 			return
@@ -101,16 +98,11 @@ function Plugin:ClientConnect( Client )
 
 		if not Player then return end
 
-		self.Welcomed[ Client ] = true
-
 		Shine:Notify( nil, "", "", "%s has joined the game.", true, Player:GetName() )
 	end )
 end
 
 function Plugin:ClientDisconnect( Client )
-	if not self.Welcomed[ Client ] then return end
-
-	self.Welcomed[ Client ] = nil
 	
 	local ID = Client:GetUserId()
 


### PR DESCRIPTION
Value Welcomed was dropped with every mapchange by the server. By that way the plugin stopped working if a client connected then a mapchange was performed and the client disconnect.
