### PR TITLE
Patch for request #92

### DIFF
--- a/lua/shine/extensions/mapvote.lua
+++ b/lua/shine/extensions/mapvote.lua
@@ -412,10 +412,10 @@ function Plugin:EndGame()
 			self.Round = self.Round + 1
 			if self.Round >= self.Config.VoteAfterRound then 
 			TimeLeft = 0
-			end
-		end
+			else TimeLeft = self.Config.ForceChange + 1 end
+			local Message = "There are some Rounds remaining on this map."
+		else local Message = "There is %s remaining on this map." end
 		
-		local Message = "There is %s remaining on this map."
 
 		if TimeLeft <= self.Config.ForceChange then
 			if not self:VoteStarted() and not self.VoteOnEnd then


### PR DESCRIPTION
Added Round based vote:
- added option VoteafterRound
  - if 0 its disabled (default)
  - if enabled it enables also VoteonEnd to start Vote
    -added value Round to count played Rounds
- if map get extended and VoteafterRound is enabled Map will extend for one Round if there are MaxOptions votes left

Hope you don't have to do so much yourself this time.
