### PR TITLE
Remove TimeLeft in VoteMessage if Voteonend is true

### DIFF
--- a/lua/shine/extensions/mapvote.lua
+++ b/lua/shine/extensions/mapvote.lua
@@ -460,7 +460,7 @@ function Plugin:EndGame()
 				Message = "Waiting on map vote to change map."
 
 				if self.VoteOnEnd then
-					self:StartVote( true )
+					self:StartVote( nil, true )
 
 					local Gamerules = GetGamerules()
 


### PR DESCRIPTION
Don't show any "Time left" in VoteMessage if VoteonEnd is true
