### PR TITLE
pregame: added AllowAttackPreGame

### DIFF
--- a/lua/shine/extensions/pregame.lua
+++ b/lua/shine/extensions/pregame.lua
@@ -11,8 +11,6 @@ local Clamp = math.Clamp
 local Floor = math.floor
 local StringFormat = string.format
 
-local originalGetCanAttack
-
 local Plugin = {}
 Plugin.Version = "1.5"
 
@@ -54,15 +52,6 @@ function Plugin:Initialise()
 		if OnBlacklist then
 			return false, StringFormat( "Pregame plugin does not work with %s.", OnBlacklist )
 		end
-	end
-
-	if not self.Config.AllowAttackPreGame then
-		originalGetCanAttack = Shine.ReplaceClassMethod("Player", "GetCanAttack", function(self)
-			local Gamerules = GetGamerules()
-			local preGame = Gamerules:GetGameState() == kGameState.PreGame or Gamerules:GetGameState() == kGameState.NotStarted
-			local canAttack = originalGetCanAttack(self) and not preGame
-			return canAttack
-		end)
 	end
 
 	self.Config.RequireComs = Clamp( Floor( self.Config.RequireComs ), 0, 2 )
@@ -109,8 +98,9 @@ function Plugin:ClientConfirmConnect( Client )
 end
 
 function Plugin:CheckPlayerCanAttack()
-	if Gamerules:GetGameState() == kGameState.PreGame or Gamerules:GetGameState() == kGameState.NotStarted then 
-		return	self.Config.AllowAttackPreGame
+	local Gamerules = GetGamerules()
+	if Gamerules:GetGameState() == kGameState.PreGame or Gamerules:GetGameState() == kGameState.NotStarted then
+		return self.Config.AllowAttackPreGame
 	end
 end
 


### PR DESCRIPTION
When set to 'false', attacks made during preGame animate on the client
and are not processed by the server or other clients. I'd love to see
this matured into something that doesn't even animate the client.

Wiki edit for https://github.com/Person8880/Shine/wiki/Pregame:
## Overview

The pregame plugin provides a way to customise the pregame time. It offers three modes:
1. The old mode where you set a fixed pregame length and once that time is up, the game starts. This does not require any commanders to start the game.
2. A second mode, slightly closer to the standard NS2 mode than the third. In this mode, the game will wait until one team has a commander. Once they do, the pregame timer is started. If the other team gets a commander before this timer is up, the game starts after the countdown time. Otherwise, it waits until the pregame timer is up, and then starts the game.
3. A third mode, a mid point between the default NS2 mode where you must have 2 commanders, and the old time limited pregame. In this mode, you set a timeout. If the pregame reaches this timeout with 1 team having a commander and the other not, the game is started. If both teams do not have a commander still, it will still wait until at least 1 team has a commander. If both teams have a commander before the timeout, the game can be given a fixed countdown time after which it starts.
## Config

The default config looks something like this:

```
{
    "ShowCountdown": true,
    "PreGameTime": 45,
    "CountdownTime": 15,
    "RequireComs": 1,
    "AbortIfNoCom": false,
    "AllowAttackPreGame": true
}
```

The file should be called "PreGame.json" and should be placed in the directory defined as your plugin config directory (default is config://shine/plugins).

| Option | Description |
| --- | --- |
| RequireComs | Set it to 0 to get the first mode described above. 1 is the second mode, 2 is the third mode. |
| ShowCountdown | Determines whether to display a countdown on player's screens for when the round will start. |
| PreGameTime | Determines how long in seconds the pregame should last. When "RequireComs" is 0, the pregame lasts exactly this long. When "RequireComs" is set to 1, this is how long the pregame will last once one team has a commander. When "RequireComs" is set to 2, this is how long to wait before dropping the starting requirement to 1 commander. |
| CountdownTime | If you are using the plugin with "RequireComs" set to 1 or 2, then once two commanders are present, the game will start after this amount of time. |
| AbortIfNoCom | If you are using "RequireComs" 1 or 2, then the countdown to start will be aborted if a commander leaves the chair and this is set to true. |
| AllowAttackPreGame | Set to false to prevent pregame attacks. Default is true. |
