### PR TITLE
added: workshopupdatehandler

### DIFF
--- a/lua/shine/extensions/workshopupdatehandler.lua
+++ b/lua/shine/extensions/workshopupdatehandler.lua
@@ -1,15 +1,41 @@
 local lastKnownUpdate = {}
 local changedModName
-local whenToNextCheck = 0
-local whenToNextNotify = 0
+local remainingNotifications = math.huge
+local CHECK_FOR_MOD_CHANGE_TIMER_ID = "CheckForModChange"
 
-local function notifyOrCycle()
-	if #Shine.GetAllPlayers() == 0 then
-		MapCycle_CycleMap()
-	else
-		Shine:Notify( nil, "All", Shine.Config.ChatName, string.format("%s mod has updated in Steam Workshop.", changedModName) )
-		Shine:Notify( nil, "All", Shine.Config.ChatName, string.format("Players cannot connect to the server until mapchange.", changedModName) )
+local function secondsToHoursMinutesSeconds(sSeconds)
+	local nHours = 0
+	local nMins = 0
+	local nSecs = 0
+	local nSeconds = tonumber(sSeconds)
+	if nSeconds ~= 0 then
+		nHours = string.format("%02.f", math.floor(nSeconds/3600));
+		nMins = string.format("%02.f", math.floor(nSeconds/60 - (nHours*60)));
+		nSecs = string.format("%02.f", math.floor(nSeconds - nHours*3600 - nMins *60));
 	end
+	return nHours, nMins, nSecs
+end
+
+local function getTimeRemainingDescriptor(secondsRemaining)
+	local result
+	local hours, minutes, seconds = secondsToHoursMinutesSeconds(secondsRemaining)
+	if tonumber(hours) > 0 then
+		result = string.format("in %s:%s:%s", hours, minutes, seconds)
+	elseif tonumber(minutes) > 0 then
+		result = string.format("in %s minute", tonumber(minutes));
+		if tonumber(minutes) > 1 then
+			result = result .. "s"
+		else
+		end
+		if tonumber(seconds) > 0 then
+			result = result .. string.format(" and %s seconds", tonumber(seconds));
+		else
+
+		end
+	else
+		result = string.format("in %s seconds", tonumber(seconds));
+	end
+	return result
 end
 
 local function findCharactersBetween(response, openingCharacters, closingCharacters)
@@ -27,7 +53,7 @@ local function findCharactersBetween(response, openingCharacters, closingCharact
 	return result
 end
 
-local function getUpdateFromResponse(response)
+local function getUpdatedTimeFromResponse(response)
 	local result = findCharactersBetween(response, "Update:", "</div>")
 	return result
 end
@@ -37,13 +63,25 @@ local function getModNameFromResponse(response)
 	return result
 end
 
-local function checkForModChange()
+local Plugin = {}
+
+Plugin.HasConfig = true
+Plugin.ConfigName = "WorkshopUpdateHandler.json"
+Plugin.CheckConfig = true
+Plugin.DefaultConfig = {
+	CheckIntervalInSeconds = 60,
+	RepeatNotifications = true,
+	NotifyIntervalInSeconds = 180,
+	ForceMapChangeAfterNotifications = 5
+}
+
+function Plugin:CheckForModChange(plugin)
     for i = 1, Server.GetNumActiveMods() do
     	local id = tonumber(Server.GetActiveModId(i), 16)
 		local url = "http://steamcommunity.com/sharedfiles/filedetails/changelog/" .. id
 		Shared.SendHTTPRequest(url, "GET", function(response)
 			if not changedModName then
-				local update = getUpdateFromResponse(response)
+				local update = getUpdatedTimeFromResponse(response)
 				if lastKnownUpdate[id] == nil then
 					lastKnownUpdate[id] = update
 				elseif lastKnownUpdate[id] ~= update then
@@ -51,6 +89,8 @@ local function checkForModChange()
 					local modName = getModNameFromResponse(response)
 					if modName and modName ~= "" then
 						changedModName = modName
+						Shine.Timer.Destroy(CHECK_FOR_MOD_CHANGE_TIMER_ID)
+						self:NotifyOrCycle()
 					end
 				end
 			end
@@ -58,38 +98,33 @@ local function checkForModChange()
     end
 end
 
-local Plugin = {}
-
-Plugin.HasConfig = true
-Plugin.ConfigName = "WorkshopUpdateHandler.json"
-
-Plugin.DefaultConfig = {
-	CheckIntervalInSeconds = 60,
-	RepeatNotifications = true,
-	NotifyIntervalInSeconds = 180
-}
-
-function Plugin:Think()
-	local now = Shared.GetTime()
-	if changedModName then
-		if now > whenToNextNotify then
-			notifyOrCycle()
-			if self.Config.RepeatNotifications then
-				whenToNextNotify = Shared.GetTime() + self.Config.NotifyIntervalInSeconds
-			else
-				whenToNextNotify = math.huge
-			end
+function Plugin:NotifyOrCycle()
+	Shine:Notify( nil, "All", Shine.Config.ChatName, string.format("%s mod has updated in Steam Workshop.", changedModName) )
+	Shine:Notify( nil, "All", Shine.Config.ChatName, "Players cannot connect to the server until mapchange." )
+	if remainingNotifications < math.huge then
+		local timeRemainingBeforeForcedMapChangeDescriptor = "now"
+		remainingNotifications = remainingNotifications - 1
+		local secondsRemainingBeforeForcedMapChange = remainingNotifications * self.Config.NotifyIntervalInSeconds
+		if secondsRemainingBeforeForcedMapChange > 5 then
+			timeRemainingBeforeForcedMapChangeDescriptor = getTimeRemainingDescriptor(secondsRemainingBeforeForcedMapChange)
 		end
-	else
-		if now > whenToNextCheck  then
-    		checkForModChange()
-			whenToNextCheck = Shared.GetTime() + self.Config.CheckIntervalInSeconds
-		end
+		local message = string.format("Map will cycle automatically %s.", timeRemainingBeforeForcedMapChangeDescriptor)
+		Shine:Notify( nil, "All", Shine.Config.ChatName, message )
+	end
+	if #Shine.GetAllPlayers() == 0 or remainingNotifications == 0 then
+		Shine.Timer.Simple(3, function() MapCycle_CycleMap() end )
+	end
+	if self.Config.RepeatNotifications then
+		Shine.Timer.Simple(self.Config.NotifyIntervalInSeconds, function() self:NotifyOrCycle() end )
 	end
 end
 
 function Plugin:Initialise()
     self.Enabled = true
+    if self.Config.ForceMapChangeAfterNotifications > 0 then
+	    remainingNotifications = self.Config.ForceMapChangeAfterNotifications
+    end
+    Shine.Timer.Create(CHECK_FOR_MOD_CHANGE_TIMER_ID, self.Config.CheckIntervalInSeconds, math.huge, function() self:CheckForModChange() end )
     return true
 end
 


### PR DESCRIPTION
This extension monitors the Steam Workshop for updates to mods actively
running on the server. When an update is found, it either notifies
players that no one new can connect or, in the case of an empty server,
immediately cycles the map.

Wiki page for https://github.com/Person8880/Shine/wiki/Workshop-Update-Handler:
## Overview

The Workshop Update Handler plugin monitors the Steam Workshop and notifies players when an active mod on your server has updated. If the server is empty when an active mod updates, the plugin immediately cycles the map. All of this minimizes the chances for incoming players seeing the "mod out of date" error when joining your server.

When the plugin detects an update to an active mod, it notifies players with a message similar to the following:

Shine Administration mod has updated in Steam Workshop.
Players cannot connect to the server until mapchange.

Once the plugin detects an update in any active mod, it stops monitoring the Steam Workshop and begins notifying (or, if the server is empty, cycling the map).

If the "ForceMapChangeAfterNotifications" config option is set to a non-zero value, the notification messages will display the time remaining to the forced cycling of the map.
## Config

The plugin automatically detects which Steam Workshop mods are active on your server, so all that's left is configuring how often you want it to check for updates and, if one is found, how often you want it to display notifications (for the duration of the current map).

The default config looks something like this:

```
{
    "CheckIntervalInSeconds": 60,
    "RepeatNotifications": true,
    "NotifyIntervalInSeconds": 180,
    "ForceMapChangeAfterNotifications": 5
}
```

The file should be called "WorkshopUpdateHandler.json" and should be placed in the directory defined as your plugin config directory (default is config://shine/plugins).

| Option | Description |
| --- | --- |
| CheckIntervalInSeconds | Number of seconds between each check of the Steam Workshop. |
| RepeatNotifications | If true, notifications will repeat at the interval defined in "NotifyIntervalInSeconds". |
| NotifyIntervalInSeconds | Number of seconds between each repeated update notification. |
| ForceMapChangeAfterNotifications | Number of update notifications after which to cycle the map even if players are present and/or playing. Set to 0 to disable. If this is set higher than 1, be sure to set "RepeatNotifications" to true. |
