### PR TITLE
Added support for multiple Rows with Badges+ Mod

### DIFF
--- a/lua/shine/extensions/badges.lua
+++ b/lua/shine/extensions/badges.lua
@@ -64,13 +64,11 @@ function Plugin:Setup()
 		end
 		
 		for Row, GroupRowBadges in pairs( GroupBadges ) do
-			if GroupRowBadges then
-				for i = 1, #GroupRowBadges do
-					local BadgeName = GroupRowBadges[ i ]
+			for i = 1, #GroupRowBadges do
+				local BadgeName = GroupRowBadges[ i ]
 
-					if not AssignBadge( ID, BadgeName, Row ) then
-						Print( "%s has a non-existant or reserved badge: %s", GroupName, BadgeName )
-					end
+				if not AssignBadge( ID, BadgeName, Row ) then
+					Print( "%s has a non-existant or reserved badge: %s", GroupName, BadgeName )
 				end
 			end
 		end
@@ -108,13 +106,11 @@ function Plugin:Setup()
 				end
 				
 				for Row, UserRowBadges in pairs( UserBadges ) do
-					if UserRowBadges then
-						for i = 1, #UserRowBadges do
-							local BadgeName = UserRowBadges[ i ]
-
-							if not AssignBadge( ID, BadgeName, Row ) then
-								Print( "%s has a non-existant or reserved badge: %s", ID, BadgeName )
-							end
+					for i = 1, #UserRowBadges do
+						local BadgeName = UserRowBadges[ i ]
+	
+						if not AssignBadge( ID, BadgeName, Row ) then
+							Print( "%s has a non-existant or reserved badge: %s", ID, BadgeName )
 						end
 					end
 				end


### PR DESCRIPTION
New format in UserConfig.json is :

Example: 

"Badges": {
                "1": [
                    "admin",
                    "clawmarks",
                    "kK_G",
                    "clover",
                    "crown",
                    "ghost"
                ],
                "2": [
                    "heart",
                    "marine",
                    "nyancat",
                    "pumpkin",
                    "skull",
                    "star"
                ],
                "3": [
                    "troll",
                    "unicorn",
                    "wrench"
                ],
                "4": [
                    "wrench_red"
                ]

So basically:

"Badges": {
                "Row": [
                    "badgename1",
                    "badgename2"
                ],
                "Row": [
                    ...
                ],
                ...
}

FYI: For Badges+ is the third row the default one for custom badges if Row is not given in GiveBadge()

I also removed that the plugin empties the badges table as this could cause some issues with some other mods which also might assign custom badges ( maybe NSL mod in future etc. )

The plugin still works with Player Badge Mod and old UserConfig.json format.

As useall you are free to change anything you don't like ;)

Happy Eastern :)
