### PR TITLE
Remove annotate

### DIFF
--- a/lua/shine/extensions/unstuck.lua
+++ b/lua/shine/extensions/unstuck.lua
@@ -97,8 +97,6 @@ function Plugin:CreateCommands()
 			return
 		end
 
-		Server.SendNetworkMessage( Client, "Shine_Command", { Command = "annotate Shine unstuck was used here." }, true )
-
 		local Success = self:UnstickPlayer( Player, Player:GetOrigin() )
 
 		if Success then


### PR DESCRIPTION
UWE was asking for this as it seems this caused a spam of "annotates" which confused mappers more than it was helping.
