### PR TITLE
Shared.Message how it should be

### DIFF
--- a/lua/shine/core/server/logging.lua
+++ b/lua/shine/core/server/logging.lua
@@ -40,7 +40,8 @@ Shared.OldMessage = Shared.OldMessage or Shared.Message
 	
 	and this function was its first feature.
 ]]
-function Shared.Message( String )
+function Shared.Message( String, Format, ... )
+	String = Format and StringFormat( String, Format, ... ) or String
 	return Shared.OldMessage( GetTimeString()..String )
 end
 


### PR DESCRIPTION
Would make it easier to use Shared.Message without using string.format all the time in the plugin code itself.
