### PR TITLE
Added Shine.Timer.GetTimeLeft

### DIFF
--- a/lua/shine/lib/timer.lua
+++ b/lua/shine/lib/timer.lua
@@ -57,11 +57,17 @@ function TimerMeta:Pause()
 end
 
 function TimerMeta:Resume()
+
 	if not self.Paused then return end
 
 	self.Paused = nil
 	self.NextRun = SharedTime() + self.TimeLeft
 	self.TimeLeft = nil
+end
+
+function TimerMeta:GetTimeLeft()
+	local Time = SharedTime()
+	return  ( self.Reps - 1 ) * self.Delay + ( self.NextRun - Time )
 end
 
 --[[
@@ -150,6 +156,14 @@ function Shine.Timer.Resume( Name )
 	local Timer = Timers[ Name ]
 	
 	Timer:Resume()
+end
+
+function Shine.Timer.GetTimeLeft( Name )
+	if not Exists( Name ) then return end
+	
+	local Timer = Timers[ Name ]
+	
+	return Timer:GetTimeLeft()
 end
 
 local Error


### PR DESCRIPTION
Kinda usefull if you  want to keep a timer running after a mapchange ( save Timeleft at mapchange into a cache file and recreate the timer at plugin initialize )

Might be usefull also for other plugin devs.
