### PR TITLE
SendNetworkMessage allways needs a "Target" value

### DIFF
--- a/lua/shine/lib/screentext/sv_screentext.lua
+++ b/lua/shine/lib/screentext/sv_screentext.lua
@@ -3,11 +3,7 @@
 ]]
 
 local function SendMessage( Player, Name, Message )
-	if Player then
-		Shine.SendNetworkMessage( Player, Name, Message, true )
-	else
-		Shine.SendNetworkMessage( Name, Message, true )
-	end
+	Shine.SendNetworkMessage( Player, Name, Message, true )
 end
 
 function Shine:SendText( Player, Message )


### PR DESCRIPTION
Seems like noone used these functions since some time
