### PR TITLE
[267] Added commands for tickrate, sendrate, bwlimit

### DIFF
--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -105,7 +105,7 @@ function Plugin:Initialise()
 		Shared.ConsoleCommand( StringFormat( "tickrate %s", self.Config.MoveRate ) )
 	end
 	if self.Config.BWLimit ~= 25 then
-		Shared.ConsoleCommand( StringFormat( "bwlimit %s", self.Config.BWLimit ) )
+		Shared.ConsoleCommand( StringFormat( "bwlimit %s", self.Config.BWLimit * 1000 ) )
 	end
 
 	self.Enabled = true


### PR DESCRIPTION
Allow server configuration of tickrate (default 30/sec), rate of updates
sent to clients (default 20/sec) and bandwidth limit per player (
default 25kb/sec)

Note: you should keep sendrate < tickrate <= mr, and interp >=
2/sendrate

Also with 267 those values ( oncluding mr and interp) will be synched correctly at client connect
