### PR TITLE
Fixed that AddChatMessage() did not work with 275

### DIFF
--- a/lua/shine/core/shared/chat.lua
+++ b/lua/shine/core/shared/chat.lua
@@ -74,8 +74,8 @@ local function AddChatMessage( Player, ChatMessages, PreHex, Prefix, Col, Messag
 	ChatMessages[ #ChatMessages + 1 ] = Col
 	ChatMessages[ #ChatMessages + 1 ] = Message
 
-    ChatMessages[ #ChatMessages + 1 ] = false
-    ChatMessages[ #ChatMessages + 1 ] = false
+	ChatMessages[ #ChatMessages + 1 ] = false
+	ChatMessages[ #ChatMessages + 1 ] = false
 
 	ChatMessages[ #ChatMessages + 1 ] = 0
 	ChatMessages[ #ChatMessages + 1 ] = 0

--- a/lua/shine/core/shared/chat.lua
+++ b/lua/shine/core/shared/chat.lua
@@ -74,8 +74,9 @@ local function AddChatMessage( Player, ChatMessages, PreHex, Prefix, Col, Messag
 	ChatMessages[ #ChatMessages + 1 ] = Col
 	ChatMessages[ #ChatMessages + 1 ] = Message
 
-	ChatMessages[ #ChatMessages + 1 ] = ""
-	ChatMessages[ #ChatMessages + 1 ] = 0
+    ChatMessages[ #ChatMessages + 1 ] = false
+    ChatMessages[ #ChatMessages + 1 ] = false
+
 	ChatMessages[ #ChatMessages + 1 ] = 0
 	ChatMessages[ #ChatMessages + 1 ] = 0
 


### PR DESCRIPTION
These two fields get used with 275 for indicating if sender is commander and if sender is rookie. As AddChatMessage() is only used for shine message we set both those fields to false. Works also with 274