### PR TITLE
Custom votes, easier defining of time

### DIFF
--- a/lua/shine/core/client/commands.lua
+++ b/lua/shine/core/client/commands.lua
@@ -28,7 +28,7 @@ function CommandMeta:AddParam( Table )
 end
 
 --[[
-	Creates a command object. 
+	Creates a command object.
 	The object stores the console command and the function to run.
 	It can also have parameters added to it to pass to its function.
 ]]
@@ -100,8 +100,18 @@ function Shine:RunClientCommand( ConCommand, ... )
 
 	for i = 1, ExpectedCount do
 		local CurArg = ExpectedArgs[ i ]
+		local ArgString = Args[ i ]
+		local TakeRestOfLine = CurArg.TakeRestOfLine
 
-		ParsedArgs[ i ] = ParseParameter( nil, Args[ i ], CurArg )
+		if TakeRestOfLine then
+			if i < ExpectedCount then
+				error( "Take rest of line called on function expecting more arguments!" )
+			end
+
+			ArgString = self.CommandUtil.BuildLineFromArgs( Args, i )
+		end
+
+		ParsedArgs[ i ] = ParseParameter( nil, ArgString, CurArg )
 
 		--Specifically check for nil (boolean argument could be false).
 		if ParsedArgs[ i ] == nil and not CurArg.Optional then
@@ -109,15 +119,6 @@ function Shine:RunClientCommand( ConCommand, ... )
 				i, ConCommand, CurArg.Type ) )
 
 			return
-		end
-
-		if CurArg.Type == "string" and CurArg.TakeRestOfLine then
-			if i == ExpectedCount then
-				ParsedArgs[ i ] = self.CommandUtil.BuildLineFromArgs( CurArg, ParsedArgs[ i ],
-					Args, i )
-			else
-				error( "Take rest of line called on function expecting more arguments!" )
-			end
 		end
 	end
 

--- a/lua/shine/core/server/commands.lua
+++ b/lua/shine/core/server/commands.lua
@@ -8,7 +8,9 @@ local StringExplode = string.Explode
 local StringFind = string.find
 local StringFormat = string.format
 local StringGSub = string.gsub
+local StringSub = string.sub
 local TableConcat = table.concat
+local TableInsert = table.insert
 local TableRemove = table.remove
 local TableSort = table.sort
 local tostring = tostring
@@ -109,7 +111,7 @@ function Shine:RegisterCommand( ConCommand, ChatCommand, Function, NoPerm, Silen
 	--This prevents hooking again if a plugin is reloaded.
 	if not HookedCommands[ ConCommand ] then
 		Event.Hook( "Console_"..ConCommand, function( Client, ... )
-			return Shine:RunCommand( Client, ConCommand, ... )
+			return Shine:RunCommand( Client, ConCommand, false, ... )
 		end )
 		HookedCommands[ ConCommand ] = true
 	end
@@ -389,35 +391,66 @@ local ArgValidators = {
 	end
 }
 
---[[
-	Executes a Shine command. Should not be called directly.
-	Inputs: Client running the command, console command to run,
-	string arguments passed to the command.
-]]
-function Shine:RunCommand( Client, ConCommand, ... )
-	local Command = self.Commands[ ConCommand ]
+function Shine:NotifyCommandError( Client, Message, Format, ... )
+	Message = Format and StringFormat( Message, ... ) or Message
 
-	if not Command or Command.Disabled then return end
+	if not Client then
+		Print( Message )
+		return
+	end
 
-	local Allowed, ArgRestrictions = self:GetPermission( Client, ConCommand )
-	if not Allowed then
-		self:NotifyError( Client, "You do not have permission to use %s.", true, ConCommand )
+	local FromChat = self:IsCommandFromChat()
+	if FromChat then
+		self:NotifyError( Client, Message )
 
 		return
 	end
 
-	local Player = Client or "Console"
-	local Args = { ... }
+	ServerAdminPrint( Client, Message )
+end
+
+local function Notify( Client, FromChat, Message, Format, ... )
+	Message = Format and StringFormat( Message, ... ) or Message
+
+	if not Client then
+		Print( Message )
+		return
+	end
+
+	if FromChat then
+		Shine:NotifyColour( Client, 255, 160, 0, Message )
+
+		return
+	end
+
+	ServerAdminPrint( Client, Message )
+end
+
+Shine.CommandStack = {}
+
+--Store a stack of calling commands, which tells us if it's from the chat or not.
+--This is purely in case someone uses Shine:RunCommand() during a command (which you really shouldn't).
+function Shine:IsCommandFromChat()
+	return self.CommandStack[ #self.CommandStack ] == true
+end
+
+local function PopCommandStack( self )
+	self.CommandStack[ #self.CommandStack ] = nil
+end
+
+local function GetCommandArgs( self, Client, ConCommand, FromChat, Command, Args )
+	local Allowed, ArgRestrictions = self:GetPermission( Client, ConCommand )
+	if not Allowed then
+		self:NotifyCommandError( Client, "You do not have permission to use %s.", true, ConCommand )
+
+		return
+	end
+
 	local ExpectedArgs = Command.Arguments
 	local ExpectedCount = #ExpectedArgs
 
 	if Args[ 1 ] == nil and ExpectedCount > 0 and not ExpectedArgs[ 1 ].Optional then
-		if Client then
-			ServerAdminPrint( Client, StringFormat( "%s - %s", ConCommand,
-				Command.Help or "No help available." ) )
-		else
-			Print( "%s - %s", ConCommand, Command.Help or "No help available." )
-		end
+		Notify( Client, FromChat, "%s - %s", true, ConCommand, Command.Help or "No help available." )
 
 		return
 	end
@@ -435,14 +468,14 @@ function Shine:RunCommand( Client, ConCommand, ... )
 		if ParsedArgs[ i ] == nil and not CurArg.Optional then
 			if CurArg.Type:find( "client" ) then
 				if CurArg.Type == "client" and Extra then
-					self:NotifyError( Player, "You cannot target yourself with this command." )
+					self:NotifyCommandError( Client, "You cannot target yourself with this command." )
 				else
 					--No client means no match.
-					self:NotifyError( Player, "No matching %s found.", true,
+					self:NotifyCommandError( Client, "No matching %s found.", true,
 						CurArg.Type == "client" and "player was" or "players were" )
 				end
 			else
-				self:NotifyError( Player,
+				self:NotifyCommandError( Client,
 					CurArg.Error or "Incorrect argument #%i to %s, expected %s.",
 					true, i, ConCommand, CurArg.Type )
 			end
@@ -463,7 +496,7 @@ function Shine:RunCommand( Client, ConCommand, ... )
 
 				--The restriction wiped the argument as it's not allowed.
 				if ParsedArgs[ i ] == nil then
-					self:NotifyError( Player,
+					self:NotifyCommandError( Client,
 						"Invalid argument #%i, restricted in rank settings.", true, i )
 
 					return
@@ -478,7 +511,7 @@ function Shine:RunCommand( Client, ConCommand, ... )
 					Args, i )
 			else
 				self:Print( "Take rest of line called on function expecting more arguments!" )
-				self:NotifyError( Player,
+				self:NotifyCommandError( Client,
 					"The author of this command misconfigured it. If you know them, tell them!" )
 
 				return
@@ -488,7 +521,7 @@ function Shine:RunCommand( Client, ConCommand, ... )
 		--Ensure the calling client can target the return client.
 		if ArgType == "client" and not CurArg.IgnoreCanTarget then
 			if not self:CanTarget( Client, ParsedArgs[ i ] ) then
-				self:NotifyError( Player, "You do not have permission to target %s.",
+				self:NotifyCommandError( Client, "You do not have permission to target %s.",
 					true, ParsedArgs[ i ]:GetControllingPlayer():GetName() )
 
 				return
@@ -501,7 +534,7 @@ function Shine:RunCommand( Client, ConCommand, ... )
 
 			if ParsedArg then
 				if #ParsedArg == 0 then
-					self:NotifyError( Player, "No matching players found." )
+					self:NotifyCommandError( Client, "No matching players found." )
 
 					return
 				end
@@ -516,7 +549,7 @@ function Shine:RunCommand( Client, ConCommand, ... )
 				end
 
 				if #ParsedArg == 0 then
-					self:NotifyError( Player,
+					self:NotifyCommandError( Client,
 						"You do not have permission to target anyone you specified." )
 
 					return
@@ -525,7 +558,36 @@ function Shine:RunCommand( Client, ConCommand, ... )
 		end
 	end
 
+	return ParsedArgs
+end
+
+--[[
+	Executes a Shine command. Should not be called directly.
+	Inputs: Client running the command, console command to run,
+	string arguments passed to the command.
+]]
+function Shine:RunCommand( Client, ConCommand, FromChat, ... )
+	local Command = self.Commands[ ConCommand ]
+	if not Command or Command.Disabled then return end
+
+	local Args = { ... }
+	--In case someone was calling Shine:RunCommand() directly (even though it says "Should not be called directly.")
+	if not IsType( FromChat, "boolean" ) then
+		TableInsert( Args, 1, FromChat )
+		FromChat = false
+	end
+
+	self.CommandStack[ #self.CommandStack + 1 ] = FromChat
+
+	local ParsedArgs = GetCommandArgs( self, Client, ConCommand, FromChat, Command, Args )
+	if not ParsedArgs then
+		PopCommandStack( self )
+		return
+	end
+
 	local Success = xpcall( Command.Func, OnError, Client, unpack( ParsedArgs ) )
+
+	PopCommandStack( self )
 
 	if not Success then
 		Shine:DebugPrint( "[Command Error] Console command %s failed.", true, ConCommand )
@@ -549,9 +611,9 @@ Shine.Hook.Add( "PlayerSay", "CommandExecute", function( Client, Message )
 	if not FirstWord then return end
 
 	--They've done !, / or some other special character first.
-	if FirstWord:sub( 1, 1 ):find( "[^%w]" ) then
-		Directive = FirstWord:sub( 1, 1 )
-		Exploded[ 1 ] = FirstWord:sub( 2 )
+	if StringFind( StringSub( FirstWord, 1, 1 ), "[^%w]" ) then
+		Directive = StringSub( FirstWord, 1, 1 )
+		Exploded[ 1 ] = StringSub( FirstWord, 2 )
 	end
 
 	if not Directive then return end
@@ -561,7 +623,7 @@ Shine.Hook.Add( "PlayerSay", "CommandExecute", function( Client, Message )
 
 	TableRemove( Exploded, 1 )
 
-	Shine:RunCommand( Client, CommandObj.ConCmd, unpack( Exploded ) )
+	Shine:RunCommand( Client, CommandObj.ConCmd, true, unpack( Exploded ) )
 
 	if CommandObj.Silent then return "" end
 	if Shine.Config.SilentChatCommands then return "" end

--- a/lua/shine/extensions/ban/server.lua
+++ b/lua/shine/extensions/ban/server.lua
@@ -511,7 +511,7 @@ function Plugin:CreateCommands()
 	end
 	local BanCommand = self:BindCommand( "sh_ban", "ban", Ban )
 	BanCommand:AddParam{ Type = "client", NotSelf = true }
-	BanCommand:AddParam{ Type = "number", Min = 0, Round = true, Optional = true,
+	BanCommand:AddParam{ Type = "time", Units = "minutes", Min = 0, Round = true, Optional = true,
 		Default = self.Config.DefaultBanTime }
 	BanCommand:AddParam{ Type = "string", Optional = true, TakeRestOfLine = true,
 		Default = "No reason given." }
@@ -615,7 +615,7 @@ function Plugin:CreateCommands()
 	end
 	local BanIDCommand = self:BindCommand( "sh_banid", "banid", BanID )
 	BanIDCommand:AddParam{ Type = "string", Error = "Please specify a Steam ID to ban." }
-	BanIDCommand:AddParam{ Type = "number", Min = 0, Round = true, Optional = true,
+	BanIDCommand:AddParam{ Type = "time", Units = "minutes", Min = 0, Round = true, Optional = true,
 		Default = self.Config.DefaultBanTime }
 	BanIDCommand:AddParam{ Type = "string", Optional = true, TakeRestOfLine = true,
 		Default = "No reason given." }

--- a/lua/shine/extensions/ban/server.lua
+++ b/lua/shine/extensions/ban/server.lua
@@ -54,7 +54,7 @@ Plugin.SilentConfigSave = true
 ]]
 function Plugin:Initialise()
 	self.Retries = {}
-	
+
 	if self.Config.GetBansFromWeb then
 		--Load bans list after everything else.
 		self:SimpleTimer( 1, function()
@@ -63,18 +63,18 @@ function Plugin:Initialise()
 	else
 		self:MergeNS2IntoShine()
 	end
-	
+
 	self:CreateCommands()
 	self:CheckBans()
 
 	if not Hooked then
 		--Hook into the default banning commands.
 		Event.Hook( "Console_sv_ban", function( Client, ... )
-			Shine:RunCommand( Client, "sh_ban", ... )
+			Shine:RunCommand( Client, "sh_ban", false, ... )
 		end )
 
 		Event.Hook( "Console_sv_unban", function( Client, ... )
-			Shine:RunCommand( Client, "sh_unban", ... )
+			Shine:RunCommand( Client, "sh_unban", false, ... )
 		end )
 
 		--Override the bans list function (have to do it after everything's loaded).
@@ -98,9 +98,9 @@ function Plugin:Initialise()
 
 		Hooked = true
 	end
-	
+
 	self:VerifyConfig()
-	
+
 	self.Enabled = true
 
 	return true
@@ -151,7 +151,7 @@ end
 
 function Plugin:SaveConfig()
 	self:ShineToNS2()
-	
+
 	self.BaseClass.SaveConfig( self )
 end
 
@@ -194,7 +194,7 @@ function Plugin:MergeNS2IntoShine()
 		for i = 1, #VanillaBans do
 			local Table = VanillaBans[ i ]
 			local ID = tostring( Table.id )
-			
+
 			if ID then
 				VanillaIDs[ ID ] = true
 
@@ -319,11 +319,11 @@ end
 	Output: Success.
 ]]
 function Plugin:AddBan( ID, Name, Duration, BannedBy, BanningID, Reason )
-	if not tonumber( ID ) then 
+	if not tonumber( ID ) then
 		ID = Shine.SteamIDToNS2( ID )
 
 		if not ID then
-			return false, "invalid Steam ID" 
+			return false, "invalid Steam ID"
 		end
 	end
 
@@ -360,7 +360,7 @@ function Plugin:AddBan( ID, Name, Duration, BannedBy, BanningID, Reason )
 			self.Retries[ ID ] = nil
 
 			if not Data then return end
-			
+
 			local Decoded = Decode( Data )
 
 			if not Decoded then return end
@@ -386,7 +386,7 @@ function Plugin:AddBan( ID, Name, Duration, BannedBy, BanningID, Reason )
 
 				return
 			end
-			
+
 			Shine.TimedHTTPRequest( self.Config.BansSubmitURL, "POST", PostParams,
 				SuccessFunc, TimeoutFunc, self.Config.SubmitTimeout )
 		end
@@ -430,7 +430,7 @@ function Plugin:RemoveBan( ID, DontSave, UnbannerID )
 			self.Retries[ ID ] = nil
 
 			if not Data then return end
-			
+
 			local Decoded = Decode( Data )
 
 			if not Decoded then return end
@@ -456,7 +456,7 @@ function Plugin:RemoveBan( ID, DontSave, UnbannerID )
 
 				return
 			end
-			
+
 			Shine.TimedHTTPRequest( self.Config.BansSubmitURL, "POST", PostParams,
 				SuccessFunc, TimeoutFunc, self.Config.SubmitTimeout )
 		end
@@ -589,18 +589,18 @@ function Plugin:CreateCommands()
 		local BanningID = Client and Client:GetUserId() or 0
 		local Target = Shine.GetClientByNS2ID( tonumber( ID ) )
 		local TargetName = "<unknown>"
-		
+
 		if Target then
 			TargetName = Target:GetControllingPlayer():GetName()
 		end
-		
+
 		if self:AddBan( ID, TargetName, Duration, BanningName, BanningID, Reason ) then
 			local DurationString = Duration ~= 0 and "for "..string.TimeToString( Duration )
 				or "permanently"
 
 			Shine:AdminPrint( nil, "%s banned %s[%s] %s.", true, BanningName, TargetName,
 				ID, DurationString )
-			
+
 			if Target then
 				Server.DisconnectClient( Target )
 
@@ -626,7 +626,7 @@ function Plugin:CreateCommands()
 			Shine:AdminPrint( Client, "There are no bans on record." )
 			return
 		end
-		
+
 		Shine:AdminPrint( Client, "Currently stored bans:" )
 		for ID, BanTable in pairs( self.Config.Banned ) do
 			local TimeRemaining = BanTable.UnbanTime == 0 and "Forever"
@@ -730,7 +730,7 @@ function Plugin:NetworkUnban( ID )
 	end
 
 	if not self.BanNetworkedClients then return end
-	
+
 	for Client in pairs( self.BanNetworkedClients ) do
 		self:SendNetworkMessage( Client, "Unban", { ID = ID }, true )
 	end
@@ -738,7 +738,7 @@ end
 
 function Plugin:ReceiveRequestBanData( Client, Data )
 	if not Shine:GetPermission( Client, self.ListPermission ) then return end
-	
+
 	self.BanNetworkedClients = self.BanNetworkedClients or {}
 
 	self.BanNetworkedClients[ Client ] = self.BanNetworkedClients[ Client ] or 1

--- a/lua/shine/extensions/ban/shared.lua
+++ b/lua/shine/extensions/ban/shared.lua
@@ -34,6 +34,7 @@ local SGUI = Shine.GUI
 
 local Date = os.date
 local StringFormat = string.format
+local StringTimeToString = string.TimeToString
 local TableEmpty = table.Empty
 local TableRemove = table.remove
 
@@ -56,8 +57,8 @@ function Plugin:SetupAdminMenu()
 
 		Window = SGUI:Create( "Panel" )
 		Window:SetAnchor( "CentreMiddle" )
-		Window:SetSize( Vector( 400, 296, 0 ) )
-		Window:SetPos( Vector( -200, -148, 0 ) )
+		Window:SetSize( Vector( 400, 328, 0 ) )
+		Window:SetPos( Vector( -200, -164, 0 ) )
 		Window:AddTitleBar( "Add ban" )
 		Window:SkinColour()
 
@@ -74,15 +75,20 @@ function Plugin:SetupAdminMenu()
 		local DurationEntry
 		local ReasonEntry
 
+		local X = 16
+		local Y = 32
+
 		local IDLabel = SGUI:Create( "Label", Window )
 		IDLabel:SetText( "NS2ID:" )
 		IDLabel:SetFont( Fonts.kAgencyFB_Small )
 		IDLabel:SetBright( true )
-		IDLabel:SetPos( Vector( 16, 32, 0 ) )
+		IDLabel:SetPos( Vector( X, Y, 0 ) )
+
+		Y = Y + 32
 
 		local IDEntry = SGUI:Create( "TextEntry", Window )
 		IDEntry:SetSize( TextEntrySize - Vector( 32, 0, 0 ) )
-		IDEntry:SetPos( Vector( 16, 64, 0 ) )
+		IDEntry:SetPos( Vector( X, Y, 0 ) )
 		IDEntry:SetFont( Fonts.kAgencyFB_Small )
 		IDEntry:SetNumeric( true )
 		function IDEntry:OnTab()
@@ -99,7 +105,7 @@ function Plugin:SetupAdminMenu()
 		MenuButton:SetSize( Vector( 32, 32, 0 ) )
 		MenuButton:SetText( ">" )
 		MenuButton:SetFont( Fonts.kAgencyFB_Small )
-		MenuButton:SetPos( Vector( -48, 64, 0 ) )
+		MenuButton:SetPos( Vector( -48, Y, 0 ) )
 		MenuButton:SetTooltip( "Select a player." )
 		local Menu
 
@@ -141,32 +147,63 @@ function Plugin:SetupAdminMenu()
 			end
 		end
 
+		Y = Y + 40
+
 		local DurationLabel = SGUI:Create( "Label", Window )
 		DurationLabel:SetText( "Duration (in minutes, 0 for permanent):" )
 		DurationLabel:SetFont( Fonts.kAgencyFB_Small )
 		DurationLabel:SetBright( true )
-		DurationLabel:SetPos( Vector( 16, 104, 0 ) )
+		DurationLabel:SetPos( Vector( X, Y, 0 ) )
+
+		Y = Y + 32
 
 		DurationEntry = SGUI:Create( "TextEntry", Window )
 		DurationEntry:SetSize( TextEntrySize )
-		DurationEntry:SetPos( Vector( 16, 136, 0 ) )
+		DurationEntry:SetPos( Vector( X, Y, 0 ) )
 		DurationEntry:SetFont( Fonts.kAgencyFB_Small )
-		DurationEntry:SetNumeric( true )
+		DurationEntry:SetCharPattern( "[%w%.%-]" )
 		function DurationEntry:OnTab()
 			self:LoseFocus()
 
 			ReasonEntry:RequestFocus()
 		end
 
+		Y = Y + 40
+
+		local DurationValueLabel = SGUI:Create( "Label", Window )
+		DurationValueLabel:SetText( "Please enter a duration..." )
+		DurationValueLabel:SetFont( Fonts.kAgencyFB_Small )
+		DurationValueLabel:SetBright( true )
+		DurationValueLabel:SetPos( Vector( X, Y, 0 ) )
+		local DurationOptions = { Units = "minutes", Min = 0, Round = true }
+		function DurationEntry:OnTextChanged( OldValue, NewValue )
+			if NewValue == "" then
+				DurationValueLabel:SetText( "Please enter a duration..." )
+				return
+			end
+
+			local Minutes = Shine.CommandUtil.ParamTypes.time( nil, NewValue, DurationOptions )
+			if Minutes == 0 then
+				DurationValueLabel:SetText( "Duration: Permanent." )
+				return
+			end
+
+			DurationValueLabel:SetText( StringFormat( "Duration: %s", StringTimeToString( Minutes * 60 ) ) )
+		end
+
+		Y = Y + 32
+
 		local ReasonLabel = SGUI:Create( "Label", Window )
 		ReasonLabel:SetText( "Reason:" )
 		ReasonLabel:SetFont( Fonts.kAgencyFB_Small )
 		ReasonLabel:SetBright( true )
-		ReasonLabel:SetPos( Vector( 16, 176, 0 ) )
+		ReasonLabel:SetPos( Vector( X, Y, 0 ) )
+
+		Y = Y + 32
 
 		ReasonEntry = SGUI:Create( "TextEntry", Window )
 		ReasonEntry:SetSize( TextEntrySize )
-		ReasonEntry:SetPos( Vector( 16, 208, 0 ) )
+		ReasonEntry:SetPos( Vector( X, Y, 0 ) )
 		ReasonEntry:SetFont( Fonts.kAgencyFB_Small )
 		function ReasonEntry:OnTab()
 			self:LoseFocus()
@@ -177,7 +214,7 @@ function Plugin:SetupAdminMenu()
 		local AddBan = SGUI:Create( "Button", Window )
 		AddBan:SetAnchor( "BottomMiddle" )
 		AddBan:SetSize( Vector( 128, 32, 0 ) )
-		AddBan:SetPos( Vector( -64, -48, 0 ) )
+		AddBan:SetPos( Vector( -64, -44, 0 ) )
 		AddBan:SetText( "Add Ban" )
 		AddBan:SetFont( Fonts.kAgencyFB_Small )
 		function AddBan.DoClick()

--- a/lua/shine/extensions/ban/shared.lua
+++ b/lua/shine/extensions/ban/shared.lua
@@ -195,6 +195,8 @@ function Plugin:SetupAdminMenu()
 			Shine.AdminMenu:DontDestroyOnClose( Window )
 			Window:Destroy()
 			Window = nil
+
+			self:RequestBanData()
 		end
 	end
 

--- a/lua/shine/extensions/ban/shared.lua
+++ b/lua/shine/extensions/ban/shared.lua
@@ -110,7 +110,7 @@ function Plugin:SetupAdminMenu()
 				Menu = nil
 				return
 			end
-			
+
 			local Pos = Button:GetScreenPos()
 			Pos.x = Pos.x - TextEntrySize.x + 32
 			Pos.y = Pos.y + TextEntrySize.y
@@ -130,7 +130,9 @@ function Plugin:SetupAdminMenu()
 				local Name = Ent.playerName
 
 				Menu:AddButton( Name, function()
-					IDEntry:SetText( SteamID )
+					if SGUI.IsValid( IDEntry ) then
+						IDEntry:SetText( SteamID )
+					end
 
 					Shine.AdminMenu:DontDestroyOnClose( Menu )
 					Menu:Destroy()
@@ -181,10 +183,10 @@ function Plugin:SetupAdminMenu()
 		function AddBan.DoClick()
 			local ID = tonumber( IDEntry:GetText() )
 			if not ID then return end
-			
+
 			local Duration = tonumber( DurationEntry:GetText() )
 			if not Duration then return end
-			
+
 			local Reason = ReasonEntry:GetText()
 
 			Shine.AdminMenu:RunCommand( self.BanCommand, StringFormat( "%s %s %s",
@@ -195,7 +197,7 @@ function Plugin:SetupAdminMenu()
 			Window = nil
 		end
 	end
-	
+
 	self:AddAdminMenuTab( self.AdminTab, {
 		OnInit = function( Panel, Data )
 			local List = SGUI:Create( "List", Panel )
@@ -240,7 +242,7 @@ function Plugin:SetupAdminMenu()
 			function Unban.DoClick()
 				local Row = List:GetSelectedRow()
 				if not Row then return end
-				
+
 				local Data = Row.BanData
 				if not Data then return end
 				local ID = Data.ID
@@ -294,7 +296,7 @@ function Plugin:ReceiveUnban( Data )
 	local ID = Data.ID
 
 	if not self.BanData then return end
-	
+
 	local BanData = self.BanData
 	local Rows = self.Rows
 	local List = self.BanList

--- a/lua/shine/extensions/ban/shared.lua
+++ b/lua/shine/extensions/ban/shared.lua
@@ -221,8 +221,8 @@ function Plugin:SetupAdminMenu()
 			local ID = tonumber( IDEntry:GetText() )
 			if not ID then return end
 
-			local Duration = tonumber( DurationEntry:GetText() )
-			if not Duration then return end
+			local Duration = DurationEntry:GetText()
+			if Duration == "" then return end
 
 			local Reason = ReasonEntry:GetText()
 

--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -252,7 +252,7 @@ local function NotifyError( Client, Message, Format, ... )
 		return
 	end
 
-	Shine:NotifyError( Client, Message, Format, ... )
+	Shine:NotifyCommandError( Client, Message, Format, ... )
 end
 
 local Histories = {}
@@ -1193,6 +1193,8 @@ function Plugin:CreateCommands()
 		local StartVote
 
 		local function CustomVote( Client, VoteQuestion )
+			if not Client then return end
+
 			StartVote = StartVote or Shine.GetUpValue( RegisterVoteType, "StartVote", true )
 			if not StartVote then return end
 

--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -69,7 +69,7 @@ Hook.Add( "NS2EventHook", "BaseCommandsOverrides", function( Name, OldFunc )
 	if Name == "Console_sv_say" then
 		local function NewSay( Client, ... )
 			if Shine:IsExtensionEnabled( "basecommands" ) then
-				return Shine:RunCommand( Client, "sh_say", ... )
+				return Shine:RunCommand( Client, "sh_say", false, ... )
 			end
 
 			return OldFunc( Client, ... )
@@ -1188,6 +1188,24 @@ function Plugin:CreateCommands()
 	local MoveRateCommand = self:BindCommand( "sh_moverate", "moverate", MoveRate )
 	MoveRateCommand:AddParam{ Type = "number", Min = 5, Round = true }
 	MoveRateCommand:Help( "<rate> Sets the move rate and saves it." )
+
+	do
+		local StartVote
+
+		local function CustomVote( Client, VoteQuestion )
+			StartVote = StartVote or Shine.GetUpValue( RegisterVoteType, "StartVote", true )
+			if not StartVote then return end
+
+			StartVote( "ShineCustomVote", Client, { VoteQuestion = VoteQuestion } )
+		end
+		local CustomVoteCommand = self:BindCommand( "sh_customvote", "customvote", CustomVote )
+		CustomVoteCommand:AddParam{ Type = "string", TakeRestOfLine = true }
+		CustomVoteCommand:Help( "<question> Starts a vote with the given question." )
+	end
+end
+
+function Plugin:OnCustomVoteSuccess( Data )
+
 end
 
 function Plugin:IsClientGagged( Client )

--- a/lua/shine/extensions/basecommands/shared.lua
+++ b/lua/shine/extensions/basecommands/shared.lua
@@ -45,10 +45,23 @@ end
 Shine:RegisterExtension( "basecommands", Plugin )
 
 if Server then
-	RegisterVoteType( "ShineCustomVote", { VoteQuestion = "string (64)" } )
+	local function RegisterCustomVote()
+		RegisterVoteType( "ShineCustomVote", { VoteQuestion = "string (64)" } )
 
-	SetVoteSuccessfulCallback( "ShineCustomVote", 4, function( Data )
-		Plugin:OnCustomVoteSuccess( Data )
+		SetVoteSuccessfulCallback( "ShineCustomVote", 4, function( Data )
+			Plugin:OnCustomVoteSuccess( Data )
+		end )
+	end
+
+	if RegisterVoteType then
+		RegisterCustomVote()
+		return
+	end
+
+	Shine.Hook.Add( "PostLoadScript", "SetupCustomVote", function( Script )
+		if Script ~= "lua/Voting.lua" then return end
+
+		RegisterCustomVote()
 	end )
 
 	return

--- a/lua/shine/extensions/basecommands/shared.lua
+++ b/lua/shine/extensions/basecommands/shared.lua
@@ -44,7 +44,29 @@ end
 
 Shine:RegisterExtension( "basecommands", Plugin )
 
-if Server then return end
+if Server then
+	RegisterVoteType( "ShineCustomVote", { VoteQuestion = "string (64)" } )
+
+	SetVoteSuccessfulCallback( "ShineCustomVote", 4, function( Data )
+		Plugin:OnCustomVoteSuccess( Data )
+	end )
+
+	return
+end
+
+Shine.Hook.Add( "PostLoadScript", "SetupCustomVote", function( Script )
+	if Script ~= "lua/Voting.lua" then return end
+
+	Shine.Hook.Remove( "PostLoadScript", "SetupCustomVote" )
+
+	RegisterVoteType( "ShineCustomVote", { VoteQuestion = "string (64)" } )
+
+	AddVoteSetupCallback( function( VoteMenu )
+		AddVoteStartListener( "ShineCustomVote", function( Data )
+			return Data.VoteQuestion
+		end )
+	end )
+end )
 
 local Shine = Shine
 local Hook = Shine.Hook

--- a/lua/shine/extensions/commbans/server.lua
+++ b/lua/shine/extensions/commbans/server.lua
@@ -57,7 +57,7 @@ function Plugin:CheckCommLogin( CommandStation, Player )
 	local BanData = self.Config.Banned[ ID ]
 
 	if not BanData then return end
-	
+
 	local CurTime = Time()
 
 	if BanData.UnbanTime == 0 or BanData.UnbanTime > CurTime then
@@ -117,7 +117,7 @@ function Plugin:CreateCommands()
 	end
 	local BanCommand = self:BindCommand( "sh_commban", "commban", Ban )
 	BanCommand:AddParam{ Type = "client", NotSelf = true }
-	BanCommand:AddParam{ Type = "number", Min = 0, Round = true, Optional = true,
+	BanCommand:AddParam{ Type = "time", Units = "minutes", Min = 0, Round = true, Optional = true,
 		Default = self.Config.DefaultBanTime }
 	BanCommand:AddParam{ Type = "string", Optional = true, TakeRestOfLine = true,
 		Default = "No reason given." }
@@ -189,18 +189,18 @@ function Plugin:CreateCommands()
 		local BanningID = Client and Client:GetUserId() or 0
 		local Target = Shine.GetClientByNS2ID( tonumber( ID ) )
 		local TargetName = "<unknown>"
-		
+
 		if Target then
 			TargetName = Target:GetControllingPlayer():GetName()
 		end
-		
+
 		if self:AddBan( ID, TargetName, Duration, BanningName, BanningID, Reason ) then
 			local DurationString = Duration ~= 0 and "for "..string.TimeToString( Duration )
 				or "permanently"
 
 			Shine:AdminPrint( nil, "%s banned %s[%s] from commanding %s.", true, BanningName,
 				TargetName, ID, DurationString )
-			
+
 			if Target then
 				local TargetPlayer = Target:GetControllingPlayer()
 				if TargetPlayer and TargetPlayer:isa( "Commander" ) then
@@ -219,7 +219,7 @@ function Plugin:CreateCommands()
 	end
 	local BanIDCommand = self:BindCommand( "sh_commbanid", "commbanid", BanID )
 	BanIDCommand:AddParam{ Type = "string", Error = "Please specify a Steam ID to ban." }
-	BanIDCommand:AddParam{ Type = "number", Min = 0, Round = true, Optional = true,
+	BanIDCommand:AddParam{ Type = "time", Units = "minutes", Min = 0, Round = true, Optional = true,
 		Default = self.Config.DefaultBanTime }
 	BanIDCommand:AddParam{ Type = "string", Optional = true, TakeRestOfLine = true,
 		Default = "No reason given." }

--- a/lua/shine/extensions/funcommands/server.lua
+++ b/lua/shine/extensions/funcommands/server.lua
@@ -60,14 +60,14 @@ function Plugin:CreateCommands()
 
 	local function GoTo( Client, Target )
 		if not Client then return end
-		
+
 		local TargetPlayer = Target:GetControllingPlayer()
 		local Player = Client:GetControllingPlayer()
 
 		if not Player or not TargetPlayer then return end
-		
+
 		if not self:MovePlayerToPlayer( Player, TargetPlayer ) then
-			Shine:NotifyError( Client, "Failed to find valid location near player." )
+			Shine:NotifyCommandError( Client, "Failed to find valid location near player." )
 		else
 			Shine:CommandNotify( Client, "teleported to %s.", true,
 				TargetPlayer:GetName() or "<unknown>" )
@@ -84,9 +84,9 @@ function Plugin:CreateCommands()
 		local Player = Client:GetControllingPlayer()
 
 		if not Player or not TargetPlayer then return end
-		
+
 		if not self:MovePlayerToPlayer( TargetPlayer, Player ) then
-			Shine:NotifyError( Client, "Failed to find valid location near you." )
+			Shine:NotifyCommandError( Client, "Failed to find valid location near you." )
 		else
 			Shine:CommandNotify( Client, "teleported %s to themself.",
 				true, TargetPlayer:GetName() or "<unknown>" )

--- a/lua/shine/extensions/mapvote/server.lua
+++ b/lua/shine/extensions/mapvote/server.lua
@@ -1499,7 +1499,8 @@ function Plugin:CreateCommands()
 		end
 	end
 	local AddTimeCommand = self:BindCommand( "sh_addtimelimit", "addtimelimit", AddTime )
-	AddTimeCommand:AddParam{ Type = "number", Error = "Please specify a time to add." }
+	AddTimeCommand:AddParam{ Type = "time", Units = "minutes", TakeRestOfLine = true,
+		Error = "Please specify a time to add." }
 	AddTimeCommand:Help( "<time in minutes> Adds the given time to the current map's time limit." )
 
 	local function SetTime( Client, Time )
@@ -1510,7 +1511,8 @@ function Plugin:CreateCommands()
 		Shine:CommandNotify( Client, "set the map time to %s.", true, string.TimeToString( Time ) )
 	end
 	local SetTimeCommand = self:BindCommand( "sh_settimelimit", "settimelimit", SetTime )
-	SetTimeCommand:AddParam{ Type = "number", Min = 0, Error = "Please specify the map time." }
+	SetTimeCommand:AddParam{ Type = "time", Units = "minutes", Min = 0, TakeRestOfLine = true,
+		Error = "Please specify the map time." }
 	SetTimeCommand:Help( "<time in minutes> Sets the current map's time limit." )
 
 	local function AddRounds( Client, Rounds )

--- a/lua/shine/extensions/mapvote/server.lua
+++ b/lua/shine/extensions/mapvote/server.lua
@@ -601,6 +601,11 @@ function Plugin:EndGame()
 			return
 		end
 
+		--Don't say anything if there's more than an hour left.
+		if TimeLeft > 3600 then
+			return
+		end
+
 		--Round the time down to the nearest 30 seconds.
 		if TimeLeft > 30 then
 			TimeLeft = TimeLeft - ( TimeLeft % 30 )

--- a/lua/shine/extensions/serverswitch/server.lua
+++ b/lua/shine/extensions/serverswitch/server.lua
@@ -63,7 +63,7 @@ end
 
 function Plugin:ClientConfirmConnect( Client )
 	if not Shine:IsValidClient( Client ) then return end
-	
+
 	self:ProcessClient( Client )
 end
 
@@ -81,7 +81,7 @@ function Plugin:CreateCommands()
 		local Player = Client:GetControllingPlayer()
 
 		if not Player then return end
-		
+
 		local ServerData = self.Config.Servers[ Num ]
 
 		if not ServerData then
@@ -101,13 +101,13 @@ function Plugin:CreateCommands()
 
 		local Password = ServerData.Password
 
-		if not Password then 
+		if not Password then
 			Password = ""
 		elseif Password ~= "" then
 			Password = " "..Password
 		end
-		
-		Shine.SendNetworkMessage( Client, "Shine_Command", { 
+
+		Shine.SendNetworkMessage( Client, "Shine_Command", {
 			Command = StringFormat( "connect %s:%s%s", ServerData.IP, ServerData.Port, Password )
 		}, true )
 	end

--- a/lua/shine/extensions/tournamentmode/server.lua
+++ b/lua/shine/extensions/tournamentmode/server.lua
@@ -67,14 +67,14 @@ function Plugin:Initialise()
 	end
 
 	self:CreateCommands()
-	
+
 	self.Enabled = true
 
 	return true
 end
 
 function Plugin:Notify( Positive, Player, Message, Format, ... )
-	Shine:NotifyDualColour( Player, Positive and 0 or 255, Positive and 255 or 0, 0, 
+	Shine:NotifyDualColour( Player, Positive and 0 or 255, Positive and 255 or 0, 0,
 		"[TournamentMode]", 255, 255, 255, Message, Format, ... )
 end
 
@@ -89,7 +89,7 @@ function Plugin:EndGame( Gamerules, WinningTeam )
 	--Record the winner, and network it.
 	if WinningTeam == Gamerules.team1 or WinningTeam == 1 then
 		self.TeamScores[ 1 ] = self.TeamScores[ 1 ] + 1
-	
+
 		self.dt.MarineScore = self.TeamScores[ 1 ]
 	elseif WinningTeam == Gamerules.team2 or WinningTeam == 2 then
 		self.TeamScores[ 2 ] = self.TeamScores[ 2 ] + 1
@@ -104,7 +104,7 @@ local NextStartNag = 0
 
 function Plugin:CheckGameStart( Gamerules )
 	local State = Gamerules:GetGameState()
-	
+
 	if State == kGameState.PreGame or State == kGameState.NotStarted then
 		self.GameStarted = false
 
@@ -132,7 +132,7 @@ function Plugin:GetStartNag()
 	local AliensReady = self.ReadyStates[ 2 ]
 
 	if MarinesReady and AliensReady then return nil end
-	
+
 	if MarinesReady and not AliensReady then
 		return StringFormat( "Waiting on %s to start", self:GetTeamName( 2 ) )
 	elseif AliensReady and not MarinesReady then
@@ -181,7 +181,7 @@ function Plugin:StartGame( Gamerules )
 
 	for i = 1, Count do
 		local Player = Players[ i ]
-		
+
 		if Player.ResetScores then
 			Player:ResetScores()
 		end
@@ -209,7 +209,7 @@ function Plugin:ClientConfirmConnect( Client )
 
 		self.DisabledAutobalance = true
 	end
-	
+
 	if Client:GetIsVirtual() then return end
 
 	local ID = Client:GetUserId()
@@ -217,7 +217,7 @@ function Plugin:ClientConfirmConnect( Client )
 	if self.Config.ForceTeams then
 		if self.TeamMembers[ ID ] then
 			Gamerules:JoinTeam( Client:GetControllingPlayer(), self.TeamMembers[ ID ],
-				nil, true )     
+				nil, true )
 		end
 	end
 end
@@ -266,7 +266,7 @@ end
 ]]
 function Plugin:PostJoinTeam( Gamerules, Player, OldTeam, NewTeam, Force )
 	if NewTeam == 0 or NewTeam == 3 then return end
-	
+
 	local Client = Server.GetOwner( Player )
 
 	if not Client then return end
@@ -339,13 +339,13 @@ function Plugin:CreateCommands()
 		local Player = Client:GetControllingPlayer()
 
 		if not Player then return end
-		
+
 		local Team = Player:GetTeamNumber()
 
 		if Team ~= 1 and Team ~= 2 then return end
 
 		if not Player:isa( "Commander" ) and not self.Config.EveryoneReady then
-			Shine:NotifyError( Client, "Only the commander can ready up the team." )
+			Shine:NotifyCommandError( Client, "Only the commander can ready up the team." )
 
 			return
 		end
@@ -354,7 +354,7 @@ function Plugin:CreateCommands()
 
 		if self.Config.EveryoneReady then
 			if self.ReadiedPlayers[ Client ] then
-				Shine:NotifyError( Client,
+				Shine:NotifyCommandError( Client,
 					"You are already ready! Use !unready to unready yourself." )
 
 				return
@@ -380,7 +380,7 @@ function Plugin:CreateCommands()
 			end
 
 			if not Ready then return end
-			
+
 			self.ReadyStates[ Team ] = true
 
 			local TeamName = self:GetTeamName( Team )
@@ -418,32 +418,32 @@ function Plugin:CreateCommands()
 				self:Notify( true, nil, "%s is now ready. Waiting on %s to start.",
 					true, TeamName, self:GetTeamName( OtherTeam ) )
 			end
-			
+
 			--Add a delay to prevent ready->unready spam.
 			self.NextReady[ Team ] = Time + 5
 
 			self:CheckStart()
 		else
-			Shine:NotifyError( Client,
+			Shine:NotifyCommandError( Client,
 				"Your team is already ready! Use !unready to unready your team." )
 		end
 	end
 	local ReadyCommand = self:BindCommand( "sh_ready", { "rdy", "ready" }, ReadyUp, true )
 	ReadyCommand:Help( "Makes your team ready to start the game." )
-	
+
 	local function Unready( Client )
 		if self.GameStarted then return end
 
 		local Player = Client:GetControllingPlayer()
 
 		if not Player then return end
-		
+
 		local Team = Player:GetTeamNumber()
 
 		if Team ~= 1 and Team ~= 2 then return end
 
 		if not Player:isa( "Commander" ) and not self.Config.EveryoneReady then
-			Shine:NotifyError( Client, "Only the commander can ready up the team." )
+			Shine:NotifyCommandError( Client, "Only the commander can ready up the team." )
 
 			return
 		end
@@ -452,7 +452,7 @@ function Plugin:CreateCommands()
 
 		if self.Config.EveryoneReady then
 			if not self.ReadiedPlayers[ Client ] then
-				Shine:NotifyError( Client,
+				Shine:NotifyCommandError( Client,
 					"You haven't readied yet! Use !ready to ready yourself." )
 
 				return
@@ -492,7 +492,7 @@ function Plugin:CreateCommands()
 
 			self:CheckStart()
 		else
-			Shine:NotifyError( Client,
+			Shine:NotifyCommandError( Client,
 				"Your team has not readied yet! Use !ready to ready your team." )
 		end
 	end

--- a/lua/shine/extensions/unstuck.lua
+++ b/lua/shine/extensions/unstuck.lua
@@ -25,7 +25,7 @@ function Plugin:Initialise()
 	self:CreateCommands()
 
 	self.Enabled = true
-	
+
 	return true
 end
 
@@ -47,7 +47,7 @@ function Plugin:UnstickPlayer( Player, Pos )
 	end
 
 	local Height, Radius = GetTraceCapsuleFromExtents( Bounds )
-	
+
 	local SpawnPoint
 	local ResourceNear
 	local i = 1
@@ -85,7 +85,7 @@ function Plugin:CreateCommands()
 
 			return
 		end
-		
+
 		local Time = Shared.GetTime()
 
 		local NextUse = self.Users[ Client ]

--- a/lua/shine/lib/string.lua
+++ b/lua/shine/lib/string.lua
@@ -100,30 +100,16 @@ function string.DigitalTime( Time )
 end
 
 do
-	local StringGSub = string.gsub
+	local StringGMatch = string.gmatch
 	local StringLower = string.lower
 	local tonumber = tonumber
 
 	local Times = {
-		sec = 1,
-		secs = 1,
-		s = 1,
-		second = 1,
-		seconds = 1,
-		m = 60,
-		minute = 60,
-		minutes = 60,
-		min = 60,
-		mins = 60,
-		h = 3600,
-		hour = 3600,
-		hours = 3600,
-		d = 86400,
-		day = 86400,
-		days = 86400,
-		w = 604800,
-		week = 604800,
-		weeks = 604800
+		sec = 1, secs = 1, s = 1, second = 1, seconds = 1,
+		m = 60,	minute = 60, minutes = 60, min = 60, mins = 60,
+		h = 3600, hr = 3600, hrs = 3600, hour = 3600, hours = 3600,
+		d = 86400, day = 86400, days = 86400,
+		w = 604800, week = 604800, weeks = 604800
 	}
 
 	--[[
@@ -135,16 +121,15 @@ do
 	function string.ToTime( String )
 		local Time = 0
 
-		StringGSub( StringLower( String ), "([%-%d%.]+)%s-([a-zA-Z]+)", function( Amount, Unit )
+		for Amount, Unit in StringGMatch( StringLower( String ), "([%-%d%.]+)%s-([a-z]+)" ) do
 			local Magnitude = Times[ Unit ]
-			if not Magnitude then return "" end
-
-			Amount = tonumber( Amount )
-			if not Amount then return "" end
-			Time = Time + Amount * Magnitude
-
-			return ""
-		end )
+			if Magnitude then
+				Amount = tonumber( Amount )
+				if Amount then
+					Time = Time + Amount * Magnitude
+				end
+			end
+		end
 
 		return Time
 	end

--- a/lua/shine/lib/string.lua
+++ b/lua/shine/lib/string.lua
@@ -8,6 +8,15 @@ local StringFormat = string.format
 local StringSub = string.sub
 local TableConcat = table.concat
 
+--[[
+	Splits the given string by the given pattern.
+
+	Inputs:
+		1. String to split.
+		2. Pattern to split with.
+	Output:
+		Table containing strings separated by the given pattern.
+]]
 function string.Explode( String, Pattern )
 	local Ret = {}
 	local FindPattern = "(.-)"..Pattern
@@ -45,6 +54,12 @@ do
 	}
 	local NumTimes = #TimeFuncs
 
+	--[[
+		Converts a time value into a "nice" time string.
+
+		Input: Time value in seconds.
+		Output: "Nice" time string, e.g 65 -> "1 minute and 5 seconds".
+	]]
 	function string.TimeToString( Time )
 		if Time < 1 then return "0 seconds" end
 
@@ -69,11 +84,68 @@ do
 	end
 end
 
+--[[
+	Converts a time value to a digital representation in minutes:seconds.
+
+	Input: Time value in seconds.
+	Output: Digital time.
+]]
 function string.DigitalTime( Time )
 	if Time <= 0 then return "00:00" end
-	
+
 	local Seconds = Floor( Time % 60 )
 	local Minutes = Floor( Time / 60 )
 
 	return StringFormat( "%.2i:%.2i", Minutes, Seconds )
+end
+
+do
+	local StringGSub = string.gsub
+	local StringLower = string.lower
+	local tonumber = tonumber
+
+	local Times = {
+		sec = 1,
+		secs = 1,
+		s = 1,
+		second = 1,
+		seconds = 1,
+		m = 60,
+		minute = 60,
+		minutes = 60,
+		min = 60,
+		mins = 60,
+		h = 3600,
+		hour = 3600,
+		hours = 3600,
+		d = 86400,
+		day = 86400,
+		days = 86400,
+		w = 604800,
+		week = 604800,
+		weeks = 604800
+	}
+
+	--[[
+		Converts a string of time magnitude -> time unit to a time value in seconds.
+
+		Input: String containing some kind of time information.
+		Output: Time value the string represents in seconds.
+	]]
+	function string.ToTime( String )
+		local Time = 0
+
+		StringGSub( StringLower( String ), "([%-%d%.]+)%s-([a-zA-Z]+)", function( Amount, Unit )
+			local Magnitude = Times[ Unit ]
+			if not Magnitude then return "" end
+
+			Amount = tonumber( Amount )
+			if not Amount then return "" end
+			Time = Time + Amount * Magnitude
+
+			return ""
+		end )
+
+		return Time
+	end
 end


### PR DESCRIPTION
- Added sh_customvote command, calls a vote with the given question.
- Commands that use time values are now easier to work with.
  - For ban commands, you can now use short form strings, for example `1w` represents 1 week, `2h5m` represents 2 hours and 5 minutes.
  - For the mapvote plugin's round time commands, you can even use full sentence times, such as `1 week` or `2 hours and 5 minutes`.
  - The old behaviour of entering time in minutes as a number is still supported.
- Added a label under the duration text box in the admin menu when banning through the bans/commbans plugin that displays what the duration you are entering is being interpreted as. This should help avoid any confusion/unintended durations.
- The text entry control now supports selecting whole words by double clicking on them.