### PR TITLE
Multiple UI improvements

### DIFF
--- a/lua/shine/core/client/adminmenu.lua
+++ b/lua/shine/core/client/adminmenu.lua
@@ -336,7 +336,7 @@ do
 				UpdatePlayers()
 			end )
 
-			AdminMenu.RestoreListState( List, Data )
+			AdminMenu.RestoreListState( PlayerList, Data )
 
 			Hook.Add( "OnClientIDDisconnect", "AdminMenu_UpdatePlayers", function( ClientID )
 				local Row = Rows[ ClientID ]

--- a/lua/shine/core/client/adminmenu.lua
+++ b/lua/shine/core/client/adminmenu.lua
@@ -6,6 +6,7 @@ local Shine = Shine
 local SGUI = Shine.GUI
 local Hook = Shine.Hook
 
+local IsType = Shine.IsType
 local StringFormat = string.format
 local TableConcat = table.concat
 
@@ -201,11 +202,71 @@ function AdminMenu:OnTabCleanup( Window, Name )
 	end
 end
 
+function AdminMenu.GetListState( List )
+	local SelectedIndex
+
+	if List.MultiSelect then
+		local Selected = List:GetSelectedRows()
+
+		if #Selected > 0 then
+			SelectedIndex = {}
+			for i = 1, #Selected do
+				SelectedIndex[ i ] = Selected[ i ].Index
+			end
+		end
+	else
+		local Row = List:GetSelectedRow()
+		if Row then
+			SelectedIndex = Row.Index
+		end
+	end
+
+	Print( "SelectedIndex: %s", tostring( SelectedIndex ) )
+
+	return {
+		SortedColumn = List.SortedColumn,
+		Descending = List.Descending,
+		SelectedIndex = SelectedIndex
+	}
+end
+
+function AdminMenu.RestoreListState( List, Data )
+	if not Data then return end
+	if not Data.SortedColumn and not Data.SelectedIndex then return end
+
+	if Data.SortedColumn then
+		List:SortRows( Data.SortedColumn, nil, Data.Descending )
+	end
+
+	if Data.SelectedIndex and List.Rows then
+		if List.MultiSelect and IsType( Data.SelectedIndex, "table" ) then
+			local Selected = Data.SelectedIndex
+
+			for i = 1, #Selected do
+				local Row = List.Rows[ Selected[ i ] ]
+
+				if Row then
+					Row:SetHighlighted( true, true )
+					Row.Selected = true
+				end
+			end
+		elseif not List.MultiSelect and IsType( Data.SelectedIndex, "number" ) then
+			local Row = List.Rows[ Data.SelectedIndex ]
+			if Row then
+				List:OnRowSelect( Data.SelectedIndex, Row )
+				Row:SetHighlighted( true, true )
+				Row.Selected = true
+			end
+		end
+	end
+
+	return Data.SortedColumn ~= nil
+end
+
 --Setup the commands tab.
 do
 	local GetEnts = Shared.GetEntitiesWithClassname
 	local IterateEntList = ientitylist
-	local IsType = Shine.IsType
 	local TableEmpty = table.Empty
 	local TableRemove = table.remove
 	local TableSort = table.sort
@@ -277,9 +338,7 @@ do
 				UpdatePlayers()
 			end )
 
-			if Data and Data.SortingColumn then
-				List:SortRows( Data.SortingColumn, nil, Data.Descending )
-			end
+			AdminMenu.RestoreListState( List, Data )
 
 			Hook.Add( "OnClientIDDisconnect", "AdminMenu_UpdatePlayers", function( ClientID )
 				local Row = Rows[ ClientID ]
@@ -330,14 +389,10 @@ do
 
 		OnCleanup = function( Panel )
 			--Save column sorting, and command category expansions.
-			local SortedColumn = PlayerList.SortedColumn
-			local Descending = PlayerList.Descending
-
-			local Data = {
-				SortedColumn = SortedColumn,
-				Descending = Descending,
-				CommandExpansions = {}
-			}
+			local Data = AdminMenu.GetListState( PlayerList )
+			--Don't save selected players as the order/list can easily change.
+			Data.SelectedIndex = nil
+			Data.CommandExpansions = {}
 
 			local Categories = Commands.Categories
 

--- a/lua/shine/core/client/adminmenu.lua
+++ b/lua/shine/core/client/adminmenu.lua
@@ -221,8 +221,6 @@ function AdminMenu.GetListState( List )
 		end
 	end
 
-	Print( "SelectedIndex: %s", tostring( SelectedIndex ) )
-
 	return {
 		SortedColumn = List.SortedColumn,
 		Descending = List.Descending,

--- a/lua/shine/core/client/adminmenu.lua
+++ b/lua/shine/core/client/adminmenu.lua
@@ -469,6 +469,9 @@ do
 				end
 
 				Menu = Button:AddMenu( Vector( 128, 32, 0 ) )
+				Menu:CallOnRemove( function()
+					Menu = nil
+				end )
 				self:DestroyOnClose( Menu )
 
 				for i = 1, #Data, 2 do

--- a/lua/shine/core/client/votemenu_gui.lua
+++ b/lua/shine/core/client/votemenu_gui.lua
@@ -7,9 +7,11 @@ local Shine = Shine
 
 local Hook = Shine.Hook
 local SGUI = Shine.GUI
+local IsType = Shine.IsType
 
 local Ceil = math.ceil
 local Cos = math.cos
+local Max = math.max
 local Pi = math.pi
 
 local VoteMenu = {}
@@ -104,7 +106,42 @@ local ClickFuncs = {
 function VoteMenu:Create()
 	self.TeamType = PlayerUI_GetTeamType()
 
-	local BackSize = GUIScale( MenuSize )
+	local ScreenWidth = Client.GetScreenWidth()
+	local ScreenHeight = Client.GetScreenHeight()
+
+	local WidthMult = Max( ScreenWidth / 1920, 1 )
+	local HeightMult = Max( ScreenHeight / 1080, 1 )
+
+	local function Scale( Value )
+		local Scale
+		if ScreenWidth > 2880 then
+			Scale =  SGUI.TenEightyPScale( Value )
+		else
+			Scale = GUIScale( Value )
+		end
+
+		if IsType( Scale, "number" ) then
+			return Scale * WidthMult
+		end
+
+		Scale.x = Scale.x * WidthMult
+		Scale.y = Scale.y * HeightMult
+
+		return Scale
+	end
+
+	local BackSize = Scale( MenuSize )
+
+	if ScreenWidth <= 1920 then
+		self.Font = FontName
+		self.TextScale = Scale( FontScale )
+	elseif ScreenWidth <= 2880 then
+		self.Font = Fonts.kAgencyFB_Medium
+		self.TextScale = FontScale
+	else
+		self.Font = Fonts.kAgencyFB_Huge
+		self.TextScale = FontScale * 0.6
+	end
 
 	local Background = SGUI:Create( "Panel" )
 	Background:SetAnchor( GUIItem.Middle, GUIItem.Center )
@@ -120,10 +157,9 @@ function VoteMenu:Create()
 
 	self.ButtonIndex = 0
 
-	self.TextScale = GUIScale( 1 ) * FontScale
-	self.ButtonSize = GUIScale( ButtonSize )
-	self.ButtonClipping = GUIScale( ButtonClipping )
-	self.MaxButtonOffset = GUIScale( MaxButtonOffset )
+	self.ButtonSize = Scale( ButtonSize )
+	self.ButtonClipping = Scale( ButtonClipping )
+	self.MaxButtonOffset = Scale( MaxButtonOffset )
 
 	self:SetPage( self.ActivePage or "Main" )
 
@@ -387,7 +423,7 @@ local function AddButton( self, Pos, Anchor, Text, DoClick )
 		Texture = ButtonTexture[ self.TeamType or PlayerUI_GetTeamType() ],
 		HighlightTexture = ButtonHighlightTexture[ self.TeamType or PlayerUI_GetTeamType() ],
 		Text = Text,
-		Font = FontName,
+		Font = self.Font,
 		TextScale = self.TextScale,
 		TextColour = TextCol,
 		DoClick = DoClick,

--- a/lua/shine/extensions/ban/shared.lua
+++ b/lua/shine/extensions/ban/shared.lua
@@ -268,9 +268,7 @@ function Plugin:SetupAdminMenu()
 				self:RequestBanData()
 			end
 
-			if Data and Data.SortedColumn then
-				List:SortRows( Data.SortedColumn, nil, Data.Descending )
-			end
+			Shine.AdminMenu.RestoreListState( List, Data )
 
 			local Unban = SGUI:Create( "Button", Panel )
 			Unban:SetAnchor( "BottomLeft" )
@@ -314,15 +312,10 @@ function Plugin:SetupAdminMenu()
 		OnCleanup = function( Panel )
 			TableEmpty( self.Rows )
 
-			local SortedColumn = self.BanList.SortedColumn
-			local Descending = self.BanList.Descending
-
+			local BanList = self.BanList
 			self.BanList = nil
 
-			return {
-				SortedColumn = SortedColumn,
-				Descending = Descending
-			}
+			return Shine.AdminMenu.GetListState( BanList )
 		end
 	} )
 end

--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -1254,7 +1254,12 @@ function Plugin:ReceiveRequestMapData( Client, Data )
 end
 
 function Plugin:ReceiveRequestPluginData( Client, Data )
-	if not Shine:GetPermission( Client, "sh_loadplugin" ) then return end
+	if not Shine:GetPermission( Client, "sh_loadplugin" )
+	and not Shine:GetPermission( Client, "sh_unloadplugin" ) then
+		return
+	end
+
+	self:SendNetworkMessage( Client, "PluginTabAuthed", {}, true )
 
 	self.PluginClients = self.PluginClients or {}
 

--- a/lua/shine/extensions/basecommands/shared.lua
+++ b/lua/shine/extensions/basecommands/shared.lua
@@ -160,9 +160,7 @@ function Plugin:SetupAdminMenuCommands()
 				end
 			end
 
-			if Data and Data.SortedColumn then
-				List:SortRows( Data.SortedColumn, nil, Data.Descending )
-			else
+			if not Shine.AdminMenu.RestoreListState( List, Data ) then
 				List:SortRows( 1 )
 			end
 
@@ -197,15 +195,10 @@ function Plugin:SetupAdminMenuCommands()
 		end,
 
 		OnCleanup = function( Panel )
-			local SortColumn = self.MapList.SortedColumn
-			local Descending = self.MapList.Descending
-
+			local MapList = self.MapList
 			self.MapList = nil
 
-			return {
-				SortedColumn = SortColumn,
-				Descending = Descending
-			}
+			return Shine.AdminMenu.GetListState( MapList )
 		end
 	} )
 
@@ -244,9 +237,7 @@ function Plugin:SetupAdminMenuCommands()
 				end
 			end
 
-			if Data and Data.SortedColumn then
-				List:SortRows( Data.SortedColumn, nil, Data.Descending )
-			else
+			if not Shine.AdminMenu.RestoreListState( List, Data ) then
 				List:SortRows( 1 )
 			end
 
@@ -360,15 +351,13 @@ function Plugin:SetupAdminMenuCommands()
 
 			TableEmpty( self.PluginRows )
 
+			local PluginList = self.PluginList
 			self.PluginList = nil
 
 			Hook.Remove( "OnPluginLoad", "AdminMenu_OnPluginLoad" )
 			Hook.Remove( "OnPluginUnload", "AdminMenu_OnPluginUnload" )
 
-			return {
-				SortedColumn = SortColumn,
-				Descending = Descending
-			}
+			return Shine.AdminMenu.GetListState( PluginList )
 		end
 	} )
 end

--- a/lua/shine/extensions/basecommands/shared.lua
+++ b/lua/shine/extensions/basecommands/shared.lua
@@ -256,7 +256,7 @@ function Plugin:SetupAdminMenuCommands()
 				local Selected = List:GetSelectedRow()
 				if not Selected then return end
 
-				return Selected:GetColumnText( 1 )
+				return Selected:GetColumnText( 1 ), Selected:GetColumnText( 2 ) == "Enabled"
 			end
 
 			local UnloadPlugin = SGUI:Create( "Button", Panel )
@@ -266,8 +266,9 @@ function Plugin:SetupAdminMenuCommands()
 			UnloadPlugin:SetText( "Unload Plugin" )
 			UnloadPlugin:SetFont( Fonts.kAgencyFB_Small )
 			function UnloadPlugin:DoClick()
-				local Plugin = GetSelectedPlugin()
+				local Plugin, Enabled = GetSelectedPlugin()
 				if not Plugin then return false end
+				if not Enabled then return false end
 
 				local Menu = self:AddMenu()
 

--- a/lua/shine/extensions/chatbox/client.lua
+++ b/lua/shine/extensions/chatbox/client.lua
@@ -325,11 +325,11 @@ function Plugin:CreateChatbox()
 	if not Pos.x or not Pos.y then
 		ChatBoxPos = self.GUIChat.inputItem:GetPosition() - Vector( 0, 100 * ScalarScale, 0 )
 	else
-		Pos.x = Clamp( Pos.x, 0, ScreenWidth - PanelSize.x )
-		Pos.y = Clamp( Pos.y, -ScreenHeight + PanelSize.y, -PanelSize.y )
-
 		ChatBoxPos = Vector( Pos.x, Pos.y, 0 )
 	end
+
+	ChatBoxPos.x = Clamp( ChatBoxPos.x, 0, ScreenWidth - PanelSize.x )
+	ChatBoxPos.y = Clamp( ChatBoxPos.y, -ScreenHeight + PanelSize.y, -PanelSize.y )
 
 	--Invisible background.
 	local DummyPanel = SGUI:Create( "Panel" )

--- a/lua/shine/extensions/chatbox/client.lua
+++ b/lua/shine/extensions/chatbox/client.lua
@@ -224,7 +224,7 @@ local function VectorMultiply( Vec1, Vec2 )
 end
 
 function Plugin:GetFont()
-	return self.Font--self.UseTinyFont and Fonts.kAgencyFB_Tiny or Fonts.kAgencyFB_Small
+	return self.Font
 end
 
 function Plugin:GetTextScale()

--- a/lua/shine/extensions/mapvote/server.lua
+++ b/lua/shine/extensions/mapvote/server.lua
@@ -749,10 +749,14 @@ function Plugin:AddVote( Client, Map, Revote )
 	if self.Vote.Voted[ Client ] and not Revote then return false, "already voted" end
 
 	local Choice = self:GetVoteChoice( Map )
-	if not Choice then return false, "map is not a valid choice" end
+	if not Choice then return false, StringFormat( "%s is not a valid map choice.", Map ) end
 
 	if Revote then
 		local OldVote = self.Vote.Voted[ Client ]
+		if OldVote == Choice then
+			return false, StringFormat( "You have already voted for %s.", Choice )
+		end
+
 		if OldVote then
 			self.Vote.VoteList[ OldVote ] = self.Vote.VoteList[ OldVote ] - 1
 		end
@@ -1392,9 +1396,13 @@ function Plugin:CreateCommands()
 
 				return
 			end
+
+			NotifyError( Player, Err )
+
+			return
 		end
 
-		NotifyError( Player, "%s is not a valid map choice.", true, Map )
+		NotifyError( Player, Err )
 	end
 	local VoteCommand = self:BindCommand( "sh_vote", "vote", Vote, true )
 	VoteCommand:AddParam{ Type = "string", Error = "Please specify a map to vote for." }

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -1314,17 +1314,20 @@ function ControlMeta:HideTooltip()
 	end )
 end
 
-function ControlMeta:SetHighlighted( Highlighted )
+function ControlMeta:SetHighlighted( Highlighted, SkipAnim )
 	if Highlighted == self.Highlighted then return end
 
 	if Highlighted then
 		self.Highlighted = true
 
 		if not self.TextureHighlight then
-			self:FadeTo( self.Background, self.InactiveCol,
-			self.ActiveCol, 0, 0.1, function( Background )
-				Background:SetColor( self.ActiveCol )
-			end )
+			if SkipAnim then
+				self.Background:SetColor( self.ActiveCol )
+				return
+			end
+
+			self:FadeTo( self.Background, self.InactiveCol, self.ActiveCol,
+				0, 0.1 )
 		else
 			self.Background:SetTexture( self.HighlightTexture )
 		end
@@ -1332,10 +1335,13 @@ function ControlMeta:SetHighlighted( Highlighted )
 		self.Highlighted = false
 
 		if not self.TextureHighlight then
-			self:FadeTo( self.Background, self.ActiveCol,
-			self.InactiveCol, 0, 0.1, function( Background )
-				Background:SetColor( self.InactiveCol )
-			end )
+			if SkipAnim then
+				self.Background:SetColor( self.InactiveCol )
+				return
+			end
+
+			self:FadeTo( self.Background, self.ActiveCol, self.InactiveCol,
+				0, 0.1 )
 		else
 			self.Background:SetTexture( self.Texture )
 		end

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -1384,7 +1384,24 @@ function ControlMeta:ShowTooltip( X, Y )
 	Y = SelfPos.y + Y
 
 	local Tooltip = SGUI.IsValid( self.Tooltip ) and self.Tooltip or SGUI:Create( "Tooltip" )
-	Tooltip:SetText( self.TooltipText )
+
+	ScrW = ScrW or Client.GetScreenWidth
+	ScrH = ScrH or Client.GetScreenHeight
+
+	local W = ScrW()
+	local Font
+	local TextScale
+
+	if W <= 1366 then
+		Font = Fonts.kAgencyFB_Tiny
+	elseif W > 1920 and W <= 2880 then
+		Font = Fonts.kAgencyFB_Medium
+	elseif W > 2880 then
+		Font = Fonts.kAgencyFB_Huge
+		TextScale = Vector( 0.5, 0.5, 0 )
+	end
+
+	Tooltip:SetText( self.TooltipText, Font, TextScale )
 
 	Y = Y - Tooltip:GetSize().y - 4
 

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -1314,6 +1314,34 @@ function ControlMeta:HideTooltip()
 	end )
 end
 
+function ControlMeta:SetHighlighted( Highlighted )
+	if Highlighted == self.Highlighted then return end
+
+	if Highlighted then
+		self.Highlighted = true
+
+		if not self.TextureHighlight then
+			self:FadeTo( self.Background, self.InactiveCol,
+			self.ActiveCol, 0, 0.1, function( Background )
+				Background:SetColor( self.ActiveCol )
+			end )
+		else
+			self.Background:SetTexture( self.HighlightTexture )
+		end
+	else
+		self.Highlighted = false
+
+		if not self.TextureHighlight then
+			self:FadeTo( self.Background, self.ActiveCol,
+			self.InactiveCol, 0, 0.1, function( Background )
+				Background:SetColor( self.InactiveCol )
+			end )
+		else
+			self.Background:SetTexture( self.Texture )
+		end
+	end
+end
+
 function ControlMeta:OnMouseMove( Down )
 	--Basic highlight on mouse over handling.
 	if not self.HighlightOnMouseOver then
@@ -1321,30 +1349,10 @@ function ControlMeta:OnMouseMove( Down )
 	end
 
 	if self:MouseIn( self.Background, self.HighlightMult ) then
-		if not self.Highlighted then
-			self.Highlighted = true
-
-			if not self.TextureHighlight then
-				self:FadeTo( self.Background, self.InactiveCol,
-				self.ActiveCol, 0, 0.1, function( Background )
-					Background:SetColor( self.ActiveCol )
-				end )
-			else
-				self.Background:SetTexture( self.HighlightTexture )
-			end
-		end
+		self:SetHighlighted( true )
 	else
 		if self.Highlighted and not self.ForceHighlight then
-			self.Highlighted = false
-
-			if not self.TextureHighlight then
-				self:FadeTo( self.Background, self.ActiveCol,
-				self.InactiveCol, 0, 0.1, function( Background )
-					Background:SetColor( self.InactiveCol )
-				end )
-			else
-				self.Background:SetTexture( self.Texture )
-			end
+			self:SetHighlighted( false )
 		end
 	end
 end

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -60,6 +60,94 @@ function SGUI.GetChar( Char )
 	return WideStringToString( Char )
 end
 
+do
+	local StringExplode = string.Explode
+	local StringUTF8Length = string.UTF8Length
+	local StringUTF8Sub = string.UTF8Sub
+	local TableConcat = table.concat
+
+	--[[
+		Wraps text to fit the size limit. Used for long words...
+
+		Returns two strings, first one fits entirely on one line, the other may not, and should be
+		added to the next word.
+	]]
+	local function TextWrap( Label, Text, XPos, MaxWidth )
+		local i = 1
+		local FirstLine = Text
+		local SecondLine = ""
+		local Length = StringUTF8Length( Text )
+
+		--Character by character, extend the text until it exceeds the width limit.
+		repeat
+			local CurText = StringUTF8Sub( Text, 1, i )
+
+			--Once it reaches the limit, we go back a character, and set our first and second line results.
+			if XPos + Label:GetTextWidth( CurText ) > MaxWidth then
+				FirstLine = StringUTF8Sub( Text, 1, i - 1 )
+				SecondLine = StringUTF8Sub( Text, i )
+
+				break
+			end
+
+			i = i + 1
+		until i >= Length
+
+		return FirstLine, SecondLine
+	end
+
+	--[[
+		Word wraps text, adding new lines where the text exceeds the width limit.
+
+		This time, it shouldn't freeze the game...
+	]]
+	function SGUI.WordWrap( Label, Text, XPos, MaxWidth )
+		local Words = StringExplode( Text, " " )
+		local StartIndex = 1
+		local Lines = {}
+		local i = 1
+
+		--While loop, as the size of the Words table may increase.
+		while i <= #Words do
+			local CurText = TableConcat( Words, " ", StartIndex, i )
+
+			if XPos + Label:GetTextWidth( CurText ) > MaxWidth then
+				--This means one word is wider than the whole chatbox, so we need to cut it part way through.
+				if StartIndex == i then
+					local FirstLine, SecondLine = TextWrap( Label, CurText, XPos, MaxWidth )
+
+					Lines[ #Lines + 1 ] = FirstLine
+
+					--Add the second line to the next word, or as a new next word if none exists.
+					if Words[ i + 1 ] then
+						Words[ i + 1 ] = StringFormat( "%s %s", SecondLine, Words[ i + 1 ] )
+					else
+						Words[ i + 1 ] = SecondLine
+					end
+
+					StartIndex = i + 1
+				else
+					Lines[ #Lines + 1 ] = TableConcat( Words, " ", StartIndex, i - 1 )
+
+					--We need to jump back a step, as we've still got another word to check.
+					StartIndex = i
+					i = i - 1
+				end
+			elseif i == #Words then --We're at the end!
+				Lines[ #Lines + 1 ] = CurText
+			end
+
+			i = i + 1
+		end
+
+		Label:SetText( TableConcat( Lines, "\n" ) )
+	end
+end
+
+function SGUI.TenEightyPScale( Value )
+	return math.scaledown( Value, 1080, 1280 ) * ( 2 - ( 1080 / 1280 ) )
+end
+
 SGUI.SpecialKeyStates = {
 	Ctrl = false,
 	Alt = false,

--- a/lua/shine/lib/gui/objects/label.lua
+++ b/lua/shine/lib/gui/objects/label.lua
@@ -47,8 +47,7 @@ function Label:GetText()
 end
 
 function Label:GetSize()
-	return Vector( self:GetTextWidth() * self.TextScale.x,
-		self:GetTextHeight() * self.TextScale.y, 0 )
+	return Vector( self:GetTextWidth(), self:GetTextHeight(), 0 )
 end
 
 function Label:SetTextAlignmentX( Align )
@@ -66,12 +65,18 @@ function Label:SetTextScale( Scale )
 end
 
 function Label:GetTextWidth( Text )
-	return self.Text:GetTextWidth( Text or self.Text:GetText() )
+	local Scale = self.TextScale
+	Scale = Scale and Scale.x or 1
+
+	return self.Text:GetTextWidth( Text or self.Text:GetText() ) * Scale
 end
 
 function Label:GetTextHeight( Text )
+	local Scale = self.TextScale
+	Scale = Scale and Scale.y or 1
+
 	if Text then
-		return self.Text:GetTextHeight( Text )
+		return self.Text:GetTextHeight( Text ) * Scale
 	end
 
 	local Lines = 1
@@ -81,7 +86,7 @@ function Label:GetTextHeight( Text )
 		Lines = Lines + 1
 	end
 
-	return self.Text:GetTextHeight( "!" ) * Lines
+	return self.Text:GetTextHeight( "!" ) * Lines * Scale
 end
 
 function Label:SetFont( Name )

--- a/lua/shine/lib/gui/objects/list.lua
+++ b/lua/shine/lib/gui/objects/list.lua
@@ -418,7 +418,7 @@ local function UpdateHeaderHighlighting( self, Column, OldSortingColumn )
 	if not ColumnHeader then return end
 
 	ColumnHeader.ForceHighlight = true
-	ColumnHeader:SetHighlighted( true )
+	ColumnHeader:SetHighlighted( true, true )
 
 	if OldSortingColumn then
 		local OldHeader = self.Columns[ OldSortingColumn ]

--- a/lua/shine/lib/gui/objects/list.lua
+++ b/lua/shine/lib/gui/objects/list.lua
@@ -622,6 +622,8 @@ function List:OnMouseWheel( Down )
 		return
 	end
 
+	self.Scrollbar.MouseWheelScroll = ( self.LineSize or 32 ) * 3
+
 	return self.Scrollbar:OnMouseWheel( Down )
 end
 

--- a/lua/shine/lib/gui/objects/list.lua
+++ b/lua/shine/lib/gui/objects/list.lua
@@ -62,7 +62,7 @@ function List:Initialise()
 	if ListData.HeaderSize then
 		self:SetHeaderSize( ListData.HeaderSize )
 	end
-	
+
 	if ListData.LineSize then
 		self:SetLineSize( ListData.LineSize )
 	end
@@ -89,7 +89,7 @@ function List:OnSchemeChange( Scheme )
 	if ListData.HeaderSize then
 		self:SetHeaderSize( ListData.HeaderSize )
 	end
-	
+
 	if ListData.LineSize then
 		self:SetLineSize( ListData.LineSize )
 	end
@@ -133,11 +133,11 @@ function List:SetLineSize( Size )
 
 		self.MaxRows = Floor( ( self.Size.y - self.HeaderSize ) / self.LineSize )
 	end
-	
+
 	local Rows = self.Rows
 
 	if not Rows then return end
-	
+
 	for i = 1, #Rows do
 		local Row = Rows[ i ]
 
@@ -265,16 +265,16 @@ function List:SetSize( Size )
 	self.ScrollPos = Vector( 10, self.HeaderSize, 0 )
 
 	self.MaxRows = Floor( ( Size.y - self.HeaderSize ) / self.LineSize )
-	
+
 	if self.RowCount > self.MaxRows then
 		if self.Scrollbar then
-			self.Scrollbar:SetScrollSize( self.MaxRows / self.RowCount )	
+			self.Scrollbar:SetScrollSize( self.MaxRows / self.RowCount )
 		else
 			self:AddScrollbar()
 		end
-	elseif self.Scrollbar then 
-		self.Scrollbar:SetParent() 
-		self.Scrollbar:Destroy() 
+	elseif self.Scrollbar then
+		self.Scrollbar:SetParent()
+		self.Scrollbar:Destroy()
 
 		self.Scrollbar = nil
 	end
@@ -356,6 +356,10 @@ function List:AddRow( ... )
 		end
 	end
 
+	if self.SortedColumn then
+		self:SortRows( self.SortedColumn, self.SortingFunc, self.Descending )
+	end
+
 	return Row
 end
 
@@ -409,17 +413,43 @@ function List:Reorder()
 	end
 end
 
+local function UpdateHeaderHighlighting( self, Column, OldSortingColumn )
+	local ColumnHeader = self.Columns[ Column ]
+	if not ColumnHeader then return end
+
+	ColumnHeader.ForceHighlight = true
+	ColumnHeader:SetHighlighted( true )
+
+	if OldSortingColumn then
+		local OldHeader = self.Columns[ OldSortingColumn ]
+		if not OldHeader then return end
+
+		OldHeader.ForceHighlight = false
+		OldHeader:SetHighlighted( false )
+	end
+end
+
 --[[
 	Sorts the rows, generally used to sort by column values.
 	Inputs: Column to sort by, optional sorting function.
 ]]
 function List:SortRows( Column, SortFunc, Desc )
+	local OldSortingColumn = self.SortedColumn
 	local Rows = self.Rows
-	if not Rows then return end
+
+	if not Rows then
+		self.SortedColumn = Column
+		self.Descending = Desc
+		self.SortingFunc = SortFunc
+
+		UpdateHeaderHighlighting( self, Column, OldSortingColumn )
+
+		return
+	end
 
 	if Desc == nil then
 		--Only flip the sort order if we're selecting the same column twice.
-		if self.SortedColumn == Column then
+		if OldSortingColumn == Column then
 			self.Descending = not self.Descending
 		else
 			self.Descending = true
@@ -451,6 +481,11 @@ function List:SortRows( Column, SortFunc, Desc )
 	end
 
 	self.SortedColumn = Column
+	self.SortingFunc = SortFunc
+
+	if OldSortingColumn ~= Column then
+		UpdateHeaderHighlighting( self, Column, OldSortingColumn )
+	end
 
 	return self:Reorder()
 end
@@ -466,7 +501,7 @@ function List:RemoveRow( Index )
 	local OldRow = Rows[ Index ]
 
 	if not OldRow then return end
-	
+
 	OldRow:SetParent() --This allows it to run its cleanup function.
 	OldRow:Destroy()
 
@@ -475,9 +510,9 @@ function List:RemoveRow( Index )
 	self.RowCount = self.RowCount - 1
 
 	if self.RowCount <= self.MaxRows then
-		if self.Scrollbar then 
-			self.Scrollbar:SetParent() 
-			self.Scrollbar:Destroy() 
+		if self.Scrollbar then
+			self.Scrollbar:SetParent()
+			self.Scrollbar:Destroy()
 
 			self.Scrollbar = nil
 		end
@@ -518,7 +553,7 @@ end
 
 function List:OnRowSelect( Index, Row )
 	if self.MultiSelect then return end
-	
+
 	if self.SelectedRow and self.SelectedRow ~= Row then
 		self.SelectedRow.Selected = false
 	end
@@ -553,7 +588,7 @@ function List:OnMouseDown( Key, DoubleClick )
 			return true, self.Scrollbar
 		end
 	end
-	
+
 	local Result, Child = self:CallOnChildren( "OnMouseDown", Key, DoubleClick )
 
 	if Result ~= nil then return true, Child end

--- a/lua/shine/lib/gui/objects/listheader.lua
+++ b/lua/shine/lib/gui/objects/listheader.lua
@@ -72,7 +72,7 @@ function ListHeader:SetTextScale( Scale )
 	self.TextScale = Scale
 
 	if not self.TextObj then return end
-	
+
 	self.TextObj:SetScale( Scale )
 end
 
@@ -80,7 +80,7 @@ function ListHeader:SetFont( Font )
 	self.Font = Font
 
 	if not self.TextObj then return end
-	
+
 	self.TextObj:SetFontName( Font )
 end
 
@@ -88,7 +88,7 @@ function ListHeader:SetTextColour( Col )
 	self.TextColour = Col
 
 	if not self.TextObj then return end
-	
+
 	self.TextObj:SetColor( Col )
 end
 
@@ -104,14 +104,14 @@ end
 
 function ListHeader:GetIsVisible()
 	if not self.Parent:GetIsVisible() then return false end
-	
+
 	return self.Background:GetIsVisible()
 end
 
 function ListHeader:OnMouseDown( Key, DoubleClick )
 	if not self:GetIsVisible() then return end
 	if Key ~= InputKey.MouseButton0 then return end
-	if not self.Highlighted then return end
+	if not self:MouseIn( self.Background, self.HighlightMult ) then return end
 
 	return true, self
 end
@@ -119,7 +119,7 @@ end
 function ListHeader:OnMouseUp( Key )
 	if not self:GetIsVisible() then return end
 	if Key ~= InputKey.MouseButton0 then return end
-	if not self.Highlighted then return end
+	if not self:MouseIn( self.Background, self.HighlightMult ) then return end
 
 	self.Parent:SortRows( self.Index )
 	Shared.PlaySound( nil, SGUI.Controls.Button.Sound )
@@ -129,7 +129,7 @@ end
 
 function ListHeader:Think( DeltaTime )
 	if not self:GetIsVisible() then return end
-	
+
 	self.BaseClass.Think( self, DeltaTime )
 end
 

--- a/lua/shine/lib/gui/objects/panel.lua
+++ b/lua/shine/lib/gui/objects/panel.lua
@@ -54,7 +54,7 @@ function Panel:SkinColour()
 	self.UseScheme = true
 end
 
-function Panel:AddTitleBar( Title, Font )
+function Panel:AddTitleBar( Title, Font, TextScale )
 	local TitlePanel = SGUI:Create( "Panel", self )
 	TitlePanel:SetSize( Vector( self:GetSize().x, self.TitleBarHeight, 0 ) )
 	if self.UseScheme then
@@ -76,6 +76,9 @@ function Panel:AddTitleBar( Title, Font )
 		local Skin = SGUI:GetSkin()
 
 		TitleLabel:SetColour( Skin.BrightText )
+	end
+	if TextScale then
+		TitleLabel:SetTextScale( TextScale )
 	end
 
 	self.TitleLabel = TitleLabel

--- a/lua/shine/lib/gui/objects/panel.lua
+++ b/lua/shine/lib/gui/objects/panel.lua
@@ -28,7 +28,7 @@ end
 
 function Panel:OnSchemeChange( Skin )
 	if not self.UseScheme then return end
-	
+
 	self.Background:SetColor( Skin.WindowBackground )
 
 	if SGUI.IsValid( self.TitleBar ) then
@@ -116,7 +116,7 @@ function Panel:SetScrollable()
 	Stencil:SetInheritsParentStencilSettings( false )
 	Stencil:SetClearsStencilBuffer( true )
 
-	Stencil:SetSize( self.Background:GetSize() ) 
+	Stencil:SetSize( self.Background:GetSize() )
 
 	self.Background:AddChild( Stencil )
 
@@ -124,7 +124,7 @@ function Panel:SetScrollable()
 
 	local ScrollParent = Manager:CreateGraphicItem()
 	ScrollParent:SetAnchor( GUIItem.Left, GUIItem.Top )
-	ScrollParent:SetColor( ZeroColour ) 
+	ScrollParent:SetColor( ZeroColour )
 
 	self.Background:AddChild( ScrollParent )
 
@@ -154,7 +154,7 @@ function Panel:Add( Class, Created )
 	local OldSetPos = Element.SetPos
 	function Element:SetPos( Pos )
 		OldSetPos( self, Pos )
-		
+
 		if not Pan.ScrollParent then return end
 
 		local OurSize = self:GetSize()
@@ -190,7 +190,7 @@ function Panel:Add( Class, Created )
 
 		local Pos = self:GetPos()
 		local PanSize = Pan:GetSize()
-		
+
 		local AnchorX, AnchorY = self:GetAnchor()
 
 		if AnchorY == GUIItem.Top then
@@ -221,7 +221,7 @@ function Panel:SetSize( Vec )
 	self.BaseClass.SetSize( self, Vec )
 
 	if not self.Stencil then return end
-	
+
 	self.Stencil:SetSize( Vec )
 
 	if SGUI.IsValid( self.Scrollbar ) then
@@ -396,9 +396,9 @@ local Clock = os and os.clock or Shared.GetTime
 
 function Panel:DragClick( Key, DoubleClick )
 	if not self.Draggable then return end
-	
+
 	if Key ~= InputKey.MouseButton0 then return end
-	if not self:MouseIn( self.Background, nil, nil, 20 ) then return end
+	if not self:MouseIn( self.Background, nil, nil, self:GetSize().y * 0.05 ) then return end
 
 	if Clock() - LastInput < 0.2 then
 		DoubleClick = true
@@ -415,7 +415,7 @@ function Panel:DragClick( Key, DoubleClick )
 	GetCursorPos = GetCursorPos or Client.GetCursorPosScreen
 
 	local X, Y = GetCursorPos()
-	
+
 	self.Dragging = true
 
 	self.DragStartX = X
@@ -431,13 +431,17 @@ function Panel:DragRelease( Key )
 	if not self.Draggable then return end
 	if Key ~= InputKey.MouseButton0 then return end
 	self.Dragging = false
+
+	if self.OnDragFinished then
+		self:OnDragFinished( self:GetPos() )
+	end
 end
 
 function Panel:DragMove( Down )
 	if not self.Draggable then return end
 	if not Down then return end
 	if not self.Dragging then return end
-	
+
 	local X, Y = GetCursorPos()
 
 	local XDiff = X - self.DragStartX
@@ -460,13 +464,13 @@ function Panel:OnMouseDown( Key, DoubleClick )
 			return true, self.Scrollbar
 		end
 	end
-	
+
 	local Result, Child = self:CallOnChildren( "OnMouseDown", Key, DoubleClick )
 
 	if Result ~= nil then return true, Child end
 
 	if self:DragClick( Key, DoubleClick ) then return true, self end
-	
+
 	if self.IsAWindow or self.BlockOnMouseDown then
 		if self:MouseIn( self.Background ) then return true, self end
 	end
@@ -511,7 +515,7 @@ function Panel:OnMouseWheel( Down )
 
 	if not SGUI.IsValid( self.Scrollbar ) then
 		if self.IsAWindow then return true end
-		
+
 		return
 	end
 

--- a/lua/shine/lib/gui/objects/scrollbar.lua
+++ b/lua/shine/lib/gui/objects/scrollbar.lua
@@ -117,7 +117,7 @@ function Scrollbar:OnMouseDown( Key, DoubleClick )
 	GetCursorPos = GetCursorPos or Client.GetCursorPosScreen
 
 	local X, Y = GetCursorPos()
-	
+
 	self.Scrolling = true
 
 	self.StartingPos = self.Pos
@@ -128,11 +128,15 @@ function Scrollbar:OnMouseDown( Key, DoubleClick )
 	return true, self
 end
 
+SGUI.AddProperty( Scrollbar, "MouseWheelScroll" )
+
 function Scrollbar:OnMouseWheel( Down )
 	local Parent = self.Parent
 
 	if self:MouseIn( self.Background ) or Parent:MouseIn( Parent.Background ) then
-		self:SetScroll( self.Pos + ( Down and -32 or 32 ) * self.ScrollSize, true )
+		local ScrollMagnitude = self.MouseWheelScroll or 32
+
+		self:SetScroll( self.Pos + ( Down and -ScrollMagnitude or ScrollMagnitude ) * self.ScrollSize, true )
 
 		return true
 	end
@@ -140,7 +144,7 @@ end
 
 function Scrollbar:OnMouseUp( Key )
 	if Key ~= InputKey.MouseButton0 then return end
-	
+
 	self.Scrolling = false
 
 	self.Bar:SetColor( self.InactiveCol )
@@ -151,7 +155,7 @@ end
 function Scrollbar:OnMouseMove( Down )
 	if not Down then return end
 	if not self.Scrolling then return end
-	
+
 	local X, Y = GetCursorPos()
 
 	local Diff = Y - self.StartingY

--- a/lua/shine/lib/gui/objects/tooltip.lua
+++ b/lua/shine/lib/gui/objects/tooltip.lua
@@ -41,7 +41,7 @@ function Tooltip:SetSize( Vec )
 		TextureCoords[ 3 ], TextureCoords[ 4 ] )
 end
 
-function Tooltip:SetText( Text )
+function Tooltip:SetText( Text, Font, Scale )
 	if self.Text then
 		self.Text:SetText( Text )
 
@@ -55,11 +55,17 @@ function Tooltip:SetText( Text )
 	TextObj:SetAnchor( GUIItem.Middle, GUIItem.Top )
 	TextObj:SetTextAlignmentX( GUIItem.Align_Center )
 	TextObj:SetText( Text )
-	TextObj:SetFontName( Fonts.kAgencyFB_Small )
+	TextObj:SetFontName( Font or Fonts.kAgencyFB_Small )
 	TextObj:SetPosition( Padding )
+	if Scale then
+		TextObj:SetScale( Scale )
+	end
 
-	local Width = TextObj:GetTextWidth( Text ) + 32
-	local Height = TextObj:GetTextHeight( Text ) + 16
+	local WidthScale = Scale and Scale.x or 1
+	local HeightScale = Scale and Scale.y or 1
+
+	local Width = TextObj:GetTextWidth( Text ) * WidthScale + 32
+	local Height = TextObj:GetTextHeight( Text ) * HeightScale + 16
 
 	self:SetSize( Vector( Width, Height, 0 ) )
 
@@ -75,7 +81,7 @@ function Tooltip:SetText( Text )
 	end
 
 	self.Text = TextObj
-	
+
 	self.Background:AddChild( TextObj )
 end
 


### PR DESCRIPTION
## General
- Fixed map vote messages showing "blah revoted for blah map" when they're choosing the same map twice or more. It now shows an error message to the player instead, telling them they've already voted for it.

## Admin menu fixes
- Fixed popup menus in the commands tab of the admin menu requiring two clicks to re-open if you clicked elsewhere in the menu to close them.
- Lists now highlight the header that they are sorting by.
- List scrolling with the mouse wheel now scrolls faster.
- Lists in the admin menu (with the exception of the commands tab's player list) now remember which rows were selected when switching away and back.

#### Plugins tab
- Fixed the unload plugin button in the plugins tab of the admin menu being usable on already unloaded plugins.
- The plugins tab no longer populates if you do not have permission to load or unload plugins.

## Scaling fixes
- The chatbox, MOTD window and vote menu now all scale correctly at resolutions greater than 1920x1080.
- Screen text now also scales correctly at resolutions greater than 1920x1080.
- Tooltips also now scale their font depending on resolution. Not only for larger than 1920x1080, but also for lower resolutions which should use a smaller font.