### PR TITLE
Screen text refactor, bug fixes to tournament mode and plugin inheritance

### DIFF
--- a/lua/shine/core/client/votemenu.lua
+++ b/lua/shine/core/client/votemenu.lua
@@ -15,7 +15,7 @@ Shine.ActivePlugins = ActivePlugins
 
 local WaitingForData = false
 
-Client.HookNetworkMessage( "Shine_PluginData", function( Message ) 
+Client.HookNetworkMessage( "Shine_PluginData", function( Message )
 	if #ActivePlugins > 0 then
 		for i = 1, #ActivePlugins do
 			ActivePlugins[ i ] = nil
@@ -43,11 +43,11 @@ end )
 function Shine.CheckVoteMenuBind()
 	local CustomBinds = io.open( "config://ConsoleBindings.json", "r" )
 
-	if not CustomBinds then 
+	if not CustomBinds then
 		Shine.VoteButtonBound = nil
 		Shine.VoteButton = nil
 
-		return 
+		return
 	end
 
 	local BindsFile = CustomBinds:read( "*all" )
@@ -89,26 +89,29 @@ function Shine.OpenVoteMenu()
 	Shine.Hook.Call( "OnVoteMenuOpen" )
 end
 
-local NextPress = 0
-Event.Hook( "Console_sh_votemenu", function()
-	if #ActivePlugins == 0 then --Request addon list if our table is empty.
-		if not WaitingForData then
-			Shine.SendNetworkMessage( "Shine_RequestPluginData", {}, true )
+do
+	local NextPress = 0
 
-			WaitingForData = true
+	Shine:RegisterClientCommand( "sh_votemenu", function()
+		if #ActivePlugins == 0 then --Request addon list if our table is empty.
+			if not WaitingForData then
+				Shine.SendNetworkMessage( "Shine_RequestPluginData", {}, true )
+
+				WaitingForData = true
+			end
+
+			return
 		end
 
-		return 
-	end
+		local Time = Clock()
 
-	local Time = Clock()
+		if Time >= NextPress or not Shine.VoteMenu.Visible then
+			Shine.OpenVoteMenu()
+		end
 
-	if Time >= NextPress or not Shine.VoteMenu.Visible then
-		Shine.OpenVoteMenu()
-	end
-
-	NextPress = Time + 0.3
-end )
+		NextPress = Time + 0.3
+	end )
+end
 
 local function CanBind( MenuBinds, Binds, Button )
 	for i = 1, #MenuBinds do --Main menu binds.

--- a/lua/shine/core/shared/base_plugin.lua
+++ b/lua/shine/core/shared/base_plugin.lua
@@ -456,8 +456,13 @@ function PluginMeta:CanRunAction( Action, Time, Delay )
 	return true
 end
 
+local ReservedKeys = {
+	Enabled = true,
+	Suspended = true
+}
 --Support plugins inheriting from other plugins.
 function PluginMeta:__index( Key )
+	if ReservedKeys[ Key ] then return nil end
 	if PluginMeta[ Key ] then return PluginMeta[ Key ] end
 
 	local Inherit = rawget( self, "__Inherit" )

--- a/lua/shine/extensions/adverts.lua
+++ b/lua/shine/extensions/adverts.lua
@@ -14,7 +14,7 @@ Plugin.HasConfig = true
 Plugin.ConfigName = "Adverts.json"
 
 Plugin.DefaultConfig = {
-	Adverts = { 
+	Adverts = {
 		{
 			Message = "Welcome to Natural Selection 2.",
 			Type = "chat",
@@ -84,8 +84,14 @@ function Plugin:ParseAdvert( ID, Advert )
 				X, Y = 0.5, 0.8
 			end
 
-			Shine:SendText( nil, Shine.BuildScreenMessage( 20, X, Y, Message,
-				7, R, G, B, Align, 2, 1 ) )
+			Shine.ScreenText.Add( 20, {
+				X = X, Y = Y,
+				Text = Message,
+				Duration = 7,
+				R = R, G = G, B = B,
+				Alignment = Align,
+				Size = 2, FadeIn = 1
+			} )
 		end
 	end
 end

--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -1059,8 +1059,15 @@ function Plugin:CreateCommands()
 			Colour = Colours.white
 		end
 
-		Shine:SendText( nil, Shine.BuildScreenMessage( 3, 0.5, 0.25, Message, 6,
-			Colour[ 1 ], Colour[ 2 ], Colour[ 3 ], 1, 2, 1 ) )
+		Shine.ScreenText.Add( 3, {
+			X = 0.5, Y = 0.25,
+			Text = Message,
+			Duration = 6,
+			R = Colour[ 1 ], G = Colour[ 2 ], B = Colour[ 3 ],
+			Alignment = 1,
+			Size = 2,
+			FadeIn = 1
+		} )
 		Shine:AdminPrint( nil, "CSay from %s[%s]: %s", true, PlayerName, ID, Message )
 	end
 	local CSayCommand = self:BindCommand( "sh_csay", "csay", CSay )

--- a/lua/shine/extensions/basecommands/shared.lua
+++ b/lua/shine/extensions/basecommands/shared.lua
@@ -428,8 +428,7 @@ function Plugin:UpdateAllTalk( State )
 	if not self.TextObj then
 		local GB = State > NOT_STARTED and 0 or 255
 
-		--A bit of a hack, but the whole screen text stuff is in dire need of a replacement...
-		self.TextObj = Shine.ScreenText.Add( -1, {
+		self.TextObj = Shine.ScreenText.Add( "AllTalkState", {
 			X = 0.5, Y = 0.95,
 			Text = StringFormat( "All talk is %s", Enabled ),
 			R = 255, G = GB, B = GB,

--- a/lua/shine/extensions/basecommands/shared.lua
+++ b/lua/shine/extensions/basecommands/shared.lua
@@ -400,7 +400,6 @@ end
 
 function Plugin:ReceivePluginData( Data )
 	self.PluginData = self.PluginData or {}
-
 	self.PluginData[ Data.Name ] = Data.Enabled
 
 	local Row = self.PluginRows[ Data.Name ]
@@ -430,8 +429,15 @@ function Plugin:UpdateAllTalk( State )
 		local GB = State > NOT_STARTED and 0 or 255
 
 		--A bit of a hack, but the whole screen text stuff is in dire need of a replacement...
-		self.TextObj = Shine:AddMessageToQueue( -1, 0.5, 0.95,
-			StringFormat( "All talk is %s", Enabled ), -2, 255, GB, GB, 1, 2, 1, true )
+		self.TextObj = Shine.ScreenText.Add( -1, {
+			X = 0.5, Y = 0.95,
+			Text = StringFormat( "All talk is %s", Enabled ),
+			R = 255, G = GB, B = GB,
+			Alignment = 1,
+			Size = 2,
+			FadeIn = 1,
+			IgnoreFormat = true
+		} )
 
 		return
 	end
@@ -440,16 +446,13 @@ function Plugin:UpdateAllTalk( State )
 
 	local Col = State > NOT_STARTED and Color( 255, 0, 0 ) or Color( 255, 255, 255 )
 
-	self.TextObj.Colour = Col
-	self.TextObj.Obj:SetColor( Col )
+	self.TextObj:SetColour( Col )
 end
 
 function Plugin:RemoveAllTalkText()
 	if not self.TextObj then return end
 
-	self.TextObj.LastUpdate = Shared.GetTime() - 1
-	self.TextObj.Duration = 1
-
+	self.TextObj:End()
 	self.TextObj = nil
 end
 

--- a/lua/shine/extensions/mapvote/server.lua
+++ b/lua/shine/extensions/mapvote/server.lua
@@ -788,13 +788,11 @@ function Plugin:AddVote( Client, Map, Revote )
 	return true, Choice
 end
 
-local BlankTable = {}
-
 --[[
 	Tells the given player or everyone that the vote is over.
 ]]
 function Plugin:EndVote( Player )
-	self:SendNetworkMessage( Player, "EndVote", BlankTable, true )
+	self:SendNetworkMessage( Player, "EndVote", {}, true )
 end
 
 function Plugin:ExtendMap( Time, NextMap )
@@ -1570,6 +1568,4 @@ function Plugin:Cleanup()
 	end
 
 	self.BaseClass.Cleanup( self )
-
-	self.Enabled = false
 end

--- a/lua/shine/extensions/mapvote/shared.lua
+++ b/lua/shine/extensions/mapvote/shared.lua
@@ -152,7 +152,7 @@ function Plugin:ReceiveEndVote( Data )
 
 	TableEmpty( self.MapVoteCounts )
 	TableEmpty( self.MapButtons )
-	Shine:EndMessage( 1 )
+	Shine.ScreenText.End( 1 )
 end
 
 local ButtonBoundMessage =
@@ -209,8 +209,16 @@ function Plugin:ReceiveVoteOptions( Message )
 	end
 
 	if NextMap and ShowTimeLeft then
-		local ScreenText = Shine:AddMessageToQueue( 1, 0.95, 0.2,
-			VoteMessage, Duration, 255, 0, 0, 2, nil, nil, true )
+		local ScreenText = Shine.ScreenText.Add( 1, {
+			X = 0.95, Y = 0.2,
+			Text = VoteMessage,
+			Duration = Duration,
+			R = 255, G = 0, B = 0,
+			Alignment = 2,
+			Size = 1,
+			FadeIn = 0.5,
+			IgnoreFormat = true
+		} )
 
 		ScreenText.TimeLeft = TimeLeft
 
@@ -255,8 +263,15 @@ function Plugin:ReceiveVoteOptions( Message )
 			end
 		end
 	else
-		local ScreenText = Shine:AddMessageToQueue( 1, 0.95, 0.2,
-			VoteMessage, Duration, 255, 0, 0, 2 )
+		local ScreenText = Shine.ScreenText.Add( 1, {
+			X = 0.95, Y = 0.2,
+			Text = VoteMessage,
+			Duration = Duration,
+			R = 255, G = 0, B = 0,
+			Alignment = 2,
+			Size = 1,
+			FadeIn = 0.5
+		} )
 
 		ScreenText.Obj:SetText( StringFormat( ScreenText.Text,
 			string.TimeToString( ScreenText.Duration ) ) )

--- a/lua/shine/extensions/mapvote/shared.lua
+++ b/lua/shine/extensions/mapvote/shared.lua
@@ -48,12 +48,6 @@ Plugin.MapButtons = {}
 Plugin.MapVoteCounts = {}
 Plugin.EndTime = 0
 
-function Plugin:Initialise()
-	self.Enabled = true
-
-	return true
-end
-
 function Plugin:OnVoteMenuOpen()
 	local Time = SharedTime()
 
@@ -152,7 +146,7 @@ function Plugin:ReceiveEndVote( Data )
 
 	TableEmpty( self.MapVoteCounts )
 	TableEmpty( self.MapButtons )
-	Shine.ScreenText.End( 1 )
+	Shine.ScreenText.End( "MapVote" )
 end
 
 local ButtonBoundMessage =
@@ -209,7 +203,7 @@ function Plugin:ReceiveVoteOptions( Message )
 	end
 
 	if NextMap and ShowTimeLeft then
-		local ScreenText = Shine.ScreenText.Add( 1, {
+		local ScreenText = Shine.ScreenText.Add( "MapVote", {
 			X = 0.95, Y = 0.2,
 			Text = VoteMessage,
 			Duration = Duration,
@@ -263,7 +257,7 @@ function Plugin:ReceiveVoteOptions( Message )
 			end
 		end
 	else
-		local ScreenText = Shine.ScreenText.Add( 1, {
+		local ScreenText = Shine.ScreenText.Add( "MapVote", {
 			X = 0.95, Y = 0.2,
 			Text = VoteMessage,
 			Duration = Duration,

--- a/lua/shine/extensions/pregame/server.lua
+++ b/lua/shine/extensions/pregame/server.lua
@@ -95,8 +95,15 @@ function Plugin:ClientConfirmConnect( Client )
 
 	if TimeLeft <= 0 or TimeLeft > 5 then return end
 
-	Shine:SendText( Client, Shine.BuildScreenMessage( 2, 0.5, 0.7, "Game starts in %s",
-		TimeLeft, 255, 0, 0, 1, 3, 0 ) )
+	Shine.ScreenText.Add( 2, {
+		X = 0.5, Y = 0.7,
+		Text = "Game starts in %s",
+		Duration = TimeLeft,
+		R = 255, G = 0, B = 0,
+		Alignment = 1,
+		Size = 3,
+		FadeIn = 0
+	}, Client )
 end
 
 function Plugin:CheckPlayerCanAttack()
@@ -143,20 +150,33 @@ function Plugin:AbortGameStart( Gamerules, Message, Format, ... )
 
 	self:Notify( nil, Message, Format, ... )
 
-	Shine:RemoveText( nil, { ID = 2 } )
+	Shine.ScreenText.End( 2 )
 end
 
 function Plugin:ShowGameStart( TimeTillStart, Red )
 	if self.Config.ShowCountdown then
-		Shine:SendText( nil, Shine.BuildScreenMessage( 2, 0.5, 0.7,
-			"Game starts in "..string.TimeToString( TimeTillStart ), 5,
-			255, 255, 255, 1, 3, 1 ) )
+		Shine.ScreenText.Add( 2, {
+			X = 0.5, Y = 0.7,
+			Text = "Game starts in "..string.TimeToString( TimeTillStart ),
+			Duration = 5,
+			R = 255, G = 255, B = 255,
+			Alignment = 1,
+			Size = 3,
+			FadeIn = 1
+		} )
 	end
 end
 
 function Plugin:ShowCountdown()
-	Shine:SendText( nil, Shine.BuildScreenMessage( 2, 0.5, 0.7,
-		"Game starts in %s", 5, 255, 0, 0, 1, 3, 0 ) )
+	Shine.ScreenText.Add( 2, {
+		X = 0.5, Y = 0.7,
+		Text = "Game starts in %s",
+		Duration = 5,
+		R = 255, G = 0, B = 0,
+		Alignment = 1,
+		Size = 3,
+		FadeIn = 0
+	} )
 end
 
 function Plugin:SendStartNag( Message )
@@ -217,8 +237,15 @@ Plugin.UpdateFuncs = {
 
 		if TimeLeft == 5 then
 			if self.Config.ShowCountdown and not self.SentCountdown then
-				Shine:SendText( nil, Shine.BuildScreenMessage( 2, 0.5, 0.7,
-					"Game starts in %s", TimeLeft, 255, 0, 0, 1, 3, 0 ) )
+				Shine.ScreenText.Add( 2, {
+					X = 0.5, Y = 0.7,
+					Text = "Game starts in %s",
+					Duration = TimeLeft,
+					R = 255, G = 0, B = 0,
+					Alignment = 1,
+					Size = 3,
+					FadeIn = 0
+				} )
 				self.SentCountdown = true
 			end
 		end
@@ -375,8 +402,15 @@ Plugin.UpdateFuncs = {
 						Team1Com and Team2Name or Team1Name,
 						string.TimeToString( Duration ) )
 
-					Shine:SendText( nil, Shine.BuildScreenMessage( 2, 0.5, 0.7,
-						Message, 5, 255, 255, 255, 1, 3, 1 ) )
+					Shine.ScreenText.Add( 2, {
+						X = 0.5, Y = 0.7,
+						Text = Message,
+						Duration = 5,
+						R = 255, G = 255, B = 255,
+						Alignment = 1,
+						Size = 3,
+						FadeIn = 1
+					} )
 				end
 			end
 		else

--- a/lua/shine/extensions/pregame/shared.lua
+++ b/lua/shine/extensions/pregame/shared.lua
@@ -29,12 +29,12 @@ local SharedTime = Shared.GetTime
 
 function Plugin:RemoveText()
 	if self.TextObj then
-		Shine:RemoveMessage( self.TextObj.Index )
+		self.TextObj:Remove()
 		self.TextObj = nil
 	end
 
 	if self.TimeObj then
-		Shine:RemoveMessage( self.TimeObj.Index )
+		self.TimeObj:Remove()
 		self.TimeObj = nil
 	end
 end
@@ -45,14 +45,26 @@ function Plugin:ReceiveStartDelay( Data )
 
 	if Time < StartTime then
 		local Duration = Round( StartTime - Time )
-		local TextObj = Shine:AddMessageToQueue( "PreGameStartDelay1", 0.5, 0.1,
-			"Game start waiting for players to load.", Duration, 255, 255, 255,
-			1, 1, 1, true )
-		local TimeObj = Shine:AddMessageToQueue( "PreGameStartDelay2", 0.5, 0.126,
-			"%s", Duration, 255, 255, 255, 1, 1, 1 )
 
-		self.TextObj = TextObj
-		self.TimeObj = TimeObj
+		self.TextObj = Shine.ScreenText.Add( "PreGameStartDelay1", {
+			X = 0.5, Y = 0.1,
+			Text = "Game start waiting for players to load.",
+			Duration = Duration,
+			R = 255, G = 255, B = 255,
+			Alignment = 1,
+			Size = 1,
+			FadeIn = 1,
+			IgnoreFormat = true
+		} )
+		self.TimeObj = Shine.ScreenText.Add( "PreGameStartDelay2", {
+			X = 0.5, Y = 0.126,
+			Text = "%s",
+			Duration = Duration,
+			R = 255, G = 255, B = 255,
+			Alignment = 1,
+			Size = 1,
+			FadeIn = 1
+		} )
 
 		self.TimeObj.Digital = true
 		self.TimeObj.Obj:SetText( DigitalTime( Duration ) )

--- a/lua/shine/extensions/tournamentmode/server.lua
+++ b/lua/shine/extensions/tournamentmode/server.lua
@@ -313,13 +313,27 @@ function Plugin:CheckStart()
 
 		local GameStartTime = string.TimeToString( CountdownTime )
 
-		Shine:SendText( nil, Shine.BuildScreenMessage( 2, 0.5, 0.7,
-			"Game starts in "..GameStartTime, 5, 255, 255, 255, 1, 3, 1 ) )
+		Shine.ScreenText.Add( 2, {
+			X = 0.5, Y = 0.7,
+			Text = "Game starts in "..GameStartTime,
+			Duration = 5,
+			R = 255, G = 255, B = 255,
+			Alignment = 1,
+			Size = 3,
+			FadeIn = 1
+		} )
 
 		--Game starts in 5 seconds!
 		self:CreateTimer( self.FiveSecondTimer, CountdownTime - 5, 1, function()
-			Shine:SendText( nil, Shine.BuildScreenMessage( 2, 0.5, 0.7,
-				"Game starts in %s", 5, 255, 0, 0, 1, 3, 0 ) )
+			Shine.ScreenText.Add( 2, {
+				X = 0.5, Y = 0.7,
+				Text = "Game starts in %s",
+				Duration = 5,
+				R = 255, G = 0, B = 0,
+				Alignment = 1,
+				Size = 3,
+				FadeIn = 1
+			} )
 		end )
 
 		--If we get this far, then we can start.
@@ -336,7 +350,7 @@ function Plugin:CheckStart()
 		self:DestroyTimer( self.CountdownTimer )
 
 		--Remove the countdown text.
-		Shine:RemoveText( nil, { ID = 2 } )
+		Shine.ScreenText.End( 2 )
 
 		self:Notify( false, nil, "Game start aborted." )
 	end

--- a/lua/shine/extensions/tournamentmode/server.lua
+++ b/lua/shine/extensions/tournamentmode/server.lua
@@ -502,8 +502,7 @@ function Plugin:CreateCommands()
 			self.NextReady[ Team ] = Time + 5
 			self:ReadyTeam( Team )
 		else
-			Shine:NotifyCommandError( Client,
-				"Your team is already ready! Use !unready to unready your team." )
+			Unready( Client )
 		end
 	end
 	local ReadyCommand = self:BindCommand( "sh_ready", { "rdy", "ready" }, ReadyUp, true )

--- a/lua/shine/extensions/tournamentmode/server.lua
+++ b/lua/shine/extensions/tournamentmode/server.lua
@@ -35,6 +35,22 @@ Plugin.Conflicts = {
 Plugin.CountdownTimer = "Countdown"
 Plugin.FiveSecondTimer = "5SecondCount"
 
+function Plugin:StoreConfigSettings()
+	self.OriginalServerConfig = {
+		AutoBalance = Server.GetConfigSetting( "auto_team_balance" ),
+		EndOnTeamUnbalance = Server.GetConfigSetting( "end_round_on_team_unbalance" ),
+		ForceEvenTeamsOnJoin = Server.GetConfigSetting( "force_even_teams_on_join" )
+	}
+end
+
+function Plugin:RestoreConfigSettings()
+	if not self.OriginalServerConfig then return end
+
+	Server.SetConfigSetting( "auto_team_balance", self.OriginalServerConfig.AutoBalance )
+	Server.SetConfigSetting( "end_round_on_team_unbalance", self.OriginalServerConfig.EndOnTeamUnbalance )
+	Server.SetConfigSetting( "force_even_teams_on_join", self.OriginalServerConfig.ForceEvenTeamsOnJoin )
+end
+
 function Plugin:Initialise()
 	local Gamemode = Shine.GetGamemode()
 
@@ -61,6 +77,8 @@ function Plugin:Initialise()
 
 	--We've been reactivated, we can disable autobalance here and now.
 	if self.Enabled ~= nil then
+		self:StoreConfigSettings()
+
 		Server.SetConfigSetting( "auto_team_balance", false )
 		Server.SetConfigSetting( "end_round_on_team_unbalance", false )
 		Server.SetConfigSetting( "force_even_teams_on_join", false )
@@ -201,7 +219,7 @@ end
 ]]
 function Plugin:ClientConfirmConnect( Client )
 	if not self.DisabledAutobalance then
-		self.OldTeamBalanceSetting = Server.GetConfigSetting( "auto_team_balance" )
+		self:StoreConfigSettings()
 
 		Server.SetConfigSetting( "auto_team_balance", false )
 		Server.SetConfigSetting( "end_round_on_team_unbalance", false )
@@ -332,118 +350,55 @@ function Plugin:GetOppositeTeam( Team )
 	return Team == 1 and 2 or 1
 end
 
+function Plugin:ReadyTeam( Team )
+	self.ReadyStates[ Team ] = true
+
+	local TeamName = self:GetTeamName( Team )
+
+	local OtherTeam = self:GetOppositeTeam( Team )
+	local OtherReady = self:GetReadyState( OtherTeam )
+
+	if OtherReady then
+		self:Notify( true, nil, "%s is now ready.", true, TeamName )
+	else
+		self:Notify( true, nil, "%s is now ready. Waiting on %s to start.",
+			true, TeamName, self:GetTeamName( OtherTeam ) )
+	end
+
+	self:CheckStart()
+end
+
+function Plugin:UnReadyTeam( Team, Notify )
+	if self.ReadyStates[ Team ] then
+		self.ReadyStates[ Team ] = false
+	end
+
+	if Notify then
+		local TeamName = self:GetTeamName( Team )
+		self:Notify( false, nil, "%s is no longer ready.", true, TeamName )
+	end
+
+	self:CheckStart()
+end
+
 function Plugin:CreateCommands()
-	local function ReadyUp( Client )
-		if self.GameStarted then return end
-
+	local function IsPlayingClient( Client )
 		local Player = Client:GetControllingPlayer()
-
-		if not Player then return end
+		if not Player then return false end
 
 		local Team = Player:GetTeamNumber()
+		if Team ~= 1 and Team ~= 2 then return false end
 
-		if Team ~= 1 and Team ~= 2 then return end
-
-		if not Player:isa( "Commander" ) and not self.Config.EveryoneReady then
-			Shine:NotifyCommandError( Client, "Only the commander can ready up the team." )
-
-			return
-		end
-
-		local Time = Shared.GetTime()
-
-		if self.Config.EveryoneReady then
-			if self.ReadiedPlayers[ Client ] then
-				Shine:NotifyCommandError( Client,
-					"You are already ready! Use !unready to unready yourself." )
-
-				return
-			end
-
-			local NextReady = self.NextReady[ Client ] or 0
-			if NextReady > Time then return end
-
-			self.NextReady[ Client ] = Time + 5
-
-			self.ReadiedPlayers[ Client ] = true
-
-			self:Notify( true, nil, "%s is ready.", true, Player:GetName() )
-
-			local Clients = Shine.GetTeamClients( Team )
-			local Ready = true
-
-			for i = 1, #Clients do
-				if not self.ReadiedPlayers[ Clients[ i ] ] then
-					Ready = false
-					break
-				end
-			end
-
-			if not Ready then return end
-
-			self.ReadyStates[ Team ] = true
-
-			local TeamName = self:GetTeamName( Team )
-
-			local OtherTeam = self:GetOppositeTeam( Team )
-			local OtherReady = self:GetReadyState( OtherTeam )
-
-			if OtherReady then
-				self:Notify( true, nil, "%s is now ready.", true, TeamName )
-			else
-				self:Notify( true, nil, "%s is now ready. Waiting on %s to start.",
-					true, TeamName, self:GetTeamName( OtherTeam ) )
-			end
-
-			self:CheckStart()
-
-			return
-		end
-
-		local NextReady = self.NextReady[ Team ] or 0
-
-		if not self.ReadyStates[ Team ] then
-			if NextReady > Time then return end
-
-			self.ReadyStates[ Team ] = true
-
-			local TeamName = self:GetTeamName( Team )
-
-			local OtherTeam = self:GetOppositeTeam( Team )
-			local OtherReady = self:GetReadyState( OtherTeam )
-
-			if OtherReady then
-				self:Notify( true, nil, "%s is now ready.", true, TeamName )
-			else
-				self:Notify( true, nil, "%s is now ready. Waiting on %s to start.",
-					true, TeamName, self:GetTeamName( OtherTeam ) )
-			end
-
-			--Add a delay to prevent ready->unready spam.
-			self.NextReady[ Team ] = Time + 5
-
-			self:CheckStart()
-		else
-			Shine:NotifyCommandError( Client,
-				"Your team is already ready! Use !unready to unready your team." )
-		end
+		return true, Player, Team
 	end
-	local ReadyCommand = self:BindCommand( "sh_ready", { "rdy", "ready" }, ReadyUp, true )
-	ReadyCommand:Help( "Makes your team ready to start the game." )
 
 	local function Unready( Client )
 		if self.GameStarted then return end
-
-		local Player = Client:GetControllingPlayer()
-
-		if not Player then return end
-
-		local Team = Player:GetTeamNumber()
-
-		if Team ~= 1 and Team ~= 2 then return end
+		local Valid, Player, Team = IsPlayingClient( Client )
+		if not Valid then return end
 
 		if not Player:isa( "Commander" ) and not self.Config.EveryoneReady then
-			Shine:NotifyCommandError( Client, "Only the commander can ready up the team." )
+			Shine:NotifyCommandError( Client, "Only the commander can unready the team." )
 
 			return
 		end
@@ -462,16 +417,17 @@ function Plugin:CreateCommands()
 			if NextReady > Time then return end
 
 			self.NextReady[ Client ] = Time + 5
-
 			self.ReadiedPlayers[ Client ] = false
 
-			self:Notify( false, nil, "%s is no longer ready.", true, Player:GetName() )
-
-			if self.ReadyStates[ Team ] then
-				self.ReadyStates[ Team ] = false
+			local TeamWasReady = self.ReadyStates[ Team ]
+			if TeamWasReady then
+				self:Notify( false, nil, "%s is no longer ready as %s unreadied.",
+					true, self:GetTeamName( Team ), Player:GetName() )
+			else
+				self:Notify( false, nil, "%s is no longer ready.", true, Player:GetName() )
 			end
 
-			self:CheckStart()
+			self:UnReadyTeam( Team )
 
 			return
 		end
@@ -481,16 +437,9 @@ function Plugin:CreateCommands()
 		if self.ReadyStates[ Team ] then
 			if NextReady > Time then return end
 
-			self.ReadyStates[ Team ] = false
-
-			local TeamName = self:GetTeamName( Team )
-
-			self:Notify( false, nil, "%s is no longer ready.", true, TeamName )
-
 			--Add a delay to prevent ready->unready spam.
 			self.NextReady[ Team ] = Time + 5
-
-			self:CheckStart()
+			self:UnReadyTeam( Team )
 		else
 			Shine:NotifyCommandError( Client,
 				"Your team has not readied yet! Use !ready to ready your team." )
@@ -498,6 +447,67 @@ function Plugin:CreateCommands()
 	end
 	local UnReadyCommand = self:BindCommand( "sh_unready", { "unrdy", "unready" }, Unready, true )
 	UnReadyCommand:Help( "Makes your team not ready to start the game." )
+
+	local function ReadyUp( Client )
+		if self.GameStarted then return end
+		local Valid, Player, Team = IsPlayingClient( Client )
+		if not Valid then return end
+
+		if not Player:isa( "Commander" ) and not self.Config.EveryoneReady then
+			Shine:NotifyCommandError( Client, "Only the commander can ready up the team." )
+
+			return
+		end
+
+		local Time = Shared.GetTime()
+
+		if self.Config.EveryoneReady then
+			if self.ReadiedPlayers[ Client ] then
+				Unready( Client )
+
+				return
+			end
+
+			local NextReady = self.NextReady[ Client ] or 0
+			if NextReady > Time then return end
+
+			self.NextReady[ Client ] = Time + 5
+			self.ReadiedPlayers[ Client ] = true
+
+			self:Notify( true, nil, "%s is ready.", true, Player:GetName() )
+
+			local Clients = Shine.GetTeamClients( Team )
+			local Ready = true
+
+			for i = 1, #Clients do
+				if not self.ReadiedPlayers[ Clients[ i ] ] then
+					Ready = false
+					break
+				end
+			end
+
+			if not Ready then return end
+
+			self:ReadyTeam( Team )
+
+			return
+		end
+
+		local NextReady = self.NextReady[ Team ] or 0
+
+		if not self.ReadyStates[ Team ] then
+			if NextReady > Time then return end
+
+			--Add a delay to prevent ready->unready spam.
+			self.NextReady[ Team ] = Time + 5
+			self:ReadyTeam( Team )
+		else
+			Shine:NotifyCommandError( Client,
+				"Your team is already ready! Use !unready to unready your team." )
+		end
+	end
+	local ReadyCommand = self:BindCommand( "sh_ready", { "rdy", "ready" }, ReadyUp, true )
+	ReadyCommand:Help( "Makes your team ready to start the game." )
 
 	local function SetTeamNames( Client, Marine, Alien )
 		self.TeamNames[ 1 ] = Marine
@@ -533,11 +543,10 @@ function Plugin:Cleanup()
 	self.ReadyStates = nil
 	self.TeamNames = nil
 
-	if Server.SetConfigSetting then
-		Server.SetConfigSetting( "auto_team_balance", self.OldTeamBalanceSetting or {} )
-		Server.SetConfigSetting( "end_round_on_team_unbalance", true )
-		Server.SetConfigSetting( "force_even_teams_on_join", true )
-	end
+	self:RestoreConfigSettings()
+end
 
-	self.Enabled = false
+--Restore config settings on map change, in case this plugin is disabled on the next map.
+function Plugin:MapChange()
+	self:RestoreConfigSettings()
 end

--- a/lua/shine/extensions/tournamentmode/server.lua
+++ b/lua/shine/extensions/tournamentmode/server.lua
@@ -332,7 +332,7 @@ function Plugin:CheckStart()
 				R = 255, G = 0, B = 0,
 				Alignment = 1,
 				Size = 3,
-				FadeIn = 1
+				FadeIn = 0
 			} )
 		end )
 

--- a/lua/shine/lib/screentext/sh_screentext.lua
+++ b/lua/shine/lib/screentext/sh_screentext.lua
@@ -2,47 +2,39 @@
 	Screen text rendering shared file.
 ]]
 
-local NWMessage = {
-	r = "integer (0 to 255)",
-	g = "integer (0 to 255)",
-	b = "integer (0 to 255)",
-	Message = "string (255)",
-	x = "float (0 to 1 by 0.05)",
-	y = "float (0 to 1 by 0.05)",
-	Duration = "integer (0 to 1800)",
-	ID = "integer (0 to 100)",
-	Align = "integer (0 to 2)",
-	Size = "integer (1 to 3)",
-	FadeIn = "float (0 to 2 by 0.05)"
-}
+Shine.ScreenText = {}
 
-function Shine.BuildScreenMessage( ID, x, y, Message, Duration, r, g, b, Align, Size, FadeIn )
+--DEPRECATED! Please use Shine.ScreenText.Add( ID, Params[, Player] )
+function Shine.BuildScreenMessage( ID, X, Y, Text, Duration, R, G, B, Alignment, Size, FadeIn )
 	return {
 		ID = ID,
-		r = r,
-		g = g,
-		b = b,
-		x = x,
-		y = y,
-		Message = Message,
+		R = R, G = G, B = B,
+		X = X, Y = Y,
+		Text = Text,
 		Duration = Duration,
-		Align = Align,
+		Alignment = Alignment,
 		Size = Size,
 		FadeIn = FadeIn
 	}
 end
 
-Shared.RegisterNetworkMessage( "Shine_ScreenText", NWMessage )
-
-local UpdateMessage = {
+Shared.RegisterNetworkMessage( "Shine_ScreenText", {
+	R = "integer (0 to 255)",
+	G = "integer (0 to 255)",
+	B = "integer (0 to 255)",
+	Text = "string (255)",
+	X = "float (0 to 1 by 0.05)",
+	Y = "float (0 to 1 by 0.05)",
+	Duration = "integer (0 to 1800)",
 	ID = "integer (0 to 100)",
-	Message = "string (255)"
-}
-
-Shared.RegisterNetworkMessage( "Shine_ScreenTextUpdate", UpdateMessage )
-
-local RemoveMessage = {
+	Alignment = "integer (0 to 2)",
+	Size = "integer (1 to 3)",
+	FadeIn = "float (0 to 2 by 0.05)"
+} )
+Shared.RegisterNetworkMessage( "Shine_ScreenTextUpdate", {
+	ID = "integer (0 to 100)",
+	Text = "string (255)"
+} )
+Shared.RegisterNetworkMessage( "Shine_ScreenTextRemove", {
 	ID = "integer (0 to 100)"
-}
-
-Shared.RegisterNetworkMessage( "Shine_ScreenTextRemove", RemoveMessage )
+} )

--- a/lua/shine/lib/screentext/sv_screentext.lua
+++ b/lua/shine/lib/screentext/sv_screentext.lua
@@ -2,14 +2,33 @@
 	Screen text rendering server side file.
 ]]
 
+local Shine = Shine
+
+function Shine.ScreenText.Add( ID, Params, Player )
+	Params.ID = ID
+
+	Shine:ApplyNetworkMessage( Player, "Shine_ScreenText", Params, true )
+end
+
+function Shine.ScreenText.SetText( ID, Text, Player )
+	Shine:ApplyNetworkMessage( Player, "Shine_ScreenTextUpdate", { ID = ID, Text = Text }, true )
+end
+
+function Shine.ScreenText.End( ID, Player )
+	Shine:ApplyNetworkMessage( Player, "Shine_ScreenTextRemove", { ID = ID }, true )
+end
+
+--DEPRECATED! Use Shine.ScreenText.Add( ID, Params[, Player] )
 function Shine:SendText( Player, Message )
 	self:ApplyNetworkMessage( Player, "Shine_ScreenText", Message, true )
 end
 
+--DEPRECATED! Use Shine.ScreenText.SetText( ID, Text[, Player] )
 function Shine:UpdateText( Player, Message )
 	self:ApplyNetworkMessage( Player, "Shine_ScreenTextUpdate", Message, true )
 end
 
+--DEPRECATED! Use Shine.ScreenText.End( ID[, Player] )
 function Shine:RemoveText( Player, Message )
 	self:ApplyNetworkMessage( Player, "Shine_ScreenTextRemove", Message, true )
 end


### PR DESCRIPTION
## Tournament Mode
- Fixed the ServerConfig.json settings it changes not being reset at map change thus potentially leaving them altered if it is then disabled next map.
- You can now use the !ready command to toggle between ready and unready.
- The ready state of teams when everyone is required to be ready should be notified more clearly now.

## Screen Text
- Refactored everything into its own table under `Shine.ScreenText` and made server and client usage roughly identical.
- On the client, creating a new screen text element returns a usable object that can be used to remove/change the text.
- The old functions are still present but deprecated and will be removed in the near future.

## Other fixes
- Fixed plugins inheriting the state of their parent plugin.