### PR TITLE
Fix help display for commands with no help string

### DIFF
--- a/lua/shine/core/server/commands.lua
+++ b/lua/shine/core/server/commands.lua
@@ -451,7 +451,7 @@ local function GetCommandArgs( self, Client, ConCommand, FromChat, Command, Args
 	local ExpectedCount = #ExpectedArgs
 
 	if Args[ 1 ] == nil and ExpectedCount > 0 and not ExpectedArgs[ 1 ].Optional then
-		Notify( Client, FromChat, "%s - %s", true, ConCommand, Command.Help or "No help available." )
+		Notify( Client, FromChat, "%s - %s", true, ConCommand, type(Command.Help)=="function" and "No help available." or Command.Help )
 
 		return
 	end

--- a/lua/shine/core/server/commands.lua
+++ b/lua/shine/core/server/commands.lua
@@ -451,7 +451,7 @@ local function GetCommandArgs( self, Client, ConCommand, FromChat, Command, Args
 	local ExpectedCount = #ExpectedArgs
 
 	if Args[ 1 ] == nil and ExpectedCount > 0 and not ExpectedArgs[ 1 ].Optional then
-		Notify( Client, FromChat, "%s - %s", true, ConCommand, type(Command.Help)=="function" and "No help available." or Command.Help )
+		Notify( Client, FromChat, "%s - %s", true, ConCommand, type(Command.Help)~="string" and "No help available." or Command.Help )
 
 		return
 	end

--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -345,7 +345,7 @@ local function Help( Client, Search )
 					and StringFormat( " (chat: !%s)", Command.ChatCmd ) or ""
 
 				local HelpLine = StringFormat( "%s. %s%s: %s", i, CommandName,
-					ChatCommand, type(Command.Help)=="function" and "No help available." or Command.Help )
+					ChatCommand, type(Command.Help)~="string" and "No help available." or Command.Help )
 
 				PrintToConsole( Client, HelpLine )
 			end

--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -345,7 +345,7 @@ local function Help( Client, Search )
 					and StringFormat( " (chat: !%s)", Command.ChatCmd ) or ""
 
 				local HelpLine = StringFormat( "%s. %s%s: %s", i, CommandName,
-					ChatCommand, Command.Help or "No help available." )
+					ChatCommand, type(Command.Help)=="function" and "No help available." or Command.Help )
 
 				PrintToConsole( Client, HelpLine )
 			end


### PR DESCRIPTION
When you try to use a default help string with 'Command.Help or "default"' and Help hasn't been set, it'll find the Help function from the metatable instead and display the type & id like so: "sh_adminmenu (chat: !menu): function: 0x081ddbb4".

As Command.Help will never be nil and when not set will be a function, simply check if it's a function and if it is, display the default help text.