### PR TITLE
VoteSurrender: Option to disallow voting with multiple team bases

### DIFF
--- a/lua/shine/extensions/votesurrender/server.lua
+++ b/lua/shine/extensions/votesurrender/server.lua
@@ -24,6 +24,7 @@ Plugin.DefaultConfig = {
 	VoteDelay = 10, --Time after round start before surrender vote is available
 	MinPlayers = 6, --Min players needed for voting to be enabled.
 	VoteTimeout = 120, --How long after no votes before the vote should reset?
+	AllowVoteWithMulitpleBases = true, --Is a team allowed to surrender with multiple bases
 }
 
 Plugin.CheckConfig = true
@@ -93,7 +94,8 @@ function Plugin:GetVotesNeeded( Team )
 end
 
 --[[
-	Make sure we only vote when a round has started.
+	Make sure we only vote when a round has started and
+	the team data pass the config params
 ]]
 function Plugin:CanStartVote( Team )
 	local Gamerules = GetGamerules()
@@ -101,10 +103,14 @@ function Plugin:CanStartVote( Team )
 	if not Gamerules then return false end
 
 	local State = Gamerules:GetGameState()
-	local TeamCount = self:GetTeamPlayerCount( Team )
+	local PlayingTeam = Gamerules:GetTeam( Team )
+	local TeamCount = PlayingTeam:GetNumPlayers()
 
-	return State == kGameState.Started and TeamCount >= self.Config.MinPlayers
-		and self.NextVote < SharedTime()
+	local AllowWithNumBases = self.Config.AllowVoteWithMulitpleBases or
+			PlayingTeam:GetNumCapturedTechPoints() == 1
+
+	return State == kGameState.Started and AllowWithNumBases and
+			TeamCount >= self.Config.MinPlayers and self.NextVote < SharedTime()
 end
 
 function Plugin:AddVote( Client, Team )

--- a/lua/shine/extensions/votesurrender/server.lua
+++ b/lua/shine/extensions/votesurrender/server.lua
@@ -77,16 +77,6 @@ function Plugin:GetTeamPlayerCount( Team )
 	end
 end
 
-function Plugin:GetTeamPlayers( Team )
-	local Gamerules = GetGamerules()
-
-	if Team == 1 then
-		return Gamerules.team1:GetPlayers()
-	else
-		return Gamerules.team2:GetPlayers()
-	end
-end
-
 function Plugin:GetVotesNeeded( Team )
 	local TeamCount = self:GetTeamPlayerCount( Team )
 

--- a/lua/shine/extensions/votesurrender/server.lua
+++ b/lua/shine/extensions/votesurrender/server.lua
@@ -24,7 +24,7 @@ Plugin.DefaultConfig = {
 	VoteDelay = 10, --Time after round start before surrender vote is available
 	MinPlayers = 6, --Min players needed for voting to be enabled.
 	VoteTimeout = 120, --How long after no votes before the vote should reset?
-	AllowVoteWithMulitpleBases = true, --Is a team allowed to surrender with multiple bases
+	AllowVoteWithMultipleBases = true --Is a team allowed to surrender with multiple bases
 }
 
 Plugin.CheckConfig = true
@@ -96,7 +96,7 @@ function Plugin:CanStartVote( Team )
 	local PlayingTeam = Gamerules:GetTeam( Team )
 	local TeamCount = PlayingTeam:GetNumPlayers()
 
-	local AllowWithNumBases = self.Config.AllowVoteWithMulitpleBases or
+	local AllowWithNumBases = self.Config.AllowVoteWithMultipleBases or
 			PlayingTeam:GetNumCapturedTechPoints() == 1
 
 	return State == kGameState.Started and AllowWithNumBases and


### PR DESCRIPTION
Often player vote to surrender even though their team still has multiple bases (techpoints/hives/CCs). 

To stop this behavior i added a option which allow server operators to disallow to surrender with multiple bases.

Also removed GetTeamPlayers() as it is not used at all.