### PR TITLE
Fix map cycling

### DIFF
--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -704,14 +704,14 @@ Add( "Think", "ReplaceMethods", function()
 		return OldChangeMap( MapName )
 	end
 
-	function MapCycle_CycleMap()
+	function MapCycle_CycleMap( CurrentMap )
 		local Result = Call( "OnCycleMap" )
 
 		if Result ~= nil then return end
 
 		Call( "MapChange" )
 
-		return OldCycleMap()
+		return OldCycleMap( CurrentMap )
 	end
 
 	local OldTestCycle = MapCycle_TestCycleMap

--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -701,7 +701,7 @@ function Plugin:CreateAdminCommands()
 
 	local function CycleMap( Client )
 		--The map vote plugin hooks this so we don't have to worry.
-		MapCycle_CycleMap()
+		MapCycle_CycleMap( Shared.GetMapName() )
 	end
 	local CycleMapCommand = self:BindCommand( "sh_cyclemap", "cyclemap", CycleMap )
 	CycleMapCommand:Help( "Cycles the map to the next one in the map cycle." )

--- a/lua/shine/extensions/workshopupdater.lua
+++ b/lua/shine/extensions/workshopupdater.lua
@@ -127,7 +127,7 @@ end
 ]]
 function Plugin:NotifyOrCycle( Recall )
 	if Shine.GetHumanPlayerCount() == 0 then
-		self:SimpleTimer( 5, function() MapCycle_CycleMap() end )
+		self:SimpleTimer( 5, function() MapCycle_CycleMap( Shared.GetMapName() ) end )
 
 		return
 	end
@@ -164,7 +164,7 @@ function Plugin:NotifyOrCycle( Recall )
 	end
 
 	if RemainingNotifications == 0 then
-		self:SimpleTimer( 5, function() MapCycle_CycleMap() end )
+		self:SimpleTimer( 5, function() MapCycle_CycleMap( Shared.GetMapName() ) end )
 		return
 	end
 


### PR DESCRIPTION
Was adding currentMap = currentMap or Shared.GetMapName() really that
hard to do to keep backwards compatibility?