### PR TITLE
[Suggestion] [Ban] Use the CheckConnectionAllowed event to verify clients

### DIFF
--- a/lua/shine/extensions/ban/server.lua
+++ b/lua/shine/extensions/ban/server.lua
@@ -658,9 +658,7 @@ end
 	Drops a client if they're on the ban list and still banned.
 	If they're past their ban time, their ban is removed.
 ]]
-function Plugin:ClientConnect( Client )
-	local ID = Client:GetUserId()
-
+function Plugin:CheckConnectionAllowed( ID )
 	local BanEntry = self.Config.Banned[ tostring( ID ) ]
 
 	if BanEntry then
@@ -668,7 +666,7 @@ function Plugin:ClientConnect( Client )
 
 		--Either a perma-ban or not expired.
 		if not BanEntry.UnbanTime or BanEntry.UnbanTime == 0 or BanEntry.UnbanTime > Time() then
-			Server.DisconnectClient( Client )
+			return false
 		else
 			self:RemoveBan( ID )
 		end

--- a/lua/shine/extensions/commbans/shared.lua
+++ b/lua/shine/extensions/commbans/shared.lua
@@ -9,7 +9,7 @@ Plugin.NS2Only = true
 Shine:RegisterExtension( "commbans", Plugin, {
 	Base = "ban",
 	BlacklistKeys = {
-		ClientConnect = true,
+		CheckConnectionAllowed = true,
 		OnWebConfigLoaded = true,
 		BanNetworkData = true,
 		BanNetworkedClients = true,


### PR DESCRIPTION
The CheckConnectionAllowed is triggered immediately after the first "handshake" packets have been exchanged between client and server. The ClientConnect event on the other hand is called when the client is almost done with loading.

So moving the check should save server bandwidth and avoids that banned clients block the "clients connecting" queue.