### PR TITLE
Alter the shuffling algorithm's approach to standard deviation balancing

### DIFF
--- a/lua/shine/extensions/voterandom.lua
+++ b/lua/shine/extensions/voterandom.lua
@@ -338,7 +338,7 @@ local function GetAverageSkillFunc( Players, Func )
 	}
 end
 
-local DebugMode = true
+local DebugMode = false
 local function GetHiveSkill( Ply )
 	if DebugMode then
 		local Client = GetOwner( Ply )

--- a/lua/shine/extensions/voterandom.lua
+++ b/lua/shine/extensions/voterandom.lua
@@ -338,7 +338,7 @@ local function GetAverageSkillFunc( Players, Func )
 	}
 end
 
-local DebugMode = false
+local DebugMode = true
 local function GetHiveSkill( Ply )
 	if DebugMode then
 		local Client = GetOwner( Ply )
@@ -468,6 +468,7 @@ function Plugin:PerformSwap( TeamMembers, TeamSkills, SwapData, LargerTeam, Less
 			TeamMembers[ i ][ SwapData.Indices[ i ] ] = SwapPly
 		end
 		TeamSkills[ i ].Total = SwapData.Totals[ i ]
+		TeamSkills[ i ].Average = TeamSkills[ i ].Total / TeamSkills[ i ].Count
 	end
 
 	return true, LargerTeam, LesserTeam
@@ -541,7 +542,9 @@ function Plugin:OptimiseTeams( TeamMembers, RankFunc, TeamSkills )
 			local PreStdDiff = Abs( SwapResult[ 1 ].PreStdDev - SwapResult[ 2 ].PreStdDev )
 			NewStdDiff = Abs( SwapResult[ 1 ].PostStdDev - SwapResult[ 2 ].PostStdDev )
 
-			StdDevIsBetter = NewStdDiff < PreStdDiff and NewStdDiff < SwapData.BestStdDiff
+			-- Allow a slight increase in standard deviation difference if we're improving the averages.
+			StdDevIsBetter = ( NewStdDiff <= PreStdDiff and NewStdDiff <= SwapData.BestStdDiff )
+				or ( NewStdDiff - PreStdDiff ) < 40
 		end
 
 		if AverageIsBetter and StdDevIsBetter then

--- a/test/extensions/voterandom.lua
+++ b/test/extensions/voterandom.lua
@@ -258,12 +258,8 @@ UnitTest:Test( "OptimiseLargeTeams", function( Assert )
 		end )
 
 		local AsSkillArray = {}
-		local Sum = 0
 		for j = 1, #TeamTable do
-			local Skill = Skills[ TeamTable[ j ] ]
-			AsSkillArray[ j ] = Skill
-
-			Sum = Sum + ( Skill - TeamSkills[ i ].Average ) ^ 2
+			AsSkillArray[ j ] = Skills[ TeamTable[ j ] ]
 		end
 
 		Assert:ArrayEquals( FinalTeams[ i ], AsSkillArray )


### PR DESCRIPTION
Before it would get stuck trying to improve the standard deviation and fail, thus stopping at a (often bad) point.

This change allows it to reduce the average while increasing the standard deviation slightly which gets it out of its stuck point and produces much better team compositions at the end.