### PR TITLE
Further tweaks to shuffling

### DIFF
--- a/lua/shine/extensions/voterandom.lua
+++ b/lua/shine/extensions/voterandom.lua
@@ -544,7 +544,7 @@ function Plugin:OptimiseTeams( TeamMembers, RankFunc, TeamSkills )
 
 			-- Allow a slight increase in standard deviation difference if we're improving the averages.
 			StdDevIsBetter = ( NewStdDiff <= PreStdDiff and NewStdDiff <= SwapData.BestStdDiff )
-				or ( NewStdDiff - PreStdDiff ) < 40
+				or ( SwapData.BestStdDiff == Huge and ( NewStdDiff - PreStdDiff ) < 40 )
 		end
 
 		if AverageIsBetter and StdDevIsBetter then

--- a/lua/shine/extensions/voterandom.lua
+++ b/lua/shine/extensions/voterandom.lua
@@ -70,19 +70,29 @@ Plugin.ModeStrings = ModeStrings
 Plugin.DefaultConfig = {
 	MinPlayers = 10, --Minimum number of players on the server to enable voting.
 	PercentNeeded = 0.75, --Percentage of the server population needing to vote for it to succeed.
+
 	Duration = 15, --Time to force people onto teams for after a vote. Also time between successful votes.
 	BlockAfterTime = 0, --Time after round start to block the vote. 0 to disable blocking.
 	RandomOnNextRound = true, --If false, then random teams are forced for a duration instead.
 	InstantForce = true, --Forces a shuffle of everyone instantly when the vote succeeds (for time based).
 	VoteTimeout = 60, --Time after the last vote before the vote resets.
+
 	BalanceMode = Plugin.MODE_HIVE, --How should teams be balanced?
 	FallbackMode = Plugin.MODE_KDR, --Which method should be used if Elo/Hive fails?
 	UseStandardDeviation = true, --Should standard deviation be accounted for when sorting?
+	--[[
+		How much of an increase in standard deviation should be allowed if the
+		average is being improved but the standard deviation can't be?
+	]]
+	StandardDeviationTolerance = 40,
+
 	BlockTeams = true, --Should team changing/joining be blocked after an instant force or in a round?
 	IgnoreCommanders = true, --Should the plugin ignore commanders when switching?
 	IgnoreSpectators = false, --Should the plugin ignore spectators when switching?
 	AlwaysEnabled = false, --Should the plugin be always forcing each round?
+
 	MaxStoredRounds = 3, --How many rounds of score data should we buffer?
+
 	ReconnectLogTime = 0 --How long (in seconds) after a shuffle to log reconnecting players for?
 }
 Plugin.CheckConfig = true
@@ -492,6 +502,7 @@ function Plugin:OptimiseTeams( TeamMembers, RankFunc, TeamSkills )
 
 	local IgnoreCommanders = self.Config.IgnoreCommanders
 	local UseStandardDeviation = self.Config.UseStandardDeviation
+	local StandardDeviationTolerance = self.Config.StandardDeviationTolerance
 
 	local function CheckSwap( Ply, Skill, Target, TargetSkill, LargerIndex, LesserIndex, SwapData )
 		local SwapResult = { {}, {} }
@@ -544,7 +555,7 @@ function Plugin:OptimiseTeams( TeamMembers, RankFunc, TeamSkills )
 
 			-- Allow a slight increase in standard deviation difference if we're improving the averages.
 			StdDevIsBetter = ( NewStdDiff <= PreStdDiff and NewStdDiff <= SwapData.BestStdDiff )
-				or ( SwapData.BestStdDiff == Huge and ( NewStdDiff - PreStdDiff ) < 40 )
+				or ( SwapData.BestStdDiff == Huge and ( NewStdDiff - PreStdDiff ) < StandardDeviationTolerance )
 		end
 
 		if AverageIsBetter and StdDevIsBetter then

--- a/test/extensions/voterandom.lua
+++ b/test/extensions/voterandom.lua
@@ -247,8 +247,8 @@ UnitTest:Test( "OptimiseLargeTeams", function( Assert )
 	VoteShuffle:OptimiseTeams( TeamMembers, RankFunc, TeamSkills )
 
 	local FinalTeams = {
-		{ 2000, 2000, 1700, 1200, 1000, 600, 500, 0 },
-		{ 2000, 1800, 1500, 1000, 1000, 1000, 700, 0 }
+		{ 2000, 2000, 1500, 1200, 1000, 700, 600, 0 },
+		{ 2000, 1800, 1700, 1000, 1000, 1000, 500, 0 }
 	}
 
 	for i = 1, 2 do

--- a/test/extensions/voterandom.lua
+++ b/test/extensions/voterandom.lua
@@ -12,6 +12,10 @@ end
 
 if not VoteShuffle then return end
 
+VoteShuffle.Config.IgnoreCommanders = false
+VoteShuffle.Config.UseStandardDeviation = true
+VoteShuffle.Config.StandardDeviationTolerance = 40
+
 local TableSort = table.sort
 
 UnitTest:Test( "AssignPlayers", function( Assert )
@@ -191,9 +195,6 @@ UnitTest:Test( "OptimiseTeams", function( Assert )
 		}
 	}
 
-	VoteShuffle.Config.IgnoreCommanders = false
-	VoteShuffle.Config.UseStandardDeviation = true
-
 	VoteShuffle:OptimiseTeams( TeamMembers, RankFunc, TeamSkills )
 
 	-- Final team layout should be:
@@ -240,9 +241,6 @@ UnitTest:Test( "OptimiseLargeTeams", function( Assert )
 		TeamSkills[ Team ] = Data
 		Team = Team + 1
 	end
-
-	VoteShuffle.Config.IgnoreCommanders = false
-	VoteShuffle.Config.UseStandardDeviation = true
 
 	VoteShuffle:OptimiseTeams( TeamMembers, RankFunc, TeamSkills )
 
@@ -297,9 +295,6 @@ UnitTest:Test( "OptimiseTeams with uneven teams", function( Assert )
 			Count = 2
 		}
 	}
-
-	VoteShuffle.Config.IgnoreCommanders = false
-	VoteShuffle.Config.UseStandardDeviation = true
 
 	VoteShuffle:OptimiseTeams( TeamMembers, RankFunc, TeamSkills )
 


### PR DESCRIPTION
- Fixed that swaps that lowered the difference between team's standard deviations were being discarded for those that increase it.
- Made the tolerance value configurable.