### PR TITLE
Inform the public about the ban reason when sh_ban is used.

### DIFF
--- a/lua/shine/extensions/ban/server.lua
+++ b/lua/shine/extensions/ban/server.lua
@@ -505,7 +505,7 @@ function Plugin:CreateCommands()
 		local DurationString = Duration ~= 0 and "for "..string.TimeToString( Duration )
 			or "permanently"
 
-		Shine:CommandNotify( Client, "banned %s (%s) %s.", true, TargetName, Reason, DurationString )
+		Shine:CommandNotify( Client, "banned %s %s (%s).", true, TargetName, DurationString, Reason )
 		Shine:AdminPrint( nil, "%s banned %s[%s] %s.", true, BanningName, TargetName,
 			ID, DurationString )
 	end

--- a/lua/shine/extensions/ban/server.lua
+++ b/lua/shine/extensions/ban/server.lua
@@ -505,7 +505,7 @@ function Plugin:CreateCommands()
 		local DurationString = Duration ~= 0 and "for "..string.TimeToString( Duration )
 			or "permanently"
 
-		Shine:CommandNotify( Client, "banned %s %s.", true, TargetName, DurationString )
+		Shine:CommandNotify( Client, "banned %s (%s) %s.", true, TargetName, Reason, DurationString )
 		Shine:AdminPrint( nil, "%s banned %s[%s] %s.", true, BanningName, TargetName,
 			ID, DurationString )
 	end


### PR DESCRIPTION
Often player wonder about the reason of a ban when they see the given message. 

Therefor it would make things more simple to just include the ban reason in the message.