### PR TITLE
HookStartVote is now a global function. And with the new FileHook sys…

### DIFF
--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -724,40 +724,15 @@ Add( "Think", "ReplaceMethods", function()
 		return OldTestCycle()
 	end
 
-	local OldStartVote = Shine.GetUpValue( HookStartVote, "StartVote", true )
-	if OldStartVote then
-		local function BuildNetworkReceiver( VoteName )
-			return function( Client, Data )
-				if Call( "NS2StartVote", VoteName, Client, Data ) == false then
-					Shine.SendNetworkMessage( Client, "VoteCannotStart",
-						{
-							reason = kVoteCannotStartReason.DisabledByAdmin
-						}, true )
-
-					return
-				end
-
-				OldStartVote( VoteName, Client, Data )
-			end
-		end
-
-		local AlreadyRegistered = Shine.GetUpValue( SetVoteSuccessfulCallback, "voteSuccessfulCallbacks" )
-		if AlreadyRegistered then
-			for Name in pairs( AlreadyRegistered ) do
-				Server.HookNetworkMessage( Name, BuildNetworkReceiver( Name ) )
-			end
-		end
-
-		Shine.StartNS2Vote = OldStartVote
-
-		function HookStartVote( VoteName )
-			Server.HookNetworkMessage( VoteName, BuildNetworkReceiver( VoteName ) )
-		end
-	end
-
 	Remove( "Think", "ReplaceMethods" )
 
 	Call( "OnFirstThink" )
 	Hooks.OnFirstThink = nil
 	ReservedNames.OnFirstThink = nil
 end )
+
+--[[
+	Setup the votinghook directly after Voting.lua has been loaded.
+	At this point HookStartVote hasn't been called yet.
+ ]]
+ModLoader.SetupFileHook("lua/Voting.lua", "lua/shine/shared/votinghook", "post")

--- a/lua/shine/core/shared/votinghook.lua
+++ b/lua/shine/core/shared/votinghook.lua
@@ -1,0 +1,24 @@
+--[[
+-- Shine vanilla voting hook setup
+ ]]
+Shine.StartNS2Vote = Shine.GetUpValue( HookStartVote, "StartVote", true )
+
+function HookStartVote( VoteName )
+	local function BuildNetworkReceiver( VoteName )
+		return function( Client, Data )
+			if Call( "NS2StartVote", VoteName, Client, Data ) == false then
+				Shine.SendNetworkMessage( Client, "VoteCannotStart",
+					{
+						reason = kVoteCannotStartReason.DisabledByAdmin
+					}, true )
+
+				return
+			end
+
+			Shine.StartNS2Vote( VoteName, Client, Data )
+		end
+	end
+
+	Server.HookNetworkMessage( VoteName, BuildNetworkReceiver( VoteName ) )
+end
+


### PR DESCRIPTION
This is part of the PR i had prepared (but forgot to open). By overwriting `HookStartVote` directly after Voting.lua got loaded we avoid having to rehook the network message and therefor the warning message doesn't show up anymore.

Fell free to rename the new file. I had no idea what kind of name would be appropiated.