### PR TITLE
Added percentage played tracking for mapvote, fixed shuffle block time

### DIFF
--- a/lua/shine/extensions/mapvote/voting.lua
+++ b/lua/shine/extensions/mapvote/voting.lua
@@ -576,19 +576,7 @@ function Plugin:StartVote( NextMap, Force )
 	local DeniedMaps = {}
 
 	local function SortOutMinMax( Map )
-		if not IsType( Map, "table" ) or not IsType( Map.map, "string" ) then
-			return
-		end
-
-		local Min = Map.min
-		local Max = Map.max
-
-		local MapName = Map.map
-
-		if Min and PlayerCount < Min then
-			AllMaps[ MapName ] = nil
-			DeniedMaps[ MapName ] = true
-		elseif Max and PlayerCount > Max then
+		if not self:IsValidMapChoice( Map, PlayerCount ) then
 			AllMaps[ MapName ] = nil
 			DeniedMaps[ MapName ] = true
 		end

--- a/lua/shine/extensions/mapvote/voting.lua
+++ b/lua/shine/extensions/mapvote/voting.lua
@@ -577,8 +577,8 @@ function Plugin:StartVote( NextMap, Force )
 
 	local function SortOutMinMax( Map )
 		if not self:IsValidMapChoice( Map, PlayerCount ) then
-			AllMaps[ MapName ] = nil
-			DeniedMaps[ MapName ] = true
+			AllMaps[ Map.map ] = nil
+			DeniedMaps[ Map.map ] = true
 		end
 	end
 

--- a/lua/shine/extensions/voterandom.lua
+++ b/lua/shine/extensions/voterandom.lua
@@ -1136,6 +1136,11 @@ function Plugin:JoinRandomTeam( Player )
 end
 
 function Plugin:SetGameState( Gamerules, NewState, OldState )
+	-- Reset the block time when the round stops.
+	if NewState == kGameState.NotStarted then
+		self.VoteBlockTime = nil
+	end
+
 	if NewState ~= kGameState.Countdown then return end
 
 	--Block the vote after the set time.

--- a/test/extensions/mapvote.lua
+++ b/test/extensions/mapvote.lua
@@ -1,0 +1,61 @@
+--[[
+	Map vote plugin unit tests.
+]]
+
+local UnitTest = Shine.UnitTest
+
+local MapVote = UnitTest:LoadExtension( "mapvote" )
+if not MapVote then return end
+
+MapVote.TrackMapStats = nil
+MapVote.MapStats = nil
+
+UnitTest:Test( "IsValidMapChoice - Stats", function( Assert )
+	local Map = {
+		map = "ns2_veil",
+		percent = 10
+	}
+	local MapStats = {
+		ns2_veil = 11,
+		ns2_derelict = 89
+	}
+
+	MapVote.TrackMapStats = true
+	MapVote.MapStats = MapStats
+	MapVote.TotalPlayedMaps = 100
+
+	Assert:False( MapVote:IsValidMapChoice( Map, 16 ) )
+
+	MapStats.ns2_veil = 10
+	MapStats.ns2_derelict = 90
+
+	Assert:False( MapVote:IsValidMapChoice( Map, 16 ) )
+
+	MapStats.ns2_veil = 9
+	MapStats.ns2_derelict = 91
+
+	Assert:True( MapVote:IsValidMapChoice( Map, 16 ) )
+end, function()
+	MapVote.TrackMapStats = nil
+	MapVote.MapStats = nil
+end )
+
+UnitTest:Test( "IsValidMapChoice - Player count", function( Assert )
+	local Map = {
+		map = "ns2_veil",
+		min = 5,
+		max = 10
+	}
+
+	for i = 0, Map.min - 1 do
+		Assert:False( MapVote:IsValidMapChoice( Map, i ) )
+	end
+
+	for i = Map.min, Map.max do
+		Assert:True( MapVote:IsValidMapChoice( Map, i ) )
+	end
+
+	for i = Map.max + 1, 100 do
+		Assert:False( MapVote:IsValidMapChoice( Map, i ) )
+	end
+end )

--- a/test/extensions/voterandom.lua
+++ b/test/extensions/voterandom.lua
@@ -4,12 +4,7 @@
 
 local UnitTest = Shine.UnitTest
 
-local VoteShuffle = Shine.Plugins.voterandom
-if not VoteShuffle then
-	Shine:LoadExtension( "voterandom" )
-	VoteShuffle = Shine.Plugins.voterandom
-end
-
+local VoteShuffle = UnitTest:LoadExtension( "voterandom" )
 if not VoteShuffle then return end
 
 VoteShuffle.Config.IgnoreCommanders = false

--- a/test/test_init.lua
+++ b/test/test_init.lua
@@ -17,6 +17,17 @@ local xpcall = xpcall
 
 local IsType = Shine.IsType
 
+function UnitTest:LoadExtension( Name )
+	local Plugin = Shine.Plugins[ Name ]
+
+	if not Plugin then
+		Shine:LoadExtension( Name )
+		Plugin = Shine.Plugins[ Name ]
+	end
+
+	return Plugin
+end
+
 function UnitTest:Test( Description, TestFunction, Finally, Reps )
 	local Result = {
 		Description = Description,


### PR DESCRIPTION
- Map vote plugin can now track maps played and stop maps going over a percentage of the total played.
- Shuffle plugin now correctly resets the round block time after a reset vote.