### PR TITLE
Fix commander alerts and alter chatbox text wrapping

### DIFF
--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -235,7 +235,7 @@ do
 		if SpeakerClient and self:IsClientGagged( SpeakerClient ) then return false end
 		if Listener:GetClientMuted( Speaker:GetClientIndex() ) then return false end
 
-		if ChannelType ~= VoiceChannel.Global then
+		if ChannelType and ChannelType ~= VoiceChannel.Global then
 			-- Assume non-global means local chat, so "all-talk" means true if distance check passes.
 			if self.Config.AllTalkLocal or self.Config.AllTalk or IsPregameAllTalk( self, Gamerules )
 			or IsSpectatorAllTalk( self, Listener ) then

--- a/lua/shine/extensions/chatbox/client.lua
+++ b/lua/shine/extensions/chatbox/client.lua
@@ -790,6 +790,8 @@ function Plugin:AddMessage( PlayerColour, PlayerName, MessageColour, MessageName
 	local Messages = self.Messages
 	local LastMessage = Messages[ #Messages ]
 	local StartX = 5
+	local PrefixMargin = 5
+	local LineMargin = 2
 
 	local Tags, PreLabel, MessageLabel, MessageLabel2, ReUse
 
@@ -868,12 +870,12 @@ function Plugin:AddMessage( PlayerColour, PlayerName, MessageColour, MessageName
 	--Now calculate the next message's position, it's important to do this after moving old ones up.
 	--Otherwise the scrollbar would increase its size thinking there's text further down.
 	if not LastMessage then
-		PrePos = Vector( StartX, 5, 0 )
+		PrePos = Vector( StartX, PrefixMargin, 0 )
 	else
 		local LastPre = LastMessage.Pre
-		PrePos = Vector( StartX, LastPre:GetPos().y + LastMessage.Message:GetTextHeight() + 2, 0 )
+		PrePos = Vector( StartX, LastPre:GetPos().y + LastMessage.Message:GetTextHeight() + LineMargin, 0 )
 		if LastMessage.Message2 then
-			PrePos.y = PrePos.y + LastMessage.Message2:GetTextHeight() + 2
+			PrePos.y = PrePos.y + LastMessage.Message2:GetTextHeight() + LineMargin
 		end
 	end
 
@@ -919,7 +921,7 @@ function Plugin:AddMessage( PlayerColour, PlayerName, MessageColour, MessageName
 		MessageLabel:SetText( MessageName )
 
 		local ChatBoxSize = self.ChatBox:GetSize().x
-		local XPos = PrePos.x + 5 + PreLabel:GetTextWidth()
+		local XPos = PrePos.x + PrefixMargin + PreLabel:GetTextWidth()
 		local NeedsSecondLine
 
 		if XPos + MessageLabel:GetTextWidth( MessageName ) > ChatBoxSize then
@@ -939,7 +941,7 @@ function Plugin:AddMessage( PlayerColour, PlayerName, MessageColour, MessageName
 				MessageLabel2:SetColour( MessageColour )
 				MessageLabel2:SetText( Remaining )
 
-				XPos = 5
+				XPos = StartX
 				if XPos + MessageLabel2:GetTextWidth( Remaining ) > ChatBoxSize then
 					WordWrap( MessageLabel2, Remaining, XPos, ChatBoxSize )
 				end
@@ -958,11 +960,11 @@ function Plugin:AddMessage( PlayerColour, PlayerName, MessageColour, MessageName
 		end
 	end
 
-	local MessagePos = Vector( PrePos.x + 5 + PreLabel:GetTextWidth(), PrePos.y, 0 )
+	local MessagePos = Vector( PrePos.x + PrefixMargin + PreLabel:GetTextWidth(), PrePos.y, 0 )
 	MessageLabel:SetPos( MessagePos )
 
 	if MessageLabel2 then
-		MessageLabel2:SetPos( Vector( StartX, PrePos.y + MessageLabel:GetTextHeight() + 2, 0 ) )
+		MessageLabel2:SetPos( Vector( StartX, PrePos.y + MessageLabel:GetTextHeight() + LineMargin, 0 ) )
 	end
 
 	if SGUI.IsValid( ChatBox.Scrollbar ) then

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -103,7 +103,7 @@ do
 
 		This time, it shouldn't freeze the game...
 	]]
-	function SGUI.WordWrap( Label, Text, XPos, MaxWidth )
+	function SGUI.WordWrap( Label, Text, XPos, MaxWidth, MaxLines )
 		local Words = StringExplode( Text, " " )
 		local StartIndex = 1
 		local Lines = {}
@@ -135,6 +135,10 @@ do
 					StartIndex = i
 					i = i - 1
 				end
+
+				if MaxLines and #Lines >= MaxLines then
+					break
+				end
 			elseif i == #Words then --We're at the end!
 				Lines[ #Lines + 1 ] = CurText
 			end
@@ -143,6 +147,10 @@ do
 		end
 
 		Label:SetText( TableConcat( Lines, "\n" ) )
+
+		if MaxLines then
+			return TableConcat( Words, " ", StartIndex )
+		end
 	end
 end
 

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -61,10 +61,12 @@ function SGUI.GetChar( Char )
 end
 
 do
+	local Max = math.max
 	local StringExplode = string.Explode
 	local StringUTF8Length = string.UTF8Length
 	local StringUTF8Sub = string.UTF8Sub
 	local TableConcat = table.concat
+	local TableInsert = table.insert
 
 	--[[
 		Wraps text to fit the size limit. Used for long words...
@@ -84,14 +86,14 @@ do
 
 			--Once it reaches the limit, we go back a character, and set our first and second line results.
 			if XPos + Label:GetTextWidth( CurText ) > MaxWidth then
-				FirstLine = StringUTF8Sub( Text, 1, i - 1 )
-				SecondLine = StringUTF8Sub( Text, i )
+				FirstLine = StringUTF8Sub( Text, 1, Max( i - 1, 1 ) )
+				SecondLine = StringUTF8Sub( Text, Max( i, 2 ) )
 
 				break
 			end
 
 			i = i + 1
-		until i >= Length
+		until i > Length
 
 		return FirstLine, SecondLine
 	end
@@ -118,9 +120,9 @@ do
 
 					Lines[ #Lines + 1 ] = FirstLine
 
-					--Add the second line to the next word, or as a new next word if none exists.
+					--Add the second line as the next word, or as a new next word if none exists.
 					if Words[ i + 1 ] then
-						Words[ i + 1 ] = StringFormat( "%s %s", SecondLine, Words[ i + 1 ] )
+						TableInsert( Words, i + 1, SecondLine )
 					else
 						Words[ i + 1 ] = SecondLine
 					end

--- a/lua/shine/lib/gui/objects/panel.lua
+++ b/lua/shine/lib/gui/objects/panel.lua
@@ -325,6 +325,23 @@ function Panel:SetMaxHeight( Height )
 
 	local MaxHeight = self:GetSize().y
 
+	-- Height has reduced below the max height, so remove the scrollbar.
+	if MaxHeight >= Height then
+		if SGUI.IsValid( self.Scrollbar ) then
+			self.Scrollbar:SetParent()
+			self.Scrollbar:Destroy()
+			self.Scrollbar = nil
+
+			if self.ScrollParentPos then
+				self.ScrollParentPos.y = 0
+			end
+
+			self.ScrollParent:SetPosition( self.ScrollParentPos or Vector( 0, 0, 0 ) )
+		end
+
+		return
+	end
+
 	if not SGUI.IsValid( self.Scrollbar ) then
 		local Scrollbar = SGUI:Create( "Scrollbar", self )
 		self.Scrollbar = Scrollbar


### PR DESCRIPTION
- Fixed the case where no channel identifier is passed through the `CanPlayerHearPlayer` event (such as commander alerts).
- The chatbox now wraps in the same manner as the vanilla chat display.