### PR TITLE
Kick on connection for AFK kick plugin, rename RTV

### DIFF
--- a/lua/shine/core/client/votemenu_gui.lua
+++ b/lua/shine/core/client/votemenu_gui.lua
@@ -568,6 +568,7 @@ function VoteMenu:PositionButton( Button, Index, MaxIndex, Align, IgnoreAnim )
 		Button:MoveTo( nil, nil, Pos, 0, EasingTime )
 	else
 		Button:SetPos( Pos )
+		Button:StopMoving()
 	end
 end
 

--- a/lua/shine/core/client/votemenu_gui.lua
+++ b/lua/shine/core/client/votemenu_gui.lua
@@ -89,7 +89,7 @@ local ClickFuncs = {
 	Shuffle = function()
 		return GenericClick( "sh_voterandom" )
 	end,
-	RTV = function()
+	[ "Map Vote" ] = function()
 		return GenericClick( "sh_votemap" )
 	end,
 	Surrender = function()

--- a/lua/shine/core/server/votemenu.lua
+++ b/lua/shine/core/server/votemenu.lua
@@ -7,7 +7,7 @@ local function BuildPluginData( self )
 
 	return {
 		Shuffle = self:IsExtensionEnabled( "voterandom" ),
-		RTV = self:IsExtensionEnabled( "mapvote" ) and Plugins.mapvote.Config.EnableRTV or false,
+		[ "Map Vote" ] = self:IsExtensionEnabled( "mapvote" ) and Plugins.mapvote.Config.EnableRTV or false,
 		Surrender = self:IsExtensionEnabled( "votesurrender" ),
 		Unstuck = self:IsExtensionEnabled( "unstuck" ),
 		MOTD = self:IsExtensionEnabled( "motd" )

--- a/lua/shine/core/shared/votemenu.lua
+++ b/lua/shine/core/shared/votemenu.lua
@@ -6,7 +6,7 @@ Shared.RegisterNetworkMessage( "Shine_OpenedVoteMenu", {} )
 
 local PluginMessage = {
 	Shuffle = "boolean",
-	RTV = "boolean",
+	[ "Map Vote" ] = "boolean",
 	Surrender = "boolean",
 	Unstuck = "boolean",
 	MOTD = "boolean"


### PR DESCRIPTION
- Added experimental option to kick the longest AFK player when the server's full and a new player tries to join. Have no way to test it as bots don't count as real clients.
- Renamed the RTV button to "Map Vote" to avoid confusion around what RTV means.
- Fixed a layout glitch when the admin menu button is added to the vote menu for the first time.