### PR TITLE
Add validity check

### DIFF
--- a/lua/shine/extensions/chatbox/client.lua
+++ b/lua/shine/extensions/chatbox/client.lua
@@ -275,7 +275,7 @@ local function UpdateOpacity( self, Opacity )
 	for i = 1, #OpacityVariantControls do
 		local Control = self[ OpacityVariantControls[ i ] ]
 		-- Force the skin to refresh.
-		if Control then
+		if SGUI.IsValid( Control ) then
 			Control:SetStyleName( Control:GetStyleName() )
 		end
 	end


### PR DESCRIPTION
When changing resolution, the control may have been destroyed.