### PR TITLE
More refactoring and polishing

### DIFF
--- a/lua/shine/cl_init.lua
+++ b/lua/shine/cl_init.lua
@@ -10,6 +10,7 @@ local Scripts = {
 	"lib/string.lua",
 	"lib/table.lua",
 	"lib/comparator.lua",
+	"lib/sorting.lua",
 	"lib/stream.lua",
 	"lib/utf8.lua",
 	"lib/class.lua",

--- a/lua/shine/core/client/adminmenu.lua
+++ b/lua/shine/core/client/adminmenu.lua
@@ -304,9 +304,18 @@ do
 
 	local function UpdatePlayers()
 		local PlayerEnts = GetEnts( "PlayerInfoEntity" )
+		local ExistingPlayers = {}
 
 		for _, Ent in IterateEntList( PlayerEnts ) do
 			AddPlayerToList( Ent )
+			ExistingPlayers[ Ent.clientId ] = true
+		end
+
+		for ID, Row in pairs( Rows ) do
+			if not ExistingPlayers[ ID ] then
+				PlayerList:RemoveRow( Row.Index )
+				Rows[ ID ] = nil
+			end
 		end
 	end
 

--- a/lua/shine/core/client/adminmenu.lua
+++ b/lua/shine/core/client/adminmenu.lua
@@ -13,10 +13,6 @@ Shine.AdminMenu = {}
 
 local AdminMenu = Shine.AdminMenu
 
-Hook.Add( "OnMapLoad", "AdminMenu_Hook", function()
-	Hook.SetupGlobalHook( "Scoreboard_OnClientDisconnect", "OnClientIDDisconnect", "PassivePre" )
-end )
-
 Client.HookNetworkMessage( "Shine_AdminMenu_Open", function( Data )
 	AdminMenu:SetIsVisible( true )
 end )
@@ -349,6 +345,7 @@ do
 			PlayerList:SetSize( Vector( 640 - 192 - 16, 512, 0 ) )
 			PlayerList:SetNumericColumn( 2 )
 			PlayerList:SetMultiSelect( true )
+			PlayerList:SetSecondarySortColumn( 3, 1 )
 			PlayerList.ScrollPos = Vector( 0, 32, 0 )
 
 			UpdatePlayers()
@@ -360,16 +357,6 @@ do
 			end )
 
 			AdminMenu.RestoreListState( PlayerList, Data )
-
-			Hook.Add( "OnClientIDDisconnect", "AdminMenu_UpdatePlayers", function( ClientID )
-				local Row = Rows[ ClientID ]
-
-				if SGUI.IsValid( PlayerList ) and SGUI.IsValid( Row ) then
-					PlayerList:RemoveRow( Row.Index )
-
-					Rows[ ClientID ] = nil
-				end
-			end )
 
 			Commands = SGUI:Create( "CategoryPanel", Panel )
 			Commands:SetAnchor( "TopRight" )
@@ -430,7 +417,6 @@ do
 			TableEmpty( Rows )
 
 			Shine.Timer.Destroy( "AdminMenu_Update" )
-			Hook.Remove( "OnClientIDDisconnect", "AdminMenu_UpdatePlayers" )
 
 			return Data
 		end

--- a/lua/shine/core/client/adminmenu.lua
+++ b/lua/shine/core/client/adminmenu.lua
@@ -595,12 +595,25 @@ Special thanks to:
 Got an issue or a feature request? Head over to the mod's GitHub page and post an issue,
 or leave a comment on the workshop page.
 ]],
-[[The mod's GitHub issue tracker can be found here:
-https://github.com/Person8880/Shine/issues
+[[The mod's GitHub issue tracker can be found here:]],
+{
+	Text = [[https://github.com/Person8880/Shine/issues]],
+	StyleName = "Link",
+	DoClick = function( self )
+		Client.ShowWebpage( self:GetText() )
+	end
+},
+[[
 
 If you need help with how the mod functions, you can view the wiki by clicking the button
-below. If you want to get to it outside the game, visit:
-https://github.com/Person8880/Shine/wiki]]
+below. If you want to get to it outside the game, visit:]],
+{
+	Text = [[https://github.com/Person8880/Shine/wiki]],
+	StyleName = "Link",
+	DoClick = function( self )
+		Client.ShowWebpage( self:GetText() )
+	end
+}
 }
 
 	local Units = SGUI.Layout.Units
@@ -618,7 +631,15 @@ https://github.com/Person8880/Shine/wiki]]
 			for i = 1, #Text do
 				local Label = SGUI:Create( "Label", Panel )
 				Label:SetFont( Fonts.kAgencyFB_Small )
-				Label:SetText( Text[ i ] )
+
+				local LabelText = Text[ i ]
+				if IsType( LabelText, "string" ) then
+					Label:SetText( LabelText )
+				else
+					Label:SetText( LabelText.Text )
+					Label:SetStyleName( LabelText.StyleName )
+					Label.DoClick = LabelText.DoClick
+				end
 				Layout:AddElement( Label )
 			end
 

--- a/lua/shine/core/client/adminmenu.lua
+++ b/lua/shine/core/client/adminmenu.lua
@@ -317,6 +317,8 @@ do
 				Rows[ ID ] = nil
 			end
 		end
+
+		PlayerList:RefreshSorting()
 	end
 
 	local function GenerateButton( Text, DoClick, Tooltip )

--- a/lua/shine/core/client/adminmenu.lua
+++ b/lua/shine/core/client/adminmenu.lua
@@ -313,8 +313,6 @@ do
 				Rows[ ID ] = nil
 			end
 		end
-
-		PlayerList:RefreshSorting()
 	end
 
 	local function GenerateButton( Text, DoClick, Tooltip )

--- a/lua/shine/core/client/commands.lua
+++ b/lua/shine/core/client/commands.lua
@@ -93,7 +93,7 @@ function Shine:RunClientCommand( ConCommand, ... )
 	local Command = ClientCommands[ ConCommand ]
 	if not Command or Command.Disabled then return end
 
-	local Args = { ... }
+	local Args = self.CommandUtil.AdjustArguments{ ... }
 
 	local ParsedArgs = {}
 	local ExpectedArgs = Command.Arguments

--- a/lua/shine/core/client/commands.lua
+++ b/lua/shine/core/client/commands.lua
@@ -74,13 +74,6 @@ function Shine:RemoveClientCommand( ConCommand )
 	ClientCommands[ ConCommand ] = nil
 end
 
-local function OnError( Error )
-	local Trace = Traceback()
-
-	Shine:DebugPrint( "Error: %s.\n%s", true, Error, Trace )
-	Shine:AddErrorReport( StringFormat( "Client command error: %s.", Error ), Trace )
-end
-
 function Shine.CommandUtil:OnFailedMatch( Client, ConCommand, ArgString, CurArg, i )
 	Notify( StringFormat( CurArg.Error or "Incorrect argument #%s to %s, expected %s.",
 		i, ConCommand, CurArg.Type ) )
@@ -89,6 +82,8 @@ end
 function Shine.CommandUtil:Validate( Client, ConCommand, Result, MatchedType, CurArg, i )
 	return true, Result
 end
+
+local OnError = Shine.BuildErrorHandler( "Client command error" )
 
 --[[
 	Executes a client side Shine command. Should not be called directly.

--- a/lua/shine/core/client/votemenu_gui.lua
+++ b/lua/shine/core/client/votemenu_gui.lua
@@ -221,8 +221,9 @@ Hook.Add( "PlayerKeyPress", "VoteMenuKeyPress", function( Key, Down )
 end, 1 )
 
 function VoteMenu:Think( DeltaTime )
-	local ActivePage = self.ActivePage
+	if not self.Visible then return end
 
+	local ActivePage = self.ActivePage
 	if not ActivePage then return end
 
 	local Think = self.Pages[ ActivePage ].Think

--- a/lua/shine/core/server/commands.lua
+++ b/lua/shine/core/server/commands.lua
@@ -765,6 +765,8 @@ function Shine:RunCommand( Client, ConCommand, FromChat, ... )
 		FromChat = false
 	end
 
+	Args = self.CommandUtil.AdjustArguments( Args )
+
 	self.CommandStack[ #self.CommandStack + 1 ] = FromChat
 
 	local ParsedArgs = self.CommandUtil:GetCommandArgs( Client, ConCommand, FromChat, Command, Args )

--- a/lua/shine/core/server/commands.lua
+++ b/lua/shine/core/server/commands.lua
@@ -758,14 +758,14 @@ function Shine:RunCommand( Client, ConCommand, FromChat, ... )
 	local Command = self.Commands[ ConCommand ]
 	if not Command or Command.Disabled then return end
 
-	local Args = { ... }
+	local OriginalArgs = { ... }
 	--In case someone was calling Shine:RunCommand() directly (even though it says "Should not be called directly.")
 	if not IsType( FromChat, "boolean" ) then
-		TableInsert( Args, 1, FromChat )
+		TableInsert( OriginalArgs, 1, FromChat )
 		FromChat = false
 	end
 
-	Args = self.CommandUtil.AdjustArguments( Args )
+	Args = self.CommandUtil.AdjustArguments( OriginalArgs )
 
 	self.CommandStack[ #self.CommandStack + 1 ] = FromChat
 
@@ -782,7 +782,7 @@ function Shine:RunCommand( Client, ConCommand, FromChat, ... )
 	if not Success then
 		Shine:DebugPrint( "[Command Error] Console command %s failed.", true, ConCommand )
 	else
-		local Arguments = TableConcat( Args, " " )
+		local Arguments = TableConcat( OriginalArgs, " " )
 		local Player = Client and Client:GetControllingPlayer()
 		local Name = Player and Player:GetName() or "Console"
 		local ID = Client and Client:GetUserId() or "N/A"

--- a/lua/shine/core/server/commands.lua
+++ b/lua/shine/core/server/commands.lua
@@ -323,6 +323,7 @@ ParamTypes.client = {
 do
 	local TeamDefs = {
 		[ "spectate" ] = 3,
+		[ "spectator" ] = 3,
 		[ "readyroom" ] = kTeamReadyRoom,
 		[ "rr" ] = kTeamReadyRoom,
 		[ "marine" ] = 1,

--- a/lua/shine/core/server/commands.lua
+++ b/lua/shine/core/server/commands.lua
@@ -324,6 +324,7 @@ do
 	local TeamDefs = {
 		[ "spectate" ] = 3,
 		[ "readyroom" ] = kTeamReadyRoom,
+		[ "rr" ] = kTeamReadyRoom,
 		[ "marine" ] = 1,
 		[ "alien" ] = 2,
 		[ "blue" ] = 1,

--- a/lua/shine/core/server/commands.lua
+++ b/lua/shine/core/server/commands.lua
@@ -265,18 +265,6 @@ function Shine:RemoveCommand( ConCommand, ChatCommand )
 end
 
 local IsType = Shine.IsType
-
---These define what to return for the given command arguments.
-local TargetFuncs = {
-	[ "@spectate" ] = function() return Shine.GetTeamClients( 3 ) end,
-	[ "@readyroom" ] = function() return Shine.GetTeamClients( kTeamReadyRoom ) end,
-	[ "@marine" ] = function() return Shine.GetTeamClients( 1 ) end,
-	[ "@alien" ] = function() return Shine.GetTeamClients( 2 ) end,
-	[ "@blue" ] = function() return Shine.GetTeamClients( 1 ) end,
-	[ "@orange" ] = function() return Shine.GetTeamClients( 2 ) end,
-	[ "@gold" ] = function() return Shine.GetTeamClients( 2 ) end
-}
-
 local GetDefault = Shine.CommandUtil.GetDefaultValue
 
 --Client looks for a matching client by game ID, Steam ID and name. Returns 1 client.
@@ -331,163 +319,197 @@ ParamTypes.client = {
 	end,
 	Default = "^"
 }
---Clients looks for matching clients by game ID, Steam ID, name
---or special targeting directive. Returns a table of clients.
-ParamTypes.clients = {
-	Parse = function( Client, String, Table )
-		if not String then
-			return GetDefault( Table )
+
+do
+	local TeamDefs = {
+		[ "spectate" ] = 3,
+		[ "readyroom" ] = kTeamReadyRoom,
+		[ "marine" ] = 1,
+		[ "alien" ] = 2,
+		[ "blue" ] = 1,
+		[ "orange" ] = 2,
+		[ "gold" ] = 2
+	}
+
+	local function ParseValue( Client, Value, Context, ControlCharacters )
+		local CurrentTargets = {}
+		local Negate
+
+		-- If the first character is a !, then it's a negation.
+		local ControlChar = StringSub( Value, 1, 1 )
+		if ControlChar == "!" then
+			Value = StringSub( Value, 2 )
+			ControlChar = StringSub( Value, 1, 1 )
+			Negate = true
 		end
 
-		local Vals = StringExplode( String, "," )
+		Context.IsNegative = Negate
 
-		local Clients = {}
-		local Targets = {}
+		local Parser = ControlCharacters[ ControlChar ]
+		if Parser and ( not Parser.MustEqual or Value == ControlChar ) then
+			Context.Value = StringSub( Value, 2 )
 
-		local AllClients = Shine.GetAllClients()
-		local NumClients = #AllClients
-
-		for i = 1, #Vals do
-			local CurrentTargets = {}
-
-			local Val = Vals[ i ]
-			local Negate
-
-			local ControlChar = Val:sub( 1, 1 )
-
-			if ControlChar == "!" then
-				Val = Val:sub( 2 )
-				Negate = true
-			end
-
-			--Targeting a user group.
-			if ControlChar == "%" then
-				local Group = Val:sub( 2 )
-				local InGroup = Shine:GetClientsByGroup( Group )
-
-				if #InGroup > 0 then
-					for j = 1, #InGroup do
-						local CurClient = InGroup[ j ]
-
-						if not CurrentTargets[ CurClient ] then
-							CurrentTargets[ CurClient ] = true
-						end
-					end
-				end
-			elseif ControlChar == "$" then --Targetting a specific Steam ID.
-				local ID = Val:sub( 2 )
-				local ToNum = tonumber( ID )
-
-				local CurClient
-
-				if ToNum then
-					CurClient = Shine.GetClientByNS2ID( ToNum )
-				else
-					CurClient = Shine:GetClientBySteamID( ID )
+			local Targets = Parser.Parse( Client, Context )
+			if Targets then
+				for i = 1, #Targets do
+					CurrentTargets[ Targets[ i ] ] = true
 				end
 
-				if CurClient and not CurrentTargets[ CurClient ] then
-					CurrentTargets[ CurClient ] = true
-				end
-			else
-				if Val == "*" then --Targeting everyone.
-					for j = 1, NumClients do
-						local CurClient = AllClients[ j ]
-
-						if CurClient and not CurrentTargets[ CurClient ] then
-							CurrentTargets[ CurClient ] = true
-						end
-					end
-				elseif Val == "^" then --Targeting yourself.
-					local CurClient = Client
-
-					if not Table.NotSelf then
-						if not CurrentTargets[ CurClient ] then
-							CurrentTargets[ CurClient ] = true
-						end
-					end
-				else
-					if TargetFuncs[ Val ] then --Allows for targetting multiple @types at once.
-						local Add = TargetFuncs[ Val ]()
-
-						for j = 1, #Add do
-							local Adding = Add[ j ]
-
-							if not CurrentTargets[ Adding ] then
-								CurrentTargets[ Adding ] = true
-							end
-						end
-					else
-						local CurClient = Shine:GetClient( Val )
-
-						if CurClient and not ( Table.NotSelf and CurClient == Client ) then
-							if not CurrentTargets[ CurClient ] then
-								CurrentTargets[ CurClient ] = true
-							end
-						end
-					end
-				end
-			end
-
-			if Negate then
-				if not next( Targets ) then
-					for j = 1, NumClients do
-						local CurClient = AllClients[ j ]
-
-						if not CurrentTargets[ CurClient ] then
-							Targets[ CurClient ] = true
-						end
-					end
-				else
-					for CurClient, Bool in pairs( CurrentTargets ) do
-						Targets[ CurClient ] = nil
-					end
-				end
-			else
-				for CurClient, Bool in pairs( CurrentTargets ) do
-					Targets[ CurClient ] = true
-				end
+				return CurrentTargets
 			end
 		end
 
-		if Table.NotSelf and Targets[ Client ] then
-			Targets[ Client ] = nil
-		end
+		local Target = Shine:GetClient( Value )
+		if not Target then return CurrentTargets end
 
-		for CurClient, Bool in pairs( Targets ) do
-			Clients[ #Clients + 1 ] = CurClient
-		end
+		CurrentTargets[ Target ] = true
 
-		return Clients
-	end,
-	Help = "players",
-	OnFailedMatch = function( Client, Arg )
-		Shine:NotifyCommandError( Client, "No matching players were found." )
-	end,
-	Validate = function( Client, Arg, ParsedArg )
-		if not ParsedArg then return true end
-		if #ParsedArg == 0 then
-			Shine:NotifyCommandError( Client, "No matching players found." )
-
-			return false
-		end
-
-		if Arg.IgnoreCanTarget then return true end
-
-		Shine.Stream( ParsedArg ):Filter( function( Value )
-			return Shine:CanTarget( Client, Value )
-		end )
-
-		if #ParsedArg == 0 then
-			Shine:NotifyCommandError( Client,
-				"You do not have permission to target anyone you specified." )
-
-			return false
-		end
-
-		return true
+		return CurrentTargets
 	end
-}
+
+	local function AddToTargets( CurrentTargets, Context )
+		local Targets = Context.Targets
+
+		if Context.IsNegative then
+			-- If this is the first target specifier, then negate from all connected clients.
+			if Context.ValueIndex == 1 then
+				for j = 1, Context.NumClients do
+					local Target = Context.AllClients[ j ]
+
+					if not CurrentTargets[ Target ] then
+						Targets[ Target ] = true
+					end
+				end
+			else
+				for Target in pairs( CurrentTargets ) do
+					Targets[ Target ] = nil
+				end
+			end
+		else
+			for Target in pairs( CurrentTargets ) do
+				Targets[ Target ] = true
+			end
+		end
+	end
+
+	-- Clients looks for matching clients by game ID, Steam ID, name
+	-- or special targeting directive. Returns a table of clients.
+	ParamTypes.clients = {
+		TeamDefs = TeamDefs, -- If anyone ever has teams in their mod, you can add to this.
+		ControlCharacters = {
+			[ "%" ] = {
+				-- Finds by user group name.
+				Parse = function( Client, Context )
+					return Shine:GetClientsByGroup( Context.Value )
+				end
+			},
+			[ "$" ] = {
+				-- Finds by NS2/Steam ID.
+				Parse = function( Client, Context )
+					local NS2ID = tonumber( Context.Value )
+					local Target
+
+					if NS2ID then
+						Target = Shine.GetClientByNS2ID( NS2ID )
+					else
+						Target = Shine:GetClientBySteamID( Context.Value )
+					end
+
+					return { Target }
+				end
+			},
+			[ "@" ] = {
+				-- Finds by team name.
+				Parse = function( Client, Context )
+					local TeamIndex = TeamDefs[ Context.Value ]
+					if not TeamIndex then
+						return nil
+					end
+
+					return Shine.GetTeamClients( TeamIndex )
+				end
+			},
+			[ "*" ] = {
+				-- Matches all clients connected.
+				Parse = function( Client, Context )
+					return Context.AllClients
+				end,
+				MustEqual = true
+			},
+			[ "^" ] = {
+				-- Matches the calling client.
+				Parse = function( Client, Context )
+					return { Client }
+				end,
+				MustEqual = true
+			}
+		},
+		Parse = function( Client, String, Table )
+			if not String then
+				return GetDefault( Table )
+			end
+
+			local Values = StringExplode( String, "," )
+			local Targets = {}
+
+			local AllClients, NumClients = Shine.GetAllClients()
+			local Context = {
+				AllClients = AllClients,
+				NumClients = NumClients,
+				ArgDef = Table,
+				Targets = Targets
+			}
+
+			local ControlCharacters = ParamTypes.clients.ControlCharacters
+
+			for i = 1, #Values do
+				Context.ValueIndex = i
+
+				local CurrentTargets = ParseValue( Client, Values[ i ], Context, ControlCharacters )
+				AddToTargets( CurrentTargets, Context )
+			end
+
+			if Table.NotSelf and Targets[ Client ] then
+				Targets[ Client ] = nil
+			end
+
+			local Clients = {}
+			for Target in pairs( Targets ) do
+				Clients[ #Clients + 1 ] = Target
+			end
+
+			return Clients
+		end,
+		Help = "players",
+		OnFailedMatch = function( Client, Arg )
+			Shine:NotifyCommandError( Client, "No matching players were found." )
+		end,
+		Validate = function( Client, Arg, ParsedArg )
+			if not ParsedArg then return true end
+			if #ParsedArg == 0 then
+				Shine:NotifyCommandError( Client, "No matching players found." )
+
+				return false
+			end
+
+			if Arg.IgnoreCanTarget then return true end
+
+			Shine.Stream( ParsedArg ):Filter( function( Value )
+				return Shine:CanTarget( Client, Value )
+			end )
+
+			if #ParsedArg == 0 then
+				Shine:NotifyCommandError( Client,
+					"You do not have permission to target anyone you specified." )
+
+				return false
+			end
+
+			return true
+		end
+	}
+end
+
 --Team takes either 0 - 3 directly or takes a string matching a team name
 --and turns it into the team number.
 ParamTypes.team = {

--- a/lua/shine/core/server/commands.lua
+++ b/lua/shine/core/server/commands.lua
@@ -487,7 +487,7 @@ do
 		Validate = function( Client, Arg, ParsedArg )
 			if not ParsedArg then return true end
 			if #ParsedArg == 0 then
-				Shine:NotifyCommandError( Client, "No matching players found." )
+				Shine:NotifyCommandError( Client, "No matching players were found." )
 
 				return false
 			end
@@ -510,36 +510,49 @@ do
 	}
 end
 
---Team takes either 0 - 3 directly or takes a string matching a team name
---and turns it into the team number.
-ParamTypes.team = {
-	Parse = function( Client, String, Table )
-		if not String then
-			return GetDefault( Table )
-		end
+do
+	local TeamMatches = {
+		{ "ready", 0 },
+		{ "marine", 1 },
+		{ "alien", 2 },
+		{ "spectat", 3 },
+		{ "blu", 1 },
+		{ "orang", 2 },
+		{ "gold", 2 },
+		{ "^rr", 0 }
+	}
 
-		local ToNum = tonumber( String )
+	local StringLower = string.lower
 
-		if ToNum then return MathClamp( Round( ToNum ), 0, 3 ) end
+	-- Team takes either 0 - 3 directly or takes a string matching a team name
+	-- and turns it into the team number.
+	ParamTypes.team = {
+		Parse = function( Client, String, Table )
+			if not String then
+				return GetDefault( Table )
+			end
 
-		String = String:lower()
+			local TeamNumber = tonumber( String )
+			if TeamNumber then return MathClamp( Round( TeamNumber ), 0, 3 ) end
 
-		if String:find( "ready" ) then return 0 end
-		if String:find( "marine" ) then return 1 end
-		if String:find( "blu" ) then return 1 end
-		if String:find( "alien" ) then return 2 end
-		if String:find( "orang" ) then return 2 end
-		if String:find( "gold" ) then return 2 end
-		if String:find( "spectat" ) then return 3 end
+			String = StringLower( String )
 
-		return nil
-	end,
-	Help = "team"
-}
+			for i = 1, #TeamMatches do
+				if StringFind( String, TeamMatches[ i ][ 1 ] ) then
+					return TeamMatches[ i ][ 2 ]
+				end
+			end
+
+			return nil
+		end,
+		Help = "team"
+	}
+end
+
 ParamTypes.steamid = {
 	Parse = function( Client, String, Table )
-		local Num = tonumber( String )
-		if Num then return Num end
+		local NS2ID = tonumber( String )
+		if NS2ID then return NS2ID end
 
 		return Shine.SteamIDToNS2( String )
 	end,

--- a/lua/shine/core/server/commands.lua
+++ b/lua/shine/core/server/commands.lua
@@ -297,11 +297,11 @@ ParamTypes.client = {
 		return Target
 	end,
 	Help = "player",
-	OnFailedMatch = function( Client, Arg, SelfTargeting )
+	OnFailedMatch = function( Client, Arg, SelfTargeting, ArgString )
 		if SelfTargeting then
 			Shine:NotifyCommandError( Client, "You cannot target yourself with this command." )
 		else
-			Shine:NotifyCommandError( Client, "No matching player was found." )
+			Shine:NotifyCommandError( Client, "No player matching '%s' was found.", true, ArgString )
 		end
 	end,
 	Validate = function( Client, Arg, ParsedArg )
@@ -483,13 +483,13 @@ do
 			return Clients
 		end,
 		Help = "players",
-		OnFailedMatch = function( Client, Arg )
-			Shine:NotifyCommandError( Client, "No matching players were found." )
+		OnFailedMatch = function( Client, Arg, Extra, ArgString )
+			Shine:NotifyCommandError( Client, "No players matching '%s' were found.", true, ArgString )
 		end,
-		Validate = function( Client, Arg, ParsedArg )
+		Validate = function( Client, Arg, ParsedArg, ArgString )
 			if not ParsedArg then return true end
 			if #ParsedArg == 0 then
-				Shine:NotifyCommandError( Client, "No matching players were found." )
+				Shine:NotifyCommandError( Client, "No players matching '%s' were found.", true, ArgString )
 
 				return false
 			end

--- a/lua/shine/core/server/commands.lua
+++ b/lua/shine/core/server/commands.lua
@@ -579,6 +579,8 @@ local function MatchStringRestriction( ParsedArg, Restriction )
 		return ParsedArg == Restriction
 	end
 
+	-- Escape any patterns in the string.
+	Restriction = StringGSub( Restriction, "([%%%[%]%^%$%(%)%.%+%-%?])", "%%%1" )
 	Restriction = StringGSub( Restriction, "*", "(.-)" ).."$"
 
 	return StringFind( ParsedArg, Restriction ) ~= nil

--- a/lua/shine/core/server/commands.lua
+++ b/lua/shine/core/server/commands.lua
@@ -561,15 +561,6 @@ ParamTypes.steamid = {
 
 local ParseParameter = Shine.CommandUtil.ParseParameter
 
-local Traceback = debug.traceback
-
-local function OnError( Err )
-	local Trace = Traceback()
-
-	Shine:DebugPrint( "Error: %s.\n%s", true, Err, Trace )
-	Shine:AddErrorReport( StringFormat( "Command error: %s.", Err ), Trace )
-end
-
 local function MatchStringRestriction( ParsedArg, Restriction )
 	if not StringFind( Restriction, "*" ) then
 		return ParsedArg == Restriction
@@ -738,6 +729,8 @@ function Shine.CommandUtil:GetCommandArgs( Client, ConCommand, FromChat, Command
 
 	return ParsedArgs
 end
+
+local OnError = Shine.BuildErrorHandler( "Command error" )
 
 --[[
 	Executes a Shine command. Should not be called directly.

--- a/lua/shine/core/server/config.lua
+++ b/lua/shine/core/server/config.lua
@@ -547,5 +547,5 @@ end
 Shine:LoadExtensionConfigs()
 
 if not Shine.Error then
-	Shine.Hook.Call( "PostloadConfig" )
+	Shine.Hook.CallOnce( "PostloadConfig" )
 end

--- a/lua/shine/core/shared/autocomplete.lua
+++ b/lua/shine/core/shared/autocomplete.lua
@@ -122,6 +122,7 @@ Client.HookNetworkMessage( "Shine_AutoCompleteResponse", function( Message )
 	end
 
 	Request.Callback( Request.Results )
+	Requests[ Message.RequestID ] = nil
 end )
 
 Client.HookNetworkMessage( "Shine_AutoCompleteFailed", function( Message )
@@ -129,4 +130,5 @@ Client.HookNetworkMessage( "Shine_AutoCompleteFailed", function( Message )
 	if not Request then return end
 
 	Request.Callback( Request.Results )
+	Requests[ Message.RequestID ] = nil
 end )

--- a/lua/shine/core/shared/base_plugin.lua
+++ b/lua/shine/core/shared/base_plugin.lua
@@ -203,7 +203,7 @@ do
 			if IsType( Pos, "string" ) then
 				self:GenerateDefaultConfig( true )
 			else
-				Print( "Invalid JSON for %s plugin config, loading default...", self.__Name )
+				Print( "Invalid JSON for %s plugin config. Error: %s. Loading default...", self.__Name, Err )
 
 				self.Config = self.DefaultConfig
 			end

--- a/lua/shine/core/shared/chat.lua
+++ b/lua/shine/core/shared/chat.lua
@@ -4,66 +4,52 @@
 
 local StringFormat = string.format
 
-local StringMessage = StringFormat( "string (%i)", kMaxChatLength * 4 + 1 )
+do
+	local StringMessage = StringFormat( "string (%i)", kMaxChatLength * 4 + 1 )
 
-local ChatMessage = {
-	Prefix = "string (25)",
-	Name = StringFormat( "string (%i)", kMaxNameLength ),
-	TeamNumber = StringFormat( "integer (%i to %i)", kTeamInvalid, kSpectatorIndex ),
-	TeamType = StringFormat( "integer (%i to %i)", kNeutralTeamType, kAlienTeamType ),
-	Message = StringMessage
-}
-
-function Shine.BuildChatMessage( Prefix, Name, TeamNumber, TeamType, Message )
-	return {
-		Prefix = Prefix,
-		Name = Name,
-		TeamNumber = TeamNumber,
-		TeamType = TeamType,
-		Message = Message
+	local ChatMessage = {
+		Prefix = "string (25)",
+		Name = StringFormat( "string (%i)", kMaxNameLength ),
+		TeamNumber = StringFormat( "integer (%i to %i)", kTeamInvalid, kSpectatorIndex ),
+		TeamType = StringFormat( "integer (%i to %i)", kNeutralTeamType, kAlienTeamType ),
+		Message = StringMessage
 	}
+
+	function Shine.BuildChatMessage( Prefix, Name, TeamNumber, TeamType, Message )
+		return {
+			Prefix = Prefix,
+			Name = Name,
+			TeamNumber = TeamNumber,
+			TeamType = TeamType,
+			Message = Message
+		}
+	end
+
+	Shared.RegisterNetworkMessage( "Shine_Chat", ChatMessage )
+
+	local ColourMessage = {
+		RP = "integer (0 to 255)",
+		GP = "integer (0 to 255)",
+		BP = "integer (0 to 255)",
+		Prefix = StringMessage,
+		R = "integer (0 to 255)",
+		G = "integer (0 to 255)",
+		B = "integer (0 to 255)",
+		Message = StringMessage
+	}
+
+	Shared.RegisterNetworkMessage( "Shine_ChatCol", ColourMessage )
 end
-
-Shared.RegisterNetworkMessage( "Shine_Chat", ChatMessage )
-
-local ColourMessage = {
-	RP = "integer (0 to 255)",
-	GP = "integer (0 to 255)",
-	BP = "integer (0 to 255)",
-	Prefix = StringMessage,
-	R = "integer (0 to 255)",
-	G = "integer (0 to 255)",
-	B = "integer (0 to 255)",
-	Message = StringMessage
-}
-
-Shared.RegisterNetworkMessage( "Shine_ChatCol", ColourMessage )
 
 if Server then return end
 
+local BitLShift = bit.lshift
 local IsType = Shine.IsType
 local tonumber = tonumber
 local tostring = tostring
 
 local function RGBToHex( R, G, B )
-	return tonumber( StringFormat( "0x%.2X%.2X%.2X", R, G, B ) )
-end
-
---Oh boy this is awful, but I'd rather catch the error than have pretty code.
-local function CheckArgs( RP, GP, BP, PreHex, Prefix, R, G, B, Message )
-	if not IsType( PreHex, "number" ) or not IsType( Prefix, "string" )
-	or not IsType( R, "number" ) or not IsType( G, "number" )
-	or not IsType( B, "number" ) or not IsType( Message, "string" ) then
-		Shine:AddErrorReport( "Shine.AddChatText did not receive correct values.",
-			"RGBP: %s %s %s. PreHex: %s. Prefix: '%s'. Message: '%s'. RGB: %s %s %s", true,
-			tostring( RP ), tostring( GP ), tostring( BP ),
-			tostring( PreHex ), tostring( Prefix ), tostring( Message ),
-			tostring( R ), tostring( G ), tostring( B ) )
-
-		return false
-	end
-
-	return true
+	return BitLShift( R, 16 ) + BitLShift( G, 8 ) + B
 end
 
 local function AddChatMessage( Player, ChatMessages, PreHex, Prefix, Col, Message )
@@ -82,17 +68,29 @@ local function AddChatMessage( Player, ChatMessages, PreHex, Prefix, Col, Messag
 	StartSoundEffect( Player:GetChatSound() )
 end
 
-local ChatMessages
+local GUIChatMessages
 local function GetChatMessages()
-	return ChatMessages
+	return GUIChatMessages
 end
 
 local function SetupChatMessages()
 	if not GetChatMessages() then
 		Shine.JoinUpValues( ChatUI_GetMessages, GetChatMessages, {
-			chatMessages = "ChatMessages"
+			chatMessages = "GUIChatMessages"
 		} )
 	end
+end
+
+local function SetupAndGetChatMessages()
+	SetupChatMessages()
+
+	local ChatMessages = GetChatMessages()
+	if not ChatMessages then
+		Shared.Message( "[Shine] Unable to retrieve message table!" )
+		return nil
+	end
+
+	return ChatMessages
 end
 
 --[[
@@ -105,25 +103,14 @@ end
 		Message - Message text.
 ]]
 function Shine.AddChatText( RP, GP, BP, Prefix, R, G, B, Message )
-	SetupChatMessages()
-
-	local ChatMessages = GetChatMessages()
-	if not ChatMessages then
-		Shared.Message( "[Shine] Unable to retrieve message table!" )
-
-		return
-	end
+	local ChatMessages = SetupAndGetChatMessages()
+	if not ChatMessages then return end
 
 	local Player = Client.GetLocalPlayer()
 	if not Player then return end
 
-	local PreHex = RGBToHex( RP, GP, BP )
-
-	if not CheckArgs( RP, GP, BP, PreHex, Prefix, R, G, B, Message ) then
-		return
-	end
-
-	AddChatMessage( Player, ChatMessages, PreHex, Prefix, Color( R, G, B, 1 ), Message )
+	AddChatMessage( Player, ChatMessages, RGBToHex( RP, GP, BP ),
+		Prefix, Color( R, G, B, 1 ), Message )
 end
 
 --Displays a coloured message.
@@ -140,14 +127,8 @@ end )
 
 --Deprecated chat message. Only useful for PMs/Admin say messages.
 Client.HookNetworkMessage( "Shine_Chat", function( Message )
-	SetupChatMessages()
-
-	local ChatMessages = GetChatMessages()
-
-	if not ChatMessages then
-		Shared.Message( "[Shine] Unable to retrieve message table!" )
-		return
-	end
+	local ChatMessages = SetupAndGetChatMessages()
+	if not ChatMessages then return end
 
 	local Player = Client.GetLocalPlayer()
 	if not Player then return end
@@ -158,10 +139,6 @@ Client.HookNetworkMessage( "Shine_Chat", function( Message )
 	local Name = Message.Name
 	local String = Message.Message
 	local TeamCol = kChatTextColor[ Message.TeamType ] or Color( 1, 1, 1, 1 )
-
-	if not CheckArgs( nil, nil, nil, PreHex, Prefix, TeamCol.r, TeamCol.g, TeamCol.b, String ) then
-		return
-	end
 
 	--This shows just the message, no name, no prefix (no longer used as it doesn't work).
 	if Prefix == "" and Name == "" then

--- a/lua/shine/core/shared/commands.lua
+++ b/lua/shine/core/shared/commands.lua
@@ -168,6 +168,66 @@ function Shine.CommandUtil.BuildLineFromArgs( Args, i )
 	return TableConcat( Args, " ", i )
 end
 
+do
+	local StringEndsWith = string.EndsWith
+	local StringGSub = string.gsub
+	local StringLen = string.len
+	local StringMatch = string.match
+	local StringStartsWith = string.StartsWith
+	local StringSub = string.sub
+
+	local function RemoveQuotes( String )
+		-- If the quote wasn't terminated, go to the end of the string.
+		local EndIndex = StringLen( String ) - ( StringEndsWith( String, "\"" ) and 1 or 0 )
+		String = StringSub( String, 2, EndIndex )
+		return StringGSub( String, "\\\"", "\"" )
+	end
+
+	local function GetArgBetweenQuotes( Args, StartIndex, EndIndex )
+		-- Add all text between the quotes, not including the quotes.
+		local String = TableConcat( Args, " ", StartIndex, EndIndex )
+		return RemoveQuotes( String )
+	end
+
+	--[[
+		Takes arguments bounded by quotes as a single argument.
+	]]
+	function Shine.CommandUtil.AdjustArguments( Args )
+		local RealArgs = {}
+		local Count = 0
+		local StartIndex
+
+		for i = 1, #Args do
+			local Arg = Args[ i ]
+
+			if StartIndex then
+				if StringMatch( Arg, "[^\\]\"$" ) then
+					Count = Count + 1
+					RealArgs[ Count ] = GetArgBetweenQuotes( Args, StartIndex, i )
+					StartIndex = nil
+				end
+			elseif StringStartsWith( Arg, "\"" ) then
+				if StringMatch( Arg, "[^\\]\"$" ) then
+					Count = Count + 1
+					RealArgs[ Count ] = RemoveQuotes( Arg )
+				else
+					StartIndex = i
+				end
+			else
+				Count = Count + 1
+				RealArgs[ Count ] = Arg
+			end
+		end
+
+		if StartIndex then
+			Count = Count + 1
+			RealArgs[ Count ] = GetArgBetweenQuotes( Args, StartIndex, #Args )
+		end
+
+		return RealArgs
+	end
+end
+
 if Server then return end
 
 Client.HookNetworkMessage( "Shine_Command", function( Message )

--- a/lua/shine/core/shared/commands.lua
+++ b/lua/shine/core/shared/commands.lua
@@ -144,7 +144,7 @@ function Shine.CommandUtil:GetCommandArg( Client, ConCommand, ArgString, CurArg,
 	-- Specifically check for nil (boolean argument could be false).
 	if Result == nil and not CurArg.Optional then
 		if ParamType.OnFailedMatch then
-			ParamType.OnFailedMatch( Client, CurArg, Extra )
+			ParamType.OnFailedMatch( Client, CurArg, Extra, ArgString )
 		else
 			self:OnFailedMatch( Client, ConCommand, ArgString, CurArg, i )
 		end
@@ -159,7 +159,7 @@ function Shine.CommandUtil:GetCommandArg( Client, ConCommand, ArgString, CurArg,
 		Result = NewResult
 	end
 
-	if ParamType.Validate and not ParamType.Validate( Client, CurArg, Result ) then return end
+	if ParamType.Validate and not ParamType.Validate( Client, CurArg, Result, ArgString ) then return end
 
 	return true, Result
 end

--- a/lua/shine/core/shared/config.lua
+++ b/lua/shine/core/shared/config.lua
@@ -42,7 +42,7 @@ Shine.WriteFile = WriteFile
 function Shine.LoadJSONFile( Path )
 	local Data, Err = ReadFile( Path )
 	if not Data then
-		return nil, Err
+		return false, Err
 	end
 
 	return Decode( Data )

--- a/lua/shine/core/shared/extensions.lua
+++ b/lua/shine/core/shared/extensions.lua
@@ -294,15 +294,7 @@ function Shine:EnableExtension( Name, DontLoadConfig )
 	return true
 end
 
-local function OnCleanupError( Err )
-	local Trace = Traceback()
-
-	local Locals = ToDebugString( Shine.GetLocals( 1 ) )
-
-	Shine:DebugPrint( "Plugin cleanup error: %s.\n%s", true, Err, Trace )
-	Shine:AddErrorReport( StringFormat( "Plugin cleanup error: %s.", Err ),
-		"%s\nLocals:\n%s", true, Trace, Locals )
-end
+local OnCleanupError = Shine.BuildErrorHandler( "Plugin cleanup error" )
 
 function Shine:UnloadExtension( Name )
 	local Plugin = self.Plugins[ Name ]

--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -2,6 +2,8 @@
 	Shine internal hook system.
 ]]
 
+local Shine = Shine
+
 local Clamp = math.Clamp
 local DebugSetUpValue = debug.setupvalue
 local Floor = math.floor
@@ -13,7 +15,8 @@ local StringFormat = string.format
 
 local Map = Shine.Map
 
-Shine.Hook = {}
+local Hook = {}
+Shine.Hook = Hook
 
 local Hooks = {}
 local ReservedNames = {}
@@ -33,7 +36,7 @@ local function Remove( Event, Index )
 	EventHooks[ Priority ]:Remove( Index )
 	ReservedNames[ Event ][ Index ] = nil
 end
-Shine.Hook.Remove = Remove
+Hook.Remove = Remove
 
 --[[
 	Adds a function to Shine's internal hook system.
@@ -58,7 +61,7 @@ local function Add( Event, Index, Function, Priority )
 	Hooks[ Event ][ Priority ]:Add( Index, Function )
 	ReservedNames[ Event ][ Index ] = Priority
 end
-Shine.Hook.Add = Add
+Hook.Add = Add
 
 local ToDebugString = table.ToDebugString
 local Traceback = debug.traceback
@@ -73,28 +76,24 @@ local function OnError( Err )
 		"%s\nLocals:\n%s", true, Trace, Locals )
 end
 
-local RemovalExceptions = {
-	PlayerSay = { CommandExecute = true }
-}
-
-local function CallHooks( HookMap, ProtectedHooks, Event, ... )
+local function CallHooks( HookMap, Event, ... )
 	for Index, Func in HookMap:Iterate() do
 		local Success, a, b, c, d, e, f = xpcall( Func, OnError, ... )
 
 		if not Success then
-			if not ( ProtectedHooks and ProtectedHooks[ Index ] ) then
-				Shine:DebugPrint( "[Hook Error] %s hook '%s' failed, removing.",
-					true, Event, Index )
+			Shine:DebugPrint( "[Hook Error] %s hook '%s' failed, removing.",
+				true, Event, Index )
 
-				Remove( Event, Index )
-			else
-				Shine:DebugPrint( "[Hook Error] %s hook '%s' failed.",
-					true, Event, Index )
-			end
+			Remove( Event, Index )
 		else
 			if a ~= nil then return a, b, c, d, e, f end
 		end
 	end
+end
+
+-- Placeholder until the extensions file is loaded.
+if not Shine.CallExtensionEvent then
+	Shine.CallExtensionEvent = function() end
 end
 
 --[[
@@ -102,48 +101,23 @@ end
 	Inputs: Event name, arguments to pass.
 ]]
 local function Call( Event, ... )
-	if Shine.Hook.Disabled then return end
-
-	local Plugins = Shine.Plugins
-	local AllPlugins = Shine.AllPluginsArray
+	if Hook.Disabled then return end
 
 	local Hooked = Hooks[ Event ]
-	local MaxPriority = Hooked and Hooked[ -20 ]
-	local ProtectedHooks = RemovalExceptions[ Event ]
 
-	--Call max priority hooks BEFORE plugins.
-	if MaxPriority then
-		local a, b, c, d, e, f = CallHooks( MaxPriority, ProtectedHooks, Event, ... )
-		if a ~= nil then return a, b, c, d, e, f end
+	do
+		local MaxPriority = Hooked and Hooked[ -20 ]
+		-- Call max priority hooks BEFORE plugins.
+		if MaxPriority then
+			local a, b, c, d, e, f = CallHooks( MaxPriority, Event, ... )
+			if a ~= nil then return a, b, c, d, e, f end
+		end
 	end
 
-	if Plugins and AllPlugins then
-		--Automatically call the plugin hooks.
-		for i = 1, #AllPlugins do
-			local Plugin = AllPlugins[ i ]
-			local Table = Plugins[ Plugin ]
-
-			if Table and Table.Enabled and IsType( Table[ Event ], "function" ) then
-				local Success, a, b, c, d, e, f = xpcall( Table[ Event ], OnError, Table, ... )
-
-				if not Success then
-					Table.__HookErrors = ( Table.__HookErrors or 0 ) + 1
-					Shine:DebugPrint( "[Hook Error] %s hook failed from plugin '%s'. Error count: %i.",
-						true, Event, Plugin, Table.__HookErrors )
-
-					if Table.__HookErrors >= 10 then
-						Shine:DebugPrint( "Unloading plugin '%s' for too many hook errors (%i).",
-							true, Plugin, Table.__HookErrors )
-
-						Table.__HookErrors = 0
-
-						Shine:UnloadExtension( Plugin )
-					end
-				else
-					if a ~= nil then return a, b, c, d, e, f end
-				end
-			end
-		end
+	-- Now call plugins (when loaded).
+	do
+		local a, b, c, d, e, f = Shine:CallExtensionEvent( Event, OnError, ... )
+		if a ~= nil then return a, b, c, d, e, f end
 	end
 
 	if not Hooked then return end
@@ -152,14 +126,24 @@ local function Call( Event, ... )
 		local HookMap = Hooked[ i ]
 
 		if HookMap then
-			local a, b, c, d, e, f = CallHooks( HookMap, ProtectedHooks, Event, ... )
+			local a, b, c, d, e, f = CallHooks( HookMap, Event, ... )
 			if a ~= nil then return a, b, c, d, e, f end
 		end
 	end
 end
-Shine.Hook.Call = Call
+Hook.Call = Call
 
-function Shine.Hook.GetTable()
+local function CallOnce( Event, ... )
+	local a, b, c, d, e, f = Call( Event, ... )
+
+	Hooks[ Event ] = nil
+	ReservedNames[ Event ] = nil
+
+	return a, b, c, d, e, f
+end
+Hook.CallOnce = CallOnce
+
+function Hook.GetTable()
 	return Hooks
 end
 
@@ -169,7 +153,7 @@ end
 	Inputs: Class name, method name, replacement function.
 	Output: Original function.
 ]]
-local function AddClassHook( Class, Method, ReplacementFunc )
+local function AddClassHook( ReplacementFunc, Class, Method )
 	local OldFunc
 
 	OldFunc = ReplaceMethod( Class, Method, function( ... )
@@ -185,7 +169,7 @@ end
 	Inputs: Global function name, replacement function.
 	Output: Original function.
 ]]
-local function AddGlobalHook( FuncName, ReplacementFunc )
+local function AddGlobalHook( ReplacementFunc, FuncName )
 	local Path = StringExplode( FuncName, "%." )
 
 	local Func = _G
@@ -211,7 +195,7 @@ local function AddGlobalHook( FuncName, ReplacementFunc )
 end
 
 --[[
-	All available preset hooking methods for classes:
+	All available preset hooking methods:
 
 	- Replace: Replaces the function with a Shine hook call.
 
@@ -231,33 +215,31 @@ end
 	- Halt: Calls the given Shine hook. If it returns a non-nil value,
 	the method is stopped and returns nothing. Otherwise the original method is returned.
 ]]
-local ClassHookModes = {
-	Replace = function( Class, Method, HookName )
-		AddClassHook( Class, Method, function( OldFunc, ... )
+local HookModes = {
+	Replace = function( Adder, HookName, ... )
+		Adder( function( OldFunc, ... )
 			return Call( HookName, ... )
-		end )
+		end, ... )
 	end,
-
-	PassivePre = function( Class, Method, HookName )
-		AddClassHook( Class, Method, function( OldFunc, ... )
+	PassivePre = function( Adder, HookName, ... )
+		Adder( function( OldFunc, ... )
 			Call( HookName, ... )
 
 			return OldFunc( ... )
-		end )
+		end, ... )
 	end,
-
-	PassivePost = function( Class, Method, HookName )
-		AddClassHook( Class, Method, function( OldFunc, ... )
+	PassivePost = function( Adder, HookName, ... )
+		Adder( function( OldFunc, ... )
 			local a, b, c, d, e, f = OldFunc( ... )
 
 			Call( HookName, ... )
 
 			return a, b, c, d, e, f
-		end )
+		end, ... )
 	end,
 
-	ActivePre = function( Class, Method, HookName )
-		AddClassHook( Class, Method, function( OldFunc, ... )
+	ActivePre = function( Adder, HookName, ... )
+		Adder( function( OldFunc, ... )
 			local a, b, c, d, e, f = Call( HookName, ... )
 
 			if a ~= nil then
@@ -265,11 +247,11 @@ local ClassHookModes = {
 			end
 
 			return OldFunc( ... )
-		end )
+		end, ... )
 	end,
 
-	ActivePost = function( Class, Method, HookName )
-		AddClassHook( Class, Method, function( OldFunc, ... )
+	ActivePost = function( Adder, HookName, ... )
+		Adder( function( OldFunc, ... )
 			local a, b, c, d, e, f = OldFunc( ... )
 
 			local g, h, i, j, k, l = Call( HookName, ... )
@@ -279,81 +261,17 @@ local ClassHookModes = {
 			end
 
 			return a, b, c, d, e, f
-		end )
+		end, ... )
 	end,
 
-	Halt = function( Class, Method, HookName )
-		AddClassHook( Class, Method, function( OldFunc, ... )
+	Halt = function( Adder, HookName, ... )
+		Adder( function( OldFunc, ... )
 			local Ret = Call( HookName, ... )
 
 			if Ret ~= nil then return end
 
 			return OldFunc( ... )
-		end )
-	end
-}
-
---All available preset hooking methods for global functions.
---Explanations are same as for class hooks.
-local GlobalHookModes = {
-	Replace = function( FuncName, HookName )
-		AddGlobalHook( FuncName, function( OldFunc, ... )
-			return Call( HookName, ... )
-		end )
-	end,
-
-	PassivePre = function( FuncName, HookName )
-		AddGlobalHook( FuncName, function( OldFunc, ... )
-			Call( HookName, ... )
-
-			return OldFunc( ... )
-		end )
-	end,
-
-	PassivePost = function( FuncName, HookName )
-		AddGlobalHook( FuncName, function( OldFunc, ... )
-			local a, b, c, d, e, f = OldFunc( ... )
-
-			Call( HookName, ... )
-
-			return a, b, c, d, e, f
-		end )
-	end,
-
-	ActivePre = function( FuncName, HookName )
-		AddGlobalHook( FuncName, function( OldFunc, ... )
-			local a, b, c, d, e, f = Call( HookName, ... )
-
-			if a ~= nil then
-				return a, b, c, d, e, f
-			end
-
-			return OldFunc( ... )
-		end )
-	end,
-
-	ActivePost = function( FuncName, HookName )
-		AddGlobalHook( FuncName, function( OldFunc, ... )
-			local a, b, c, d, e, f = OldFunc( ... )
-
-			local g, h, i, j, k, l = Call( HookName, ... )
-
-			if g ~= nil then
-				return g, h, i, j, k, l
-			end
-
-			return a, b, c, d, e, f
-		end )
-	end,
-
-	Halt = function( FuncName, HookName )
-		AddGlobalHook( FuncName, function( OldFunc, ... )
-			local Ret = Call( HookName, ... )
-
-			if Ret ~= nil then return end
-
-			return OldFunc( ... )
-		end )
+		end, ... )
 	end
 }
 
@@ -368,7 +286,7 @@ local GlobalHookModes = {
 
 	Output: Original function we have now replaced.
 
-	Mode can either be a string from the ClassHookModes table above,
+	Mode can either be a string from the HookModes table above,
 	or it can be a custom hook function.
 
 	The function will be passed the original function, then the arguments it was run with.
@@ -378,13 +296,12 @@ local function SetupClassHook( Class, Method, HookName, Mode )
 		return AddClassHook( Class, Method, Mode )
 	end
 
-	local HookFunc = ClassHookModes[ Mode ]
-
+	local HookFunc = HookModes[ Mode ]
 	if not HookFunc then return nil end
 
-	return HookFunc( Class, Method, HookName )
+	return HookFunc( AddClassHook, HookName, Class, Method )
 end
-Shine.Hook.SetupClassHook = SetupClassHook
+Hook.SetupClassHook = SetupClassHook
 
 --[[
 	Sets up a Shine hook for a global function.
@@ -395,7 +312,7 @@ Shine.Hook.SetupClassHook = SetupClassHook
 
 	Output: Original function we have now replaced.
 
-	Mode can either be a string from the GlobalHookModes table above,
+	Mode can either be a string from the HookModes table above,
 	or it can be a custom hook function.
 
 	The function will be passed the original function, then the arguments it was run with.
@@ -405,13 +322,12 @@ local function SetupGlobalHook( FuncName, HookName, Mode )
 		return AddGlobalHook( FuncName, Mode )
 	end
 
-	local HookFunc = GlobalHookModes[ Mode ]
-
+	local HookFunc = HookModes[ Mode ]
 	if not HookFunc then return nil end
 
-	return HookFunc( FuncName, HookName )
+	return HookFunc( AddGlobalHook, HookName, FuncName )
 end
-Shine.Hook.SetupGlobalHook = SetupGlobalHook
+Hook.SetupGlobalHook = SetupGlobalHook
 
 --[[
 	Replaces a function upvalue in the upvalues of TargetFunc.
@@ -427,7 +343,7 @@ Shine.Hook.SetupGlobalHook = SetupGlobalHook
 	Output:
 		The original function that has now been replaced.
 ]]
-function Shine.Hook.ReplaceLocalFunction( TargetFunc, UpvalueName, Replacement, DifferingValues, Recursive )
+function Hook.ReplaceLocalFunction( TargetFunc, UpvalueName, Replacement, DifferingValues, Recursive )
 	local Value, i, Func = Shine.GetUpValue( TargetFunc, UpvalueName )
 
 	if not Value or not IsType( Value, "function" ) then return end
@@ -475,26 +391,20 @@ do
 			Shine.SetUpValueByValue( Script.Load, ScriptLoad, OldScriptLoad, true )
 		end
 
-		Call "MapPreLoad"
+		CallOnce "MapPreLoad"
 	end
 	Event.Hook( "MapPreLoad", MapPreLoad )
 
 	local function MapPostLoad()
-		Call "MapPostLoad"
+		CallOnce "MapPostLoad"
 	end
 	Event.Hook( "MapPostLoad", MapPostLoad )
-end
-
-local function CallOnFirstThink()
-	Call( "OnFirstThink" )
-	Hooks.OnFirstThink = nil
-	ReservedNames.OnFirstThink = nil
 end
 
 --Client specific hooks.
 if Client then
 	local function LoadComplete()
-		Call "OnMapLoad"
+		CallOnce "OnMapLoad"
 	end
 	Event.Hook( "LoadComplete", LoadComplete )
 
@@ -541,7 +451,7 @@ if Client then
 	end, -20 )
 
 	Add( "Think", "ClientOnFirstThink", function()
-		CallOnFirstThink()
+		CallOnce( "OnFirstThink" )
 		Remove( "Think", "ClientOnFirstThink" )
 	end )
 
@@ -631,6 +541,8 @@ end
 	Here we replace class methods in order to hook into certain important events.
 ]]
 Add( "Think", "ReplaceMethods", function()
+	Remove( "Think", "ReplaceMethods" )
+
 	local Gamerules = "NS2Gamerules"
 
 	--For the factions mod.
@@ -766,6 +678,5 @@ Add( "Think", "ReplaceMethods", function()
 		end
 	end
 
-	Remove( "Think", "ReplaceMethods" )
-	CallOnFirstThink()
+	CallOnce( "OnFirstThink" )
 end )

--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -63,18 +63,7 @@ local function Add( Event, Index, Function, Priority )
 end
 Hook.Add = Add
 
-local ToDebugString = table.ToDebugString
-local Traceback = debug.traceback
-
-local function OnError( Err )
-	local Trace = Traceback()
-
-	local Locals = ToDebugString( Shine.GetLocals( 1 ) )
-
-	Shine:DebugPrint( "Error: %s.\n%s", true, Err, Trace )
-	Shine:AddErrorReport( StringFormat( "Hook error: %s.", Err ),
-		"%s\nLocals:\n%s", true, Trace, Locals )
-end
+local OnError = Shine.BuildErrorHandler( "Hook error" )
 
 local function CallHooks( HookMap, Event, ... )
 	for Index, Func in HookMap:Iterate() do

--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -282,7 +282,7 @@ local HookModes = {
 ]]
 local function SetupClassHook( Class, Method, HookName, Mode )
 	if IsType( Mode, "function" ) then
-		return AddClassHook( Class, Method, Mode )
+		return AddClassHook( Mode, Class, Method )
 	end
 
 	local HookFunc = HookModes[ Mode ]
@@ -308,7 +308,7 @@ Hook.SetupClassHook = SetupClassHook
 ]]
 local function SetupGlobalHook( FuncName, HookName, Mode )
 	if IsType( Mode, "function" ) then
-		return AddGlobalHook( FuncName, Mode )
+		return AddGlobalHook( Mode, FuncName )
 	end
 
 	local HookFunc = HookModes[ Mode ]

--- a/lua/shine/core/shared/logging.lua
+++ b/lua/shine/core/shared/logging.lua
@@ -1,4 +1,6 @@
-local StringFormat = string.format
+--[[
+	Error report handling.
+]]
 
 local DebugFile = "config://shine/DebugLog.txt"
 
@@ -10,6 +12,7 @@ local URL = "http://5.39.89.152/shine/errorreport.php"
 local OS = jit and jit.os or "Unknown"
 
 local next = next
+local StringFormat = string.format
 local TableConcat = table.concat
 local TableEmpty = table.Empty
 local TableInsert = table.insert

--- a/lua/shine/extensions/ban/server.lua
+++ b/lua/shine/extensions/ban/server.lua
@@ -117,21 +117,24 @@ end
 function Plugin:LoadBansFromWeb()
 	local function BansResponse( Response )
 		if not Response then
-			Shine:Print( "[Error] Loading bans from the web failed. Check the config to make sure the URL is correct." )
+			self:Print( "[Error] Loading bans from the web failed. Check the config to make sure the URL is correct." )
 
 			return
 		end
 
-		local BansData = Decode( Response ) or {}
+		local BansData, Pos, Err = Decode( Response )
+		if not IsType( BansData, "table" ) then
+			self:Print( "[Error] Loading bans from the web received invalid JSON. Error: %s", true, Err )
+			return
+		end
+
 		local Edited
-		if IsType( BansData, "table" ) then
-			if BansData.Banned then
-				Edited = true
-				self.Config.Banned = BansData.Banned
-			elseif BansData[ 1 ] and BanData[ 1 ].id then
-				Edited = true
-				self.Config.Banned = self:NS2ToShine( BansData )
-			end
+		if BansData.Banned then
+			Edited = true
+			self.Config.Banned = BansData.Banned
+		elseif BansData[ 1 ] and BanData[ 1 ].id then
+			Edited = true
+			self.Config.Banned = self:NS2ToShine( BansData )
 		end
 
 		--Cache the data in case we get a bad response later.
@@ -327,9 +330,9 @@ function Plugin:SendHTTPRequest( ID, PostParams, Operation, Revert )
 				return
 			end
 
-			local Decoded = Decode( Data )
+			local Decoded, Pos, Err = Decode( Data )
 			if not Decoded then
-				self:Print( "Received invalid JSON for %s of %s.", true, Operation, ID )
+				self:Print( "Received invalid JSON for %s of %s. Error: %s", true, Operation, ID, Err )
 				return
 			end
 

--- a/lua/shine/extensions/ban/server.lua
+++ b/lua/shine/extensions/ban/server.lua
@@ -139,7 +139,7 @@ function Plugin:LoadBansFromWeb()
 		end
 
 		--Cache the data in case we get a bad response later.
-		if Edited then
+		if Edited and not self:CheckBans() then
 			self:SaveConfig()
 		end
 		self:GenerateNetworkData()
@@ -336,6 +336,8 @@ function Plugin:CheckBans()
 	if Edited then
 		self:SaveConfig()
 	end
+
+	return Edited
 end
 
 function Plugin:SendHTTPRequest( ID, PostParams, Operation, Revert )

--- a/lua/shine/extensions/ban/server.lua
+++ b/lua/shine/extensions/ban/server.lua
@@ -239,7 +239,7 @@ end
 function Plugin:NS2ToShine( Data )
 	for i = 1, #Data do
 		local Table = Data[ i ]
-		local SteamID = tostring( Table.id )
+		local SteamID = Table.id and tostring( Table.id )
 
 		if SteamID then
 			Data[ SteamID ] = NS2EntryToShineEntry( Table )

--- a/lua/shine/extensions/basecommands/shared.lua
+++ b/lua/shine/extensions/basecommands/shared.lua
@@ -262,7 +262,7 @@ function Plugin:SetupAdminMenuCommands()
 			end
 
 			if not Shine.AdminMenu.RestoreListState( List, Data ) then
-				List:SortRows( 1 )
+				List:SortRows( 2, nil, true )
 			end
 
 			local ButtonSize = Vector( 128, 32, 0 )
@@ -346,33 +346,27 @@ function Plugin:SetupAdminMenuCommands()
 				end
 			end
 
-			Hook.Add( "OnPluginLoad", "AdminMenu_OnPluginLoad", function( Name, Plugin, Shared )
+			local function UpdateRow( Name, State )
 				local Row = self.PluginRows[ Name ]
 
 				if SGUI.IsValid( Row ) then
-					Row:SetColumnText( 2, "Enabled" )
+					Row:SetColumnText( 2, State )
 					if Row == List:GetSelectedRow() then
 						List:OnRowSelected( nil, Row )
 					end
 				end
+			end
+
+			Hook.Add( "OnPluginLoad", "AdminMenu_OnPluginLoad", function( Name, Plugin, Shared )
+				UpdateRow( Name, "Enabled" )
 			end )
 
 			Hook.Add( "OnPluginUnload", "AdminMenu_OnPluginUnload", function( Name, Plugin, Shared )
-				local Row = self.PluginRows[ Name ]
-
-				if SGUI.IsValid( Row ) then
-					Row:SetColumnText( 2, "Disabled" )
-					if Row == List:GetSelectedRow() then
-						List:OnRowSelected( nil, Row )
-					end
-				end
+				UpdateRow( Name, "Disabled" )
 			end )
 		end,
 
 		OnCleanup = function( Panel )
-			local SortColumn = self.PluginList.SortedColumn
-			local Descending = self.PluginList.Descending
-
 			TableEmpty( self.PluginRows )
 
 			local PluginList = self.PluginList

--- a/lua/shine/extensions/basecommands/shared.lua
+++ b/lua/shine/extensions/basecommands/shared.lua
@@ -246,6 +246,7 @@ function Plugin:SetupAdminMenuCommands()
 			List:SetSpacing( 0.7, 0.3 )
 			List:SetSize( Vector( 640, 512, 0 ) )
 			List.ScrollPos = Vector( 0, 32, 0 )
+			List:SetSecondarySortColumn( 2, 1 )
 
 			self.PluginList = List
 			self.PluginRows = self.PluginRows or {}

--- a/lua/shine/extensions/chatbox/client.lua
+++ b/lua/shine/extensions/chatbox/client.lua
@@ -514,7 +514,7 @@ function Plugin:CreateChatbox()
 	end
 
 	function SettingsButton:DoClick()
-		Plugin:OpenSettings( Border, UIScale, ScalarScale )
+		return Plugin:OpenSettings( Border, UIScale, ScalarScale )
 	end
 
 	SettingsButton:SetTooltip( "Opens/closes the chatbox settings." )
@@ -547,11 +547,11 @@ do
 				local CheckBox = SettingsPanel:Add( "CheckBox" )
 				CheckBox:SetupFromTable{
 					AutoSize = Size,
-					Checked = Checked,
 					Font = self:GetFont(),
 					Margin = Spacing( 0, 0, 0, Scaled( 4, self.UIScale.y ) )
 				}
 				CheckBox:AddLabel( Label )
+				CheckBox:SetChecked( Checked, true )
 
 				if self.TextScale ~= 1 then
 					CheckBox:SetTextScale( self.TextScale )
@@ -743,7 +743,7 @@ function Plugin:OpenSettings( MainPanel, UIScale, ScalarScale )
 	end
 
 	local SettingsButton = self.SettingsButton
-	if SettingsButton.Expanding then return end
+	if SettingsButton.Expanding then return false end
 
 	SettingsButton.Expanding = true
 
@@ -772,6 +772,8 @@ function Plugin:OpenSettings( MainPanel, UIScale, ScalarScale )
 
 		SettingsButton.Expanding = false
 	end )
+
+	return true
 end
 
 --Close on pressing escape (it's not hardcoded, unlike Source!)

--- a/lua/shine/extensions/commbans/server.lua
+++ b/lua/shine/extensions/commbans/server.lua
@@ -15,6 +15,9 @@ Plugin.Version = "1.0"
 Plugin.HasConfig = true
 Plugin.ConfigName = "CommBans.json"
 Plugin.PrintName = "CommBans"
+Plugin.NotifyPrefixColour = {
+	255, 50, 0
+}
 
 Plugin.DefaultConfig = {
 	Banned = {},
@@ -41,10 +44,6 @@ function Plugin:Initialise()
 	self.Enabled = true
 
 	return true
-end
-
-function Plugin:Notify( Player, String, Format, ... )
-	Shine:NotifyDualColour( Player, 255, 50, 0, "[CommBan]", 255, 255, 255, String, Format, ... )
 end
 
 --[[

--- a/lua/shine/extensions/mapvote/server.lua
+++ b/lua/shine/extensions/mapvote/server.lua
@@ -18,6 +18,10 @@ Plugin.Version = "1.6"
 
 Plugin.HasConfig = true
 Plugin.ConfigName = "MapVote.json"
+Plugin.PrintName = "Map Vote"
+Plugin.NotifyPrefixColour = {
+	255, 255, 0
+}
 
 Plugin.DefaultConfig = {
 	GetMapsFromMapCycle = true, --Get the valid votemaps directly from the mapcycle file.
@@ -225,10 +229,6 @@ function Plugin:OnFirstThink()
 			break
 		end
 	end
-end
-
-function Plugin:Notify( Player, Message, Format, ... )
-	Shine:NotifyDualColour( Player, 255, 255, 0, "[Map Vote]", 255, 255, 255, Message, Format, ... )
 end
 
 function Plugin:ForcePlayersIntoReadyRoom()

--- a/lua/shine/extensions/mapvote/shared.lua
+++ b/lua/shine/extensions/mapvote/shared.lua
@@ -94,39 +94,48 @@ local function SendMapVote( MapName )
 	return false
 end
 
-Shine.VoteMenu:AddPage( "MapVote", function( self )
-	local Maps = Plugin.Maps
-	if not Maps then
-		return
+do
+	local function ClosePageIfVoteFinished( self )
+		local Time = SharedTime()
+
+		if Plugin.EndTime < Time then
+			self:SetPage( "Main" )
+			return true
+		end
+
+		return false
 	end
 
-	local NumMaps = #Maps
+	Shine.VoteMenu:AddPage( "MapVote", function( self )
+		if ClosePageIfVoteFinished( self ) then return end
 
-	for i = 1, NumMaps do
-		local Map = Maps[ i ]
-		local Votes = Plugin.MapVoteCounts[ Map ]
+		local Maps = Plugin.Maps
+		if not Maps then
+			return
+		end
 
-		local Text = StringFormat( "%s (%i)", Map, Votes )
+		local NumMaps = #Maps
 
-		Plugin.MapButtons[ Map ] = self:AddSideButton( Text, function()
-			if SendMapVote( Map ) then
-				self:SetIsVisible( false )
-			else
-				return false
-			end
+		for i = 1, NumMaps do
+			local Map = Maps[ i ]
+			local Votes = Plugin.MapVoteCounts[ Map ]
+
+			local Text = StringFormat( "%s (%i)", Map, Votes )
+
+			Plugin.MapButtons[ Map ] = self:AddSideButton( Text, function()
+				if SendMapVote( Map ) then
+					self:SetIsVisible( false )
+				else
+					return false
+				end
+			end )
+		end
+
+		self:AddTopButton( "Back", function()
+			self:SetPage( "Main" )
 		end )
-	end
-
-	self:AddTopButton( "Back", function()
-		self:SetPage( "Main" )
-	end )
-end, function( self )
-	local Time = SharedTime()
-
-	if Plugin.EndTime < Time then
-		self:SetPage( "Main" )
-	end
-end )
+	end, ClosePageIfVoteFinished )
+end
 
 function Plugin:ReceiveVoteProgress( Data )
 	local MapName = Data.Map

--- a/lua/shine/extensions/mapvote/voting.lua
+++ b/lua/shine/extensions/mapvote/voting.lua
@@ -357,6 +357,8 @@ function Plugin:OnNextMapVoteFail()
 	end
 end
 
+local TableRandom = table.ChooseRandom
+
 function Plugin:ProcessResults( NextMap )
 	self:EndVote()
 
@@ -435,17 +437,7 @@ function Plugin:ProcessResults( NextMap )
 
 	--We're set to choose randomly between them on tie.
 	if self.Config.ChooseRandomOnTie then
-		local NewCount = Count * 100 --If there were 3 tied choices, we're looking at numbers between 1 and 300.
-		local RandNum = Random( 1, Count )
-		local Choice = ""
-
-		for i = 1, Count do
-			if InRange( ( i - 1 ) * 100, i * 100, ( i + 1 ) * 100 ) then --Is this map the winner?
-				Choice = Results[ i ]
-				break
-			end
-		end
-
+		local Choice = TableRandom( Results )
 		local Tied = TableConcat( Results, ", " )
 
 		self.Vote.CanVeto = true --Allow vetos.
@@ -486,22 +478,7 @@ function Plugin:ProcessResults( NextMap )
 end
 
 do
-	local TableRandom = table.ChooseRandom
-
 	local BaseEntryCount = 10
-
-	local function RemoveAllMatches( Table, Value )
-		local Offset = 0
-
-		for i = 1, #Table do
-			local Key = i - Offset
-
-			if Table[ Key ] == Value then
-				TableRemove( Table, Key )
-				Offset = Offset + 1
-			end
-		end
-	end
 
 	--[[
 		Chooses random maps from the remaining maps pool, weighting each map according
@@ -509,6 +486,7 @@ do
 	]]
 	function Plugin:ChooseRandomMaps( AllMaps, MapList, MaxOptions )
 		local MapBucket = {}
+		local Stream = Shine.Stream( MapBucket )
 		local Count = 0
 
 		for Map in pairs( AllMaps ) do
@@ -527,7 +505,9 @@ do
 
 			MapList[ #MapList + 1 ] = Choice
 
-			RemoveAllMatches( MapBucket, Choice )
+			Stream:Filter( function( Value )
+				return Value ~= Choice
+			end )
 		end
 	end
 end

--- a/lua/shine/extensions/mapvote/voting.lua
+++ b/lua/shine/extensions/mapvote/voting.lua
@@ -7,16 +7,13 @@ local Shine = Shine
 local Ceil = math.ceil
 local Floor = math.floor
 local GetNumPlayers = Shine.GetHumanPlayerCount
-local InRange = math.InRange
 local next = next
 local pairs = pairs
-local Random = math.random
 local SharedTime = Shared.GetTime
 local StringFormat = string.format
 local TableAsSet = table.AsSet
 local TableConcat = table.concat
 local TableCopy = table.Copy
-local TableRemove = table.remove
 
 local Plugin = Plugin
 local IsType = Shine.IsType

--- a/lua/shine/extensions/motd.lua
+++ b/lua/shine/extensions/motd.lua
@@ -29,16 +29,17 @@ Plugin.DefaultConfig = {
 Plugin.CheckConfig = true
 Plugin.CheckConfigTypes = true
 
+Plugin.PrintName = "MOTD"
+Plugin.NotifyPrefixColour = {
+	0, 100, 255
+}
+
 function Plugin:Initialise()
 	self:CreateCommands()
 
 	self.Enabled = true
 
 	return true
-end
-
-function Plugin:Notify( Player, String, Format, ... )
-	Shine:NotifyDualColour( Player, 0, 100, 255, "[MOTD]", 255, 255, 255, String, Format, ... )
 end
 
 function Plugin:ShowMotD( Client, OnConnect )

--- a/lua/shine/extensions/pregame/server.lua
+++ b/lua/shine/extensions/pregame/server.lua
@@ -15,6 +15,10 @@ Plugin.Version = "1.6"
 
 Plugin.HasConfig = true
 Plugin.ConfigName = "PreGame.json"
+Plugin.PrintName = "Pre Game"
+Plugin.NotifyPrefixColour = {
+	100, 100, 255
+}
 
 Plugin.DefaultConfig = {
 	PreGameTime = 45,
@@ -140,11 +144,6 @@ end
 function Plugin:DestroyTimers()
 	self:DestroyTimer( self.FiveSecTimer )
 	self:DestroyTimer( self.CountdownTimer )
-end
-
-function Plugin:Notify( Player, Message, Format, ... )
-	Shine:NotifyDualColour( Player, 100, 100, 255, "[Pre Game]", 255, 255, 255,
-		Message, Format, ... )
 end
 
 function Plugin:AbortGameStart( Gamerules, Message, Format, ... )

--- a/lua/shine/extensions/unstuck.lua
+++ b/lua/shine/extensions/unstuck.lua
@@ -19,6 +19,11 @@ Plugin.DefaultConfig = {
 Plugin.CheckConfig = true
 Plugin.CheckConfigTypes = true
 
+Plugin.PrintName = "Unstuck"
+Plugin.NotifyPrefixColour = {
+	0, 255, 0
+}
+
 function Plugin:Initialise()
 	self.Users = {}
 
@@ -27,10 +32,6 @@ function Plugin:Initialise()
 	self.Enabled = true
 
 	return true
-end
-
-function Plugin:Notify( Player, String, Format, ... )
-	Shine:NotifyDualColour( Player, 0, 255, 0, "[Unstuck]", 255, 255, 255, String, Format, ... )
 end
 
 function Plugin:UnstickPlayer( Player, Pos )

--- a/lua/shine/extensions/unstuck.lua
+++ b/lua/shine/extensions/unstuck.lua
@@ -30,18 +30,22 @@ function Plugin:Initialise()
 end
 
 function Plugin:Notify( Player, String, Format, ... )
-	Shine:NotifyDualColour( Player, 100, 100, 100, "[Unstuck]", 255, 255, 255, String, Format, ... )
+	Shine:NotifyDualColour( Player, 0, 255, 0, "[Unstuck]", 255, 255, 255, String, Format, ... )
 end
 
 function Plugin:UnstickPlayer( Player, Pos )
-	local TechID = kTechId.Skulk
+	-- Respawn ready room players instead of trying to find a spawn point near them.
+	if Player:GetTeamNumber() == kTeamReadyRoom then
+		GetGamerules():JoinTeam( Player, kTeamReadyRoom, true )
+		return true
+	end
 
+	local TechID = kTechId.Skulk
 	if Player:GetIsAlive() then
 		TechID = Player:GetTechId()
 	end
 
 	local Bounds = LookupTechData( TechID, kTechDataMaxExtents )
-
 	if not Bounds then
 		return false
 	end
@@ -65,7 +69,7 @@ function Plugin:UnstickPlayer( Player, Pos )
 	until not ResourceNear or i > 100
 
 	if SpawnPoint then
-		SpawnPlayerAtPoint( Player, SpawnPoint )
+		Player:SetOrigin( SpawnPoint )
 
 		return true
 	end
@@ -76,8 +80,8 @@ end
 function Plugin:CreateCommands()
 	local function Unstick( Client )
 		if not Client then return end
-		local Player = Client:GetControllingPlayer()
 
+		local Player = Client:GetControllingPlayer()
 		if not Player then return end
 
 		if not Player:GetIsAlive() then
@@ -99,11 +103,11 @@ function Plugin:CreateCommands()
 		local Success = self:UnstickPlayer( Player, Player:GetOrigin() )
 
 		if Success then
-			self:Notify( Player, "Successfully unstuck." )
+			self:Notify( Client, "Successfully unstuck." )
 
 			self.Users[ Client ] = Time + self.Config.TimeBetweenUse
 		else
-			Shine:NotifyError( Player, "Unable to unstick. Try again in %s.",
+			Shine:NotifyError( Client, "Unable to unstick. Try again in %s.",
 				true, string.TimeToString( self.Config.MinTime ) )
 
 			self.Users[ Client ] = Time + self.Config.MinTime

--- a/lua/shine/extensions/usermanagement.lua
+++ b/lua/shine/extensions/usermanagement.lua
@@ -79,9 +79,9 @@ function Plugin:SubmitOperation( OperationID, KeyValues, Revert )
 				return
 			end
 
-			local Decoded = Decode( Data )
+			local Decoded, Pos, Err = Decode( Data )
 			if not Decoded then
-				self:Print( "Received invalid JSON in response for operation %s.", true, OperationID )
+				self:Print( "Received invalid JSON in response for operation %s. Error: %s", true, OperationID, Err )
 				return
 			end
 

--- a/lua/shine/extensions/voterandom.lua
+++ b/lua/shine/extensions/voterandom.lua
@@ -31,6 +31,9 @@ local tostring = tostring
 local Plugin = {}
 Plugin.Version = "2.0"
 Plugin.PrintName = "Shuffle"
+Plugin.NotifyPrefixColour = {
+	100, 255, 100
+}
 
 Plugin.HasConfig = true
 Plugin.ConfigName = "VoteRandom.json"
@@ -158,10 +161,6 @@ function Plugin:Initialise()
 	self.Enabled = true
 
 	return true
-end
-
-function Plugin:Notify( Player, Message, Format, ... )
-	Shine:NotifyDualColour( Player, 100, 255, 100, "[Shuffle]", 255, 255, 255, Message, Format, ... )
 end
 
 --[[

--- a/lua/shine/extensions/welcomemessages.lua
+++ b/lua/shine/extensions/welcomemessages.lua
@@ -68,10 +68,17 @@ function Plugin:ClientConnect( Client )
 	end )
 end
 
+local Ceil = math.ceil
+
+local function ColourIntToTable( Int )
+	local Colour = ColorIntToColor( Int )
+	return { Ceil( Colour.r * 255 ), Ceil( Colour.g * 255 ), Ceil( Colour.b * 255 ) }
+end
+
 local TeamColours = {
 	[ 0 ] = { 255, 255, 255 },
-	[ 1 ] = { 50, 175, 255 },
-	[ 2 ] = { 200, 150, 10 }
+	[ 1 ] = ColourIntToTable( kMarineTeamColor or 0x4DB1FF ),
+	[ 2 ] = ColourIntToTable( kAlienTeamColor or 0xFFCA3A )
 }
 
 function Plugin:ClientDisconnect( Client )

--- a/lua/shine/extensions/workshopupdater.lua
+++ b/lua/shine/extensions/workshopupdater.lua
@@ -27,6 +27,11 @@ Plugin.DefaultConfig = {
 	ForceMapvoteAtRoundEnd = false
 }
 
+Plugin.PrintName = "Workshop"
+Plugin.NotifyPrefixColour = {
+	255, 160, 0
+}
+
 local RemainingNotifications = Huge
 local ModChangeTimer = "CheckForModChange"
 
@@ -61,12 +66,6 @@ function Plugin:Initialise()
 	self.Enabled = true
 
 	return true
-end
-
-function Plugin:Notify( String, Format, ... )
-	String = Format and StringFormat( String, ... ) or String
-
-	Shine:NotifyDualColour( nil, 255, 160, 0, "[Workshop]", 255, 255, 255, String )
 end
 
 local LastKnownUpdate = {}
@@ -148,8 +147,8 @@ function Plugin:NotifyOrCycle( Recall )
 		end
 	end
 
-	self:Notify( "The \"%s\" mod has updated on the Steam Workshop.", true, self.ChangedModName )
-	self:Notify( "Players may be unable to connect to the server until map change." )
+	self:Notify( nil, "The \"%s\" mod has updated on the Steam Workshop.", true, self.ChangedModName )
+	self:Notify( nil, "Players may be unable to connect to the server until map change." )
 
 	if RemainingNotifications < Huge then
 		local TimeRemainingString = "now"
@@ -160,7 +159,7 @@ function Plugin:NotifyOrCycle( Recall )
 			TimeRemainingString = StringFormat( "in %s", string.TimeToString( TimeBeforeChange ) )
 		end
 
-		self:Notify( "The map will cycle %s.", true, TimeRemainingString )
+		self:Notify( nil, "The map will cycle %s.", true, TimeRemainingString )
 	end
 
 	if RemainingNotifications == 0 then

--- a/lua/shine/init.lua
+++ b/lua/shine/init.lua
@@ -8,6 +8,7 @@ local Scripts = {
 	"lib/debug.lua",
 	"lib/table.lua",
 	"lib/comparator.lua",
+	"lib/sorting.lua",
 	"lib/stream.lua",
 	"lib/string.lua",
 	"lib/utf8.lua",

--- a/lua/shine/lib/comparator.lua
+++ b/lua/shine/lib/comparator.lua
@@ -30,10 +30,17 @@ local function Compile( Comparator )
 	end
 end
 
+local function CompileStable( Comparator )
+	return function( A, B )
+		return Comparator:Compare( A, B )
+	end
+end
+
 local function NewComparatorType( Name )
 	local Meta = {}
 	Meta.__index = Meta
 	Meta.Compile = Compile
+	Meta.CompileStable = CompileStable
 
 	Comparators[ Name ] = Meta
 

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -341,18 +341,7 @@ function SGUI:SetWindowFocus( Window, i )
 	self.FocusedWindow = Window
 end
 
-local ToDebugString = table.ToDebugString
-local Traceback = debug.traceback
-
-local function OnError( Error )
-	local Trace = Traceback()
-
-	local Locals = ToDebugString( Shine.GetLocals( 1 ) )
-
-	Shine:DebugPrint( "SGUI Error: %s.\n%s", true, Error, Trace )
-	Shine:AddErrorReport( StringFormat( "SGUI Error: %s.", Error ),
-		"%s\nLocals:\n%s", true, Trace, Locals )
-end
+local OnError = Shine.BuildErrorHandler( "SGUI Error" )
 
 function SGUI:PostCallEvent()
 	local PostEventActions = self.PostEventActions

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -443,6 +443,25 @@ do
 	end
 end
 
+SGUI.Mixins = {}
+
+function SGUI:RegisterMixin( Name, Table )
+	self.Mixins[ Name ] = Table
+end
+
+do
+	local TableShallowMerge = table.ShallowMerge
+
+	function SGUI:AddMixin( Table, Name )
+		local Mixin = self.Mixins[ Name ]
+
+		TableShallowMerge( Mixin, Table )
+
+		Table.Mixins = Table.Mixins or {}
+		Table.Mixins[ Name ] = Mixin
+	end
+end
+
 --[[
 	Registers a control meta-table.
 	We'll use this to create instances of it (instead of loading a script
@@ -673,6 +692,7 @@ SGUI.NotifyFocusChange = NotifyFocusChange
 	If we don't load after everything, things aren't registered properly.
 ]]
 Hook.Add( "OnMapLoad", "LoadGUIElements", function()
+	Shine.LoadScriptsByPath( "lua/shine/lib/gui/mixins" )
 	Shine.LoadScriptsByPath( "lua/shine/lib/gui/objects" )
 	include( "lua/shine/lib/gui/skin_manager.lua" )
 

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -1002,7 +1002,7 @@ function ControlMeta:OnMouseMove( Down )
 		return
 	end
 
-	if self:MouseIn( self.Background, self.HighlightMult ) then
+	if self:GetIsVisible() and self:MouseIn( self.Background, self.HighlightMult ) then
 		self:SetHighlighted( true )
 	else
 		if self.Highlighted and not self.ForceHighlight then

--- a/lua/shine/lib/gui/mixins/clickable.lua
+++ b/lua/shine/lib/gui/mixins/clickable.lua
@@ -1,0 +1,38 @@
+--[[
+	Deals with clicking.
+]]
+
+local Clock = os.clock
+
+local Clickable = {}
+
+function Clickable:OnMouseDown( Key, DoubleClick )
+	if Key ~= InputKey.MouseButton0 and Key ~= InputKey.MouseButton1 then return end
+	if not self:MouseInControl() then return end
+
+	return true, self
+end
+
+local function CallClickMethod( self, Method )
+	if not Method then return end
+
+	local Sound = self.Sound
+	if Method( self ) ~= false and Sound then
+		Shared.PlaySound( nil, Sound )
+	end
+
+	return true
+end
+
+function Clickable:OnMouseUp( Key )
+	if not self:MouseInControl() then return end
+
+	local Time = Clock()
+	if ( self.ClickDelay or 0.1 ) > 0 and ( self.NextClick or 0 ) > Time then return true end
+
+	self.NextClick = Time + ( self.ClickDelay or 0.1 )
+
+	CallClickMethod( self, Key == InputKey.MouseButton0 and self.DoClick or self.DoRightClick )
+end
+
+Shine.GUI:RegisterMixin( "Clickable", Clickable )

--- a/lua/shine/lib/gui/objects/button.lua
+++ b/lua/shine/lib/gui/objects/button.lua
@@ -147,31 +147,7 @@ function Button:OnMouseDown( Key, DoubleClick )
 		return true, Child
 	end
 
-	if Key ~= InputKey.MouseButton0 then return end
-	--We can't trust self.Highlighted.
-	if not self:MouseIn( self.Background ) then return end
-
-	return true, self
-end
-
-function Button:OnMouseUp( Key )
-	if not self:GetIsVisible() then return end
-	if not self:MouseIn( self.Background ) then return end
-
-	local Time = Clock()
-
-	if ( self.ClickDelay or 0.1 ) > 0 and ( self.NextClick or 0 ) > Time then return true end
-
-	self.NextClick = Time + ( self.ClickDelay or 0.1 )
-
-	if self.DoClick then
-		local Sound = self.Sound
-		if self:DoClick() ~= false and Sound then
-			Shared.PlaySound( nil, Sound )
-		end
-
-		return true
-	end
+	return self.Mixins.Clickable.OnMouseDown( self, Key, DoubleClick )
 end
 
 function Button:OnMouseMove( Down )
@@ -198,4 +174,5 @@ function Button:PlayerType( Char )
 	end
 end
 
+SGUI:AddMixin( Button, "Clickable" )
 SGUI:Register( "Button", Button )

--- a/lua/shine/lib/gui/objects/colour_label.lua
+++ b/lua/shine/lib/gui/objects/colour_label.lua
@@ -88,4 +88,5 @@ function ColourLabel:Think( DeltaTime )
 	self:CallOnChildren( "Think", DeltaTime )
 end
 
+SGUI:AddMixin( ColourLabel, "Clickable" )
 SGUI:Register( "ColourLabel", ColourLabel )

--- a/lua/shine/lib/gui/objects/label.lua
+++ b/lua/shine/lib/gui/objects/label.lua
@@ -65,4 +65,5 @@ function Label:SetBright( Bright )
 	-- Deprecated, does nothing.
 end
 
+SGUI:AddMixin( Label, "Clickable" )
 SGUI:Register( "Label", Label )

--- a/lua/shine/lib/gui/objects/list.lua
+++ b/lua/shine/lib/gui/objects/list.lua
@@ -403,6 +403,12 @@ function List:GetComparator( Column, Direction )
 		Column, IsNumeric and tonumber or string.UTF8Lower )
 end
 
+function List:RefreshSorting()
+	if not self.SortedColumn then return end
+
+	self:SortRows( self.SortedColumn, self.SortingFunc, self.Descending )
+end
+
 --[[
 	Sorts the rows, generally used to sort by column values.
 	Inputs: Column to sort by, optional sorting function.

--- a/lua/shine/lib/gui/objects/list.lua
+++ b/lua/shine/lib/gui/objects/list.lua
@@ -461,7 +461,6 @@ end
 ]]
 function List:RemoveRow( Index )
 	local Rows = self.Rows
-
 	if not Rows then return end
 
 	local OldRow = Rows[ Index ]
@@ -484,6 +483,10 @@ function List:RemoveRow( Index )
 		self.ScrollParent:SetPosition( Vector( 0, 0, 0 ) )
 	else
 		self.Scrollbar:SetScrollSize( self.MaxRows / self.RowCount )
+	end
+
+	if self.SelectedRow == OldRow then
+		self.SelectedRow = nil
 	end
 
 	self:Reorder()

--- a/lua/shine/lib/gui/objects/list.lua
+++ b/lua/shine/lib/gui/objects/list.lua
@@ -10,7 +10,7 @@ local Floor = math.floor
 local IsType = Shine.IsType
 local select = select
 local TableRemove = table.remove
-local TableSort = table.sort
+local TableMergeSort = table.MergeSort
 local tonumber = tonumber
 local Vector = Vector
 
@@ -438,13 +438,13 @@ function List:SortRows( Column, SortFunc, Desc )
 
 		if SecondarySortColumn then
 			Comparator = Shine.Comparator( "Composition", self:GetComparator( SecondarySortColumn, 1 ),
-				self:GetComparator( Column ) ):Compile()
+				self:GetComparator( Column ) ):CompileStable()
 		else
-			Comparator = self:GetComparator( Column ):Compile()
+			Comparator = self:GetComparator( Column ):CompileStable()
 		end
 	end
 
-	TableSort( Rows, Comparator )
+	TableMergeSort( Rows, Comparator )
 
 	self.SortedColumn = Column
 	self.SortingFunc = SortFunc

--- a/lua/shine/lib/gui/objects/listentry.lua
+++ b/lua/shine/lib/gui/objects/listentry.lua
@@ -94,6 +94,10 @@ function ListEntry:OnReorder()
 	if TextScale then
 		self:SetTextScale( TextScale )
 	end
+
+	if self.Selected then
+		self.Background:SetColor( self.ActiveCol )
+	end
 end
 
 function ListEntry:UpdateText( Obj, Size )

--- a/lua/shine/lib/gui/objects/listentry.lua
+++ b/lua/shine/lib/gui/objects/listentry.lua
@@ -147,7 +147,10 @@ function ListEntry:SetSpacing( SpacingTable )
 end
 
 function ListEntry:SetData( Index, Data )
+	if self.Data[ Index ] == Data then return end
+
 	self.Data[ Index ] = Data
+	self.Parent:RefreshSorting()
 end
 
 function ListEntry:GetData( Index )
@@ -164,7 +167,9 @@ function ListEntry:SetColumnText( Index, Text )
 	TextObjs[ Index ]:SetText( Text )
 	self:UpdateText( TextObjs[ Index ], self.Spacing[ Index ].x )
 
-	self.Parent:RefreshSorting()
+	if self.Data[ Index ] == nil then
+		self.Parent:RefreshSorting()
+	end
 end
 
 function ListEntry:GetColumnText( Index )

--- a/lua/shine/lib/gui/objects/listentry.lua
+++ b/lua/shine/lib/gui/objects/listentry.lua
@@ -21,8 +21,11 @@ end
 function ListEntry:Initialise()
 	self.BaseClass.Initialise( self )
 
+	-- Real data may be different to what's displayed (e.g. time values)
+	self.Data = {}
+
 	self.Background = GetGUIManager():CreateGraphicItem()
-	self:SetHighlightOnMouseOver( true, 0.9 )
+	self:SetHighlightOnMouseOver( true )
 end
 
 function ListEntry:SetTextColour( Colour )
@@ -143,14 +146,25 @@ function ListEntry:SetSpacing( SpacingTable )
 	end
 end
 
+function ListEntry:SetData( Index, Data )
+	self.Data[ Index ] = Data
+end
+
+function ListEntry:GetData( Index )
+	return self.Data[ Index ] or self.ColumnText[ Index ] or ""
+end
+
 function ListEntry:SetColumnText( Index, Text )
 	local TextObjs = self.TextObjs
 	if not TextObjs or not TextObjs[ Index ] then return end
+	if Text == self.ColumnText[ Index ] then return end
 
 	self.ColumnText[ Index ] = Text
 
 	TextObjs[ Index ]:SetText( Text )
 	self:UpdateText( TextObjs[ Index ], self.Spacing[ Index ].x )
+
+	self.Parent:RefreshSorting()
 end
 
 function ListEntry:GetColumnText( Index )
@@ -185,7 +199,7 @@ function ListEntry:OnMouseDown( Key, DoubleClick )
 	if not self.Parent then return end
 	if Key ~= InputKey.MouseButton0 then return end
 	if not self:GetIsVisible() then return end
-	if not self:MouseIn( self.Background, 0.9 ) then return end
+	if not self:MouseIn( self.Background ) then return end
 
 	return true, self
 end
@@ -194,7 +208,7 @@ function ListEntry:OnMouseUp( Key )
 	if not self.Parent then return end
 	if Key ~= InputKey.MouseButton0 then return end
 	if not self:GetIsVisible() then return end
-	if not self:MouseIn( self.Background, 0.9 ) then return end
+	if not self:MouseIn( self.Background ) then return end
 
 	if not self.Selected and self.Parent.OnRowSelect then
 		self.Parent:OnRowSelect( self.Index, self )

--- a/lua/shine/lib/gui/skins/default.lua
+++ b/lua/shine/lib/gui/skins/default.lua
@@ -54,6 +54,9 @@ local Skin = {
 	Label = {
 		Default = {
 			Colour = BrightText
+		},
+		Link = {
+			Colour = Colour( 1, 0.8, 0 )
 		}
 	},
 	List = {

--- a/lua/shine/lib/player.lua
+++ b/lua/shine/lib/player.lua
@@ -145,7 +145,7 @@ function Shine.EvenlySpreadTeams( Gamerules, TeamMembers )
 
 	for i, Player in pairs( Marine ) do
 		local Success, JoinSuccess, NewPlayer = xpcall( Gamerules.JoinTeam,
-			OnJoinError, Gamerules, Player, 1, nil, true )
+			OnJoinError, Gamerules, Player, 1, Player:GetTeamNumber() ~= 1, true )
 
 		if Success then
 			Marine[ i ] = NewPlayer
@@ -156,7 +156,7 @@ function Shine.EvenlySpreadTeams( Gamerules, TeamMembers )
 
 	for i, Player in pairs( Alien ) do
 		local Success, JoinSuccess, NewPlayer = xpcall( Gamerules.JoinTeam,
-			OnJoinError, Gamerules, Player, 2, nil, true )
+			OnJoinError, Gamerules, Player, 2, Player:GetTeamNumber() ~= 2, true )
 
 		if Success then
 			Alien[ i ] = NewPlayer

--- a/lua/shine/lib/sorting.lua
+++ b/lua/shine/lib/sorting.lua
@@ -1,0 +1,54 @@
+--[[
+	Stable merge sort.
+]]
+
+local Floor = math.floor
+
+local function Merge( Table, Min, Centre, Max, Comparator )
+	local Left = {}
+	local Right = {}
+
+	for i = Min, Centre do
+		Left[ i - Min + 1 ] = Table[ i ]
+	end
+
+	for i = Centre + 1, Max do
+		Right[ i - Centre ] = Table[ i ]
+	end
+
+	local LeftIndex = 1
+	local RightIndex = 1
+	local NumberLeft = #Left
+	local NumberRight = #Right
+
+	for i = Min, Max do
+		if NumberLeft < LeftIndex then
+			Table[ i ] = Right[ RightIndex ]
+			RightIndex = RightIndex + 1
+		elseif NumberRight < RightIndex then
+			Table[ i ] = Left[ LeftIndex ]
+			LeftIndex = LeftIndex + 1
+		else
+			if Comparator( Left[ LeftIndex ], Right[ RightIndex ] ) <= 0 then
+				Table[ i ] = Left[ LeftIndex ]
+				LeftIndex = LeftIndex + 1
+			else
+				Table[ i ] = Right[ RightIndex ]
+				RightIndex = RightIndex + 1
+			end
+		end
+	end
+end
+
+local function MergeSort( Table, Comparator, Start, End )
+	Start = Start or 1
+	End = End or #Table
+
+	if Start >= End then return end
+
+	local Centre = Floor( ( Start + End ) * 0.5 )
+	MergeSort( Table, Comparator, Start, Centre )
+	MergeSort( Table, Comparator, Centre + 1, End )
+	Merge( Table, Start, Centre, End, Comparator )
+end
+table.MergeSort = MergeSort

--- a/lua/shine/lib/sorting.lua
+++ b/lua/shine/lib/sorting.lua
@@ -40,7 +40,26 @@ local function Merge( Table, Min, Centre, Max, Comparator )
 	end
 end
 
+local function NaturalOrder( A, B )
+	return A == B and 0 or ( A < B and -1 or 1 )
+end
+
+--[[
+	Performs an inline sort of the given table using the merge sort algorithm.
+
+	Lua's table.sort() is not guaranteed to place elements with equal precedence
+	in the same order each time. This produces a sorting that is always identical
+	every time it is run.
+
+	The comparator takes two values, A and B, and should return a single number:
+	- Negative if value A belongs before the value B
+	- 0 if the values have equal precedence
+	- Positive if the value A belongs after the value B.
+
+	This is not the same as for Lua's standard table.sort, which expects a boolean return value.
+]]
 local function MergeSort( Table, Comparator, Start, End )
+	Comparator = Comparator or NaturalOrder
 	Start = Start or 1
 	End = End or #Table
 

--- a/lua/shine/lib/stream.lua
+++ b/lua/shine/lib/stream.lua
@@ -8,7 +8,6 @@
 local setmetatable = setmetatable
 local TableConcat = table.concat
 local TableMergeSort = table.MergeSort
-local TableRemove = table.remove
 local TableSort = table.sort
 
 local Stream = {}
@@ -26,10 +25,19 @@ end
 	Any value for which the predicate returns false will be removed.
 ]]
 function Stream:Filter( Predicate )
-	for i = #self.Data, 1, -1 do
+	local Size = #self.Data
+	local Offset = 0
+
+	for i = 1, Size do
+		self.Data[ i - Offset ] = self.Data[ i ]
 		if not Predicate( self.Data[ i ] ) then
-			TableRemove( self.Data, i )
+			self.Data[ i ] = nil
+			Offset = Offset + 1
 		end
+	end
+
+	for i = Size, Size - Offset + 1, -1 do
+		self.Data[ i ] = nil
 	end
 
 	return self

--- a/lua/shine/lib/stream.lua
+++ b/lua/shine/lib/stream.lua
@@ -44,6 +44,17 @@ function Stream:Filter( Predicate )
 end
 
 --[[
+	Performs an action on all values in the stream, without changing the stream.
+]]
+function Stream:ForEach( Function )
+	for i = 1, #self.Data do
+		Function( self.Data[ i ] )
+	end
+
+	return self
+end
+
+--[[
 	Maps the values of the stream using the given Mapper function.
 
 	All values in the stream are replaced with what the mapper function returns for them.

--- a/lua/shine/lib/stream.lua
+++ b/lua/shine/lib/stream.lua
@@ -7,6 +7,7 @@
 
 local setmetatable = setmetatable
 local TableConcat = table.concat
+local TableMergeSort = table.MergeSort
 local TableRemove = table.remove
 local TableSort = table.sort
 
@@ -52,6 +53,15 @@ end
 ]]
 function Stream:Sort( Comparator )
 	TableSort( self.Data, Comparator )
+
+	return self
+end
+
+--[[
+	Sorts the values in the stream with the given comparator using a stable merge sort.
+]]
+function Stream:StableSort( Comparator )
+	TableMergeSort( self.Data, Comparator )
 
 	return self
 end

--- a/lua/shine/lib/stream.lua
+++ b/lua/shine/lib/stream.lua
@@ -6,6 +6,7 @@
 ]]
 
 local setmetatable = setmetatable
+local TableConcat = table.concat
 local TableRemove = table.remove
 local TableSort = table.sort
 
@@ -66,6 +67,20 @@ function Stream:Limit( Limit )
 	end
 
 	return self
+end
+
+--[[
+	Concatenates the values in the stream into a single string based
+	on the string value returned by the transformation function.
+]]
+function Stream:Concat( Separator, ToStringFunc )
+	local Values = {}
+
+	for i = 1, #self.Data do
+		Values[ i ] = ToStringFunc( self.Data[ i ] )
+	end
+
+	return TableConcat( Values, Separator )
 end
 
 --[[

--- a/lua/shine/lib/table.lua
+++ b/lua/shine/lib/table.lua
@@ -211,6 +211,7 @@ end
 do
 	local Notify = Shared.Message
 	local StringFormat = string.format
+	local StringLower = string.lower
 	local StringRep = string.rep
 	local TableConcat = table.concat
 	local tonumber = tonumber
@@ -220,12 +221,12 @@ do
 	local function ToPrintKey( Key )
 		local Type = type( Key )
 
-		if Type ~= "string" and Type ~= "number" then
+		if Type ~= "string" then
 			return StringFormat( "[ %s ]", tostring( Key ) )
 		end
 
 		if Type == "string" and tonumber( Key ) then
-			return StringFormat( "\"%s\"", Key )
+			return StringFormat( "[ \"%s\" ]", Key )
 		end
 
 		return tostring( Key )
@@ -236,6 +237,24 @@ do
 		end
 
 		return tostring( Value )
+	end
+
+	local function KeySorter( A, B )
+		local AIsNumber = IsType( A, "number" )
+		local BIsNumber = IsType( B, "number" )
+		if AIsNumber and BIsNumber then
+			return A < B
+		end
+
+		if AIsNumber then
+			return true
+		end
+
+		if BIsNumber then
+			return false
+		end
+
+		return StringLower( tostring( A ) ) < StringLower( tostring( B ) )
 	end
 
 	local function TableToString( Table, Indent, Done )
@@ -250,7 +269,17 @@ do
 
 		local IndentString = StringRep( "\t", Indent )
 
-		for Key, Value in pairs( Table ) do
+		local Keys = {}
+		for Key in pairs( Table ) do
+			Keys[ #Keys + 1 ] = Key
+		end
+
+		TableSort( Keys, KeySorter )
+
+		for i = 1, #Keys do
+			local Key = Keys[ i ]
+			local Value = Table[ Key ]
+
 			if IsType( Value, "table" ) and not Done[ Value ] then
 				Done[ Value ] = true
 				local TableAsString = TableToString( Value, Indent + 1, Done )

--- a/lua/shine/lib/table.lua
+++ b/lua/shine/lib/table.lua
@@ -258,6 +258,11 @@ do
 	end
 
 	local function TableToString( Table, Indent, Done )
+		if not IsType( Table, "table" ) then
+			error( StringFormat( "bad argument #1 to 'table.ToString' (expected table, got %s)",
+				type( Table ) ), 2 )
+		end
+
 		Indent = Indent or 1
 		Done = Done or {}
 

--- a/test/core/server/commands.lua
+++ b/test/core/server/commands.lua
@@ -8,6 +8,23 @@ local NotifyCommandError = Shine.NotifyCommandError
 
 Shine.NotifyCommandError = function() end
 
+UnitTest:Test( "AdjustArguments", function( Assert )
+	local Args = {
+		"sh_test", "\"this", "is", "a", "single", "argument\"", "this", "isn't",
+		"\"this", "is", "\\\"and", "this", "is", "escaped\\\"", "end\"",
+		"\"this came from the console\"",
+		"\"this", "is", "an", "unfinished", "quote", "at", "the", "end"
+	}
+
+	local CommandArguments = Shine.CommandUtil.AdjustArguments( Args )
+	Assert:ArrayEquals( {
+		"sh_test", "this is a single argument", "this", "isn't",
+		"this is \"and this is escaped\" end",
+		"this came from the console",
+		"this is an unfinished quote at the end"
+	}, CommandArguments )
+end )
+
 UnitTest:Test( "GetCommandArg", function( Assert )
 	local Failed
 	local Parsed

--- a/test/core/server/commands.lua
+++ b/test/core/server/commands.lua
@@ -123,5 +123,47 @@ UnitTest:Test( "Validate", function( Assert )
 	Assert:Nil( NewResult )
 end )
 
+local GetAllClients = Shine.GetAllClients
+local ClientsParamType = Shine.CommandUtil.ParamTypes.clients
+local ControlCharacters = ClientsParamType.ControlCharacters
+
+UnitTest:Test( "ClientsParse", function( Assert )
+	ControlCharacters[ "&" ] = {
+		Parse = function( Client, Context )
+			local Value = tonumber( Context.Value )
+			Assert:NotNil( Value )
+
+			if Value > 0 and Value <= Context.NumClients then
+				return { Value }
+			end
+			return nil
+		end
+	}
+
+	function Shine.GetAllClients()
+		return { 1, 2, 3, 4 }, 4
+	end
+
+	local Arg = { Type = "clients" }
+
+	local function ParseString( Client, String, Table )
+		local Results = ClientsParamType.Parse( Client, String, Table )
+		table.sort( Results )
+		return Results
+	end
+
+	Assert:ArrayEquals( { 1, 3, 4 }, ParseString( 2, "!^", Arg ) )
+	Assert:ArrayEquals( { 1, 4 }, ParseString( 2, "!^,!&3", Arg ) )
+	Assert:ArrayEquals( { 1, 2, 3, 4 }, ParseString( 2, "*,!&24", Arg ) )
+
+	Assert:ArrayEquals( { 1, 2, 3, 4 }, ParseString( 2, "*", Arg ) )
+	Assert:ArrayEquals( {}, ParseString( 2, "*blah", Arg ) )
+	Assert:ArrayEquals( { 2, 3, 4 }, ParseString( 2, "&3,&4,^", Arg ) )
+	Assert:ArrayEquals( { 3, 4 }, ParseString( 2, "&3,&4,&24", Arg ) )
+end, function()
+	ControlCharacters[ "&" ] = nil
+end )
+
+Shine.GetAllClients = GetAllClients
 Shine.GetPermission = GetPermission
 Shine.NotifyCommandError = NotifyCommandError

--- a/test/lib/sorting.lua
+++ b/test/lib/sorting.lua
@@ -1,0 +1,42 @@
+--[[
+	Sorting tests.
+]]
+
+local UnitTest = Shine.UnitTest
+
+UnitTest:Test( "Simple MergeSort", function( Assert )
+	local Data = { 1, 5, 7, 2, 7, 8, 3, 1 }
+	table.MergeSort( Data, function( A, B )
+		return A == B and 0 or ( A < B and -1 or 1 )
+	end )
+
+	Assert:ArrayEquals( { 1, 1, 2, 3, 5, 7, 7, 8 }, Data )
+end )
+
+UnitTest:Test( "MergeSort stability", function( Assert )
+	local Unsorted = {
+		{
+			Name = "a"
+		},
+		{
+			Name = "c"
+		},
+		{
+			Name = "b"
+		},
+		{
+			Name = "a"
+		},
+		{
+			Name = "c"
+		}
+	}
+
+	local ExpectedResult = {
+		Unsorted[ 1 ], Unsorted[ 4 ], Unsorted[ 3 ], Unsorted[ 2 ], Unsorted[ 5 ]
+	}
+
+	table.MergeSort( Unsorted, Shine.Comparator( "Field", 1, "Name" ):CompileStable() )
+
+	Assert:ArrayEquals( ExpectedResult, Unsorted )
+end, nil, 100 )

--- a/test/lib/stream.lua
+++ b/test/lib/stream.lua
@@ -38,3 +38,9 @@ UnitTest:Test( "Limit", function( Assert )
 	Stream( Data ):Limit( 3 )
 	Assert:ArrayEquals( { 1, 2, 3 }, Data )
 end )
+
+UnitTest:Test( "Concat", function( Assert )
+	local Data = { 1, 2, 3, 4, 5, 6 }
+
+	Assert:Equals( "1, 2, 3, 4, 5, 6", Stream( Data ):Concat( ", ", tostring ) )
+end )

--- a/test/lib/stream.lua
+++ b/test/lib/stream.lua
@@ -6,7 +6,7 @@ local UnitTest = Shine.UnitTest
 local Stream = Shine.Stream
 
 UnitTest:Test( "Filter", function( Assert )
-	local Data = { 1, 2, 3, 4, 5, 6 }
+	local Data = { 1, 4, 3, 5, 2, 6 }
 
 	Stream( Data ):Filter( function( Value ) return Value > 3 end )
 

--- a/test/lib/stream.lua
+++ b/test/lib/stream.lua
@@ -29,6 +29,14 @@ UnitTest:Test( "Sort", function( Assert )
 	Assert:ArrayEquals( { 1, 2, 3, 4, 5, 6 }, Data )
 end )
 
+UnitTest:Test( "StableSort", function( Assert )
+	local Data = { 5, 3, 6, 4, 2, 1 }
+
+	Stream( Data ):StableSort()
+
+	Assert:ArrayEquals( { 1, 2, 3, 4, 5, 6 }, Data )
+end )
+
 UnitTest:Test( "Limit", function( Assert )
 	local Data = { 1, 2, 3, 4, 5, 6 }
 

--- a/test/lib/stream.lua
+++ b/test/lib/stream.lua
@@ -13,6 +13,22 @@ UnitTest:Test( "Filter", function( Assert )
 	Assert:ArrayEquals( { 4, 5, 6 }, Data )
 end )
 
+UnitTest:Test( "ForEach", function( Assert )
+	local Data = { "a", "b", "c", "d", "e", "f" }
+	local Visited = {}
+	local Count = 0
+
+	Stream( Data ):ForEach( function( Value )
+		Count = Count + 1
+		Visited[ Value ] = true
+	end )
+
+	Assert:Equals( #Data, Count )
+	for i = 1, Count do
+		Assert:True( Visited[ Data[ i ] ] )
+	end
+end )
+
 UnitTest:Test( "Map", function( Assert )
 	local Data = { 1, 2, 3, 4, 5, 6 }
 


### PR DESCRIPTION
## Bug Fixes/Enhancements
### Bug Fixes
- Fixed the admin menu commands tab not removing players that had disconnected from the list until you switched tabs away and back again.
- Fixed multiple small issues around multi-client targeting and negation of targets.
- Fixed string command argument restrictions breaking if you used a restriction with a Lua pattern control character. They will now be escaped automatically.
- Fixed the base config being overwritten with the default if it was invalid JSON. It will now only be replaced in-memory with the default, the file on disk will be unchanged.
- Fixed the `sh_unstuck` command not working in the ready room.

### Enhancements
- Commands now support multi-word arguments in the middle of the argument list. For example, `sh_kick "Name with spaces" Reason here.` would match a player whose name matches `Name with spaces` and the kick reason would be `Reason here.` as before.
  - If you need quotes inside an argument, escape them with a `\` before them. For example: `"Name \"with quotes\""`.
  - This can be applied to any argument type, not just strings.
  - This works in both the console and the chat.
- Commands that take a player or multiple players as arguments now indicate the string used to match if they fail to find a player.
- The links in the admin menu's about tab are now highlighted and click-able, which will open them in the Steam overlay.
- JSON errors are now reported when encountered, pointing at the line and column where the file stops being valid JSON.
- You can now use "rr" as the ready room team for commands which take a team value.
- Improved performance of Shine's hook system, especially for servers with a large number of extensions where few actually make use of events which fire every tick.
- Name filter improvements:
  - The name filter plugin can now use plain text name filters as well as Lua pattern based. Add `"PlainText": true` to a filter to make it search for the exact text.
  - Invalid patterns in the name filter plugin now produce a warning in the console.
  - The rename action in the name filter plugin now renames the player to a variant of `NSPlayerYYYY`, where `YYYY` is some random number.
- Bans tab improvements:
  - The bans tab now receives bans in order of expiry time, starting with the soonest to expire.
  - The bans tab now displays NS2IDs next to both the banned player name and the name of the player who banned them.
  - Sorting bans by the expiry column now actually sorts by the underlying expiry date, rather than the text displayed.

## API Changes
### Table Sorting
Added `table.MergeSort( Table[, Comparator] )`. Performs an in-line sort of the given table using the [merge sort](https://en.wikipedia.org/wiki/Merge_sort) algorithm. This provides a sort that will always keep equal precedence elements in the same order, unlike Lua's standard `table.sort()`. Comparators provided to this function have a slightly different contract to those provided to `table.sort`. They must return a single number with the following rules:
- A negative value should be returned if the first value should be placed before the second.
- A value of 0 should be returned if both values have equal precedence.
- A positive value should be returned if the first value should be placed after the second.

### Comparators
Added `Comparator:CompileStable()` for use with the new `table.MergeSort()`.

### Streams
Added `Stream:Concat()`, `Stream:ForEach()` and `Stream:StableSort()`. 
- `Concat` builds a single string from the stream's values.
- `ForEach` runs a function over all values without editing the table.
- `StableSort` performs a sort using `table.MergeSort()` and the given comparator.

`Stream:Filter()` is also now much more efficient than using `table.remove` multiple times.

### SGUI
#### Lists
- Lists now automatically resort themselves when edited (including rows being added and row values being changed).
- You can now set a secondary column to sort by. This will make the sorting sort first by the selected column, then by the secondary column. For example, the plugins tab uses this to sort by state, then name so that plugins show in alphabetical order grouped by state.

### Mixins
- SGUI now supports adding mixins to elements. Creating mixins is a case of placing them in the `lua/shine/lib/gui/mixins` folder, and registering them using `SGUI:RegisterMixin( Name, MixinTable )`.
- To add a mixin to a control table, use `SGUI:AddMixin( ControlTable, MixinName )`. When added, the mixin will add any of its methods the control does not have to the control. Any remaining methods will not replace those that the control defines. Instead, a control can access any of its mixins through `self.Mixins.MixinName`.
- The `Clickable` mixin has been added to `Button`, `Label` and `ColourLabel`. This mixin provides simple button press behaviour, with left and right click events.

### Plugins
`Plugin:Notify()` is now a standard method. To set the text in the tag, set the field `Plugin.PrintName`. To set the tag's colour, set `Plugin.NotifyPrefixColour`. For example:
```lua
Plugin.PrintName = "My Plugin"
Plugin.NotifyPrefixColour = {
    255, 0, 0
}
```
would set the plugin to display `[My Plugin] Message here` where `[My Plugin]` is displayed in red.

### Hooks
Added `Hook.CallOnce( EventName, ... )` to call an event then remove all registered hooks for it. This is useful for events that are guaranteed to fire only once.