### PR TITLE
Add map previews in the vote menu, other small fixes

### DIFF
--- a/lua/shine/core/client/votemenu_gui.lua
+++ b/lua/shine/core/client/votemenu_gui.lua
@@ -327,10 +327,7 @@ end
 	Clears out the votemenu, then populate with the given page.
 ]]
 function VoteMenu:SetPage( Name )
-	--if Name == self.ActivePage then return end
-
 	local Page = self.Pages[ Name ]
-
 	if not Page or not Page.Populate then return end
 
 	self:Clear()
@@ -338,8 +335,19 @@ function VoteMenu:SetPage( Name )
 	Page.Populate( self )
 
 	self:SortSideButtons()
-
 	self.ActivePage = Name
+end
+
+local function ClearButton( Button )
+	if not SGUI.IsValid( Button ) then return end
+
+	Button:SetIsVisible( false )
+	Button:SetTooltip( nil )
+
+	if Button.OnClear then
+		Button:OnClear()
+		Button.OnClear = nil
+	end
 end
 
 --[[
@@ -353,20 +361,11 @@ function VoteMenu:Clear()
 	local TopButton = Buttons.Top
 	local BottomButton = Buttons.Bottom
 
-	if SGUI.IsValid( TopButton ) then
-		TopButton:SetIsVisible( false )
-	end
-
-	if SGUI.IsValid( BottomButton ) then
-		BottomButton:SetIsVisible( false )
-	end
+	ClearButton( TopButton )
+	ClearButton( BottomButton )
 
 	for i = 1, #SideButtons do
-		local Button = SideButtons[ i ]
-
-		if SGUI.IsValid( Button ) then
-			Button:SetIsVisible( false )
-		end
+		ClearButton( SideButtons[ i ] )
 	end
 
 	self.ButtonIndex = 0

--- a/lua/shine/core/server/logging.lua
+++ b/lua/shine/core/server/logging.lua
@@ -163,22 +163,7 @@ end
 	Sends a coloured notification to the given player(s).
 ]]
 function Shine:NotifyColour( Player, R, G, B, String, Format, ... )
-	local Message = Format and StringFormat( String, ... ) or String
-
-	local MessageTable = {
-		R = R,
-		G = G,
-		B = B,
-		Message = Message,
-		RP = 0,
-		GP = 0,
-		BP = 0,
-		Prefix = ""
-	}
-
-	Message = Message:UTF8Sub( 1, kMaxChatLength )
-
-	self:ApplyNetworkMessage( Player, "Shine_ChatCol", MessageTable, true )
+	self:NotifyDualColour( Player, 0, 0, 0, "", R, G, B, String, Format, ... )
 end
 
 --[[
@@ -186,6 +171,7 @@ end
 ]]
 function Shine:NotifyDualColour( Player, RP, GP, BP, Prefix, R, G, B, String, Format, ... )
 	local Message = Format and StringFormat( String, ... ) or String
+	Message = Message:UTF8Sub( 1, kMaxChatLength )
 
 	local MessageTable = {
 		R = R,
@@ -197,8 +183,6 @@ function Shine:NotifyDualColour( Player, RP, GP, BP, Prefix, R, G, B, String, Fo
 		BP = BP,
 		Prefix = Prefix
 	}
-
-	Message = Message:UTF8Sub( 1, kMaxChatLength )
 
 	self:ApplyNetworkMessage( Player, "Shine_ChatCol", MessageTable, true )
 end

--- a/lua/shine/extensions/voterandom.lua
+++ b/lua/shine/extensions/voterandom.lua
@@ -1257,14 +1257,6 @@ function Plugin:JoinTeam( Gamerules, Player, NewTeam, Force, ShineForce )
 	if Gamestate == kGameState.Team1Won or Gamestate == kGameState.Team2Won
 	or GameState == kGameState.Draw then return end
 
-	local Enabled, MapVote = Shine:IsExtensionEnabled( "mapvote" )
-
-	if Enabled then
-		if MapVote:JoinTeam( Gamerules, Player, NewTeam, Force, ShineForce ) == false then
-			return false
-		end
-	end
-
 	local Client = GetOwner( Player )
 	if not Client then return false end
 

--- a/lua/shine/extensions/voterandom.lua
+++ b/lua/shine/extensions/voterandom.lua
@@ -1106,9 +1106,9 @@ function Plugin:JoinRandomTeam( Player )
 	local Team2 = Gamerules:GetTeam( kTeam2Index ):GetNumPlayers()
 
 	if Team1 < Team2 then
-		Gamerules:JoinTeam( Player, 1, nil, true )
+		Gamerules:JoinTeam( Player, 1 )
 	elseif Team2 < Team1 then
-		Gamerules:JoinTeam( Player, 2, nil, true )
+		Gamerules:JoinTeam( Player, 2 )
 	else
 		if self.LastShuffleMode == self.MODE_HIVE then
 			local Team1Players = Gamerules.team1:GetPlayers()
@@ -1134,16 +1134,16 @@ function Plugin:JoinRandomTeam( Player )
 					TeamToJoin = 2
 				end
 
-				Gamerules:JoinTeam( Player, TeamToJoin, nil, true )
+				Gamerules:JoinTeam( Player, TeamToJoin )
 
 				return
 			end
 		end
 
 		if Random() < 0.5 then
-			Gamerules:JoinTeam( Player, 1, nil, true )
+			Gamerules:JoinTeam( Player, 1 )
 		else
-			Gamerules:JoinTeam( Player, 2, nil, true )
+			Gamerules:JoinTeam( Player, 2 )
 		end
 	end
 end

--- a/lua/shine/lib/gui/objects/image.lua
+++ b/lua/shine/lib/gui/objects/image.lua
@@ -1,0 +1,16 @@
+--[[
+	Image control.
+]]
+
+local SGUI = Shine.GUI
+
+local Image = {}
+
+SGUI.AddBoundProperty( Image, "Colour", "Background:SetColor" )
+
+function Image:Initialise()
+	self.BaseClass.Initialise( self )
+	self.Background = GetGUIManager():CreateGraphicItem()
+end
+
+SGUI:Register( "Image", Image )


### PR DESCRIPTION
- The shuffle plugin's forcing of players onto teams when enforcing teams no longer passes the force argument.
- Fixed colour notifications not actually enforcing the message size limit.
- Added small previews of maps when hovering over their button in the vote menu. This only works for maps whose preview is currently mounted, so custom maps will not have a preview unless they're always mounted.