### PR TITLE
Add team swap highlighting, and small cleanup/bug fixes

### DIFF
--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -28,7 +28,7 @@ local TableRemove = table.remove
 local TableSort = table.sort
 local tostring = tostring
 
-local Plugin = {}
+local Plugin = Plugin
 Plugin.Version = "2.0"
 Plugin.PrintName = "Shuffle"
 Plugin.NotifyPrefixColour = {
@@ -95,7 +95,8 @@ Plugin.DefaultConfig = {
 	IgnoreSpectators = false, --Should the plugin ignore spectators when switching?
 	AlwaysEnabled = false, --Should the plugin be always forcing each round?
 
-	ReconnectLogTime = 0 --How long (in seconds) after a shuffle to log reconnecting players for?
+	ReconnectLogTime = 0, --How long (in seconds) after a shuffle to log reconnecting players for?
+	HighlightTeamSwaps = false -- Should players swapping teams be highlighted on the scoreboard?
 }
 Plugin.CheckConfig = true
 Plugin.CheckConfigTypes = true
@@ -158,6 +159,9 @@ function Plugin:Initialise()
 	self.ForceRandomEnd = 0 --Time based.
 	self.RandomOnNextRound = false --Round based.
 	self.ForceRandom = self.Config.AlwaysEnabled
+
+	self.dt.HighlightTeamSwaps = self.Config.HighlightTeamSwaps
+
 	self.Enabled = true
 
 	return true
@@ -1583,5 +1587,3 @@ function Plugin:CreateCommands()
 	local StatsCommand = self:BindCommand( "sh_teamstats", nil, ViewTeamStats, true )
 	StatsCommand:Help( "View Hive skill based team statistics." )
 end
-
-Shine:RegisterExtension( "voterandom", Plugin )

--- a/lua/shine/extensions/voterandom/shared.lua
+++ b/lua/shine/extensions/voterandom/shared.lua
@@ -1,0 +1,103 @@
+--[[
+	Shuffle plugin shared code.
+]]
+
+local Plugin = {}
+
+function Plugin:SetupDataTable()
+	self:AddDTVar( "boolean", "HighlightTeamSwaps", false )
+end
+
+Shine:RegisterExtension( "voterandom", Plugin )
+
+if Server then return end
+
+function Plugin:OnFirstThink()
+	-- Defensive check in case the scoreboard code changes.
+	if not Scoreboard_GetPlayerRecord or not GUIScoreboard or not GUIScoreboard.UpdateTeam then return end
+
+	Shine.Hook.SetupClassHook( "GUIScoreboard", "UpdateTeam", "OnGUIScoreboardUpdateTeam", "PassivePost" )
+end
+
+function Plugin:Initialise()
+	self.TeamTracking = {}
+	self.Enabled = true
+
+	return true
+end
+
+local function IsVisibleTeam( OurTeam, TeamNumber )
+	return OurTeam == TeamNumber or OurTeam == kTeamReadyRoom or OurTeam == kSpectatorIndex
+end
+
+local ClientGetLocalPlayer = Client.GetLocalPlayer
+
+local function GetLocalPlayerTeam()
+	local Player = ClientGetLocalPlayer()
+	if not Player then return nil end
+
+	return Player:GetTeamNumber()
+end
+
+local SharedGetTime = Shared.GetTime
+local CopyColour = Shine.GUI.CopyColour
+local pairs = pairs
+local FadeAlphaMin = 0.3
+local FadeAlphaMult = 1 - FadeAlphaMin
+local HighlightDuration = 10
+
+local function FadeRowIn( Row, Entry, Team, OurTeam, TeamNumber, TimeSinceLastChange )
+	local IsCommander = IsVisibleTeam( OurTeam, TeamNumber ) and Entry.IsCommander
+	local OriginalColour = IsCommander and GUIScoreboard.kCommanderFontColor or Team.Color
+
+	-- Fade the entry in for a short time after joining a team.
+	local Mult = FadeAlphaMin + ( TimeSinceLastChange / HighlightDuration ) * FadeAlphaMult
+	local HighlightColour = CopyColour( OriginalColour )
+	HighlightColour.a = Mult * OriginalColour.a
+
+	Row.Background:SetColor( HighlightColour )
+end
+
+local function CheckRow( self, Team, Row, OurTeam, TeamNumber, CurTime )
+	local ClientID = Row.ClientIndex
+	local Entry = Scoreboard_GetPlayerRecord( ClientID )
+	local MemoryEntry = self.TeamTracking[ ClientID ]
+
+	if not MemoryEntry then
+		MemoryEntry = {
+			TeamNumber = TeamNumber,
+			LastChange = CurTime
+		}
+		self.TeamTracking[ ClientID ] = MemoryEntry
+		return
+	end
+
+	if MemoryEntry.TeamNumber ~= TeamNumber then
+		MemoryEntry.TeamNumber = TeamNumber
+		MemoryEntry.LastChange = CurTime
+	end
+
+	local TimeSinceLastChange = CurTime - MemoryEntry.LastChange
+	if TimeSinceLastChange >= HighlightDuration then return end
+
+	FadeRowIn( Row, Entry, Team, OurTeam, TeamNumber, TimeSinceLastChange )
+end
+
+function Plugin:OnGUIScoreboardUpdateTeam( Scoreboard, Team )
+	if not self.dt.HighlightTeamSwaps then return end
+
+	local PlayerList = Team.PlayerList
+	local TeamNumber = Team.TeamNumber
+	local OurTeam = GetLocalPlayerTeam()
+
+	local CurTime = SharedGetTime()
+	for Index, Row in pairs( PlayerList ) do
+		CheckRow( self, Team, Row, OurTeam, TeamNumber, CurTime )
+	end
+
+	for ClientID in pairs( self.TeamTracking ) do
+		if not Scoreboard_GetPlayerRecord( ClientID ) then
+			self.TeamTracking[ ClientID ] = nil
+		end
+	end
+end

--- a/lua/shine/extensions/voterandom/shared.lua
+++ b/lua/shine/extensions/voterandom/shared.lua
@@ -43,6 +43,8 @@ function Plugin:Initialise()
 	-- Track changes in a separate timer too as the scoreboard's team update
 	-- only runs when the scoreboard is visible.
 	self:CreateTimer( "TrackTeamChanges", 1, -1, function()
+		if not self.dt.HighlightTeamSwaps then return end
+
 		local Scores = ScoreboardUI_GetAllScores()
 		local CurTime = SharedGetTime()
 		local Clients = {}

--- a/lua/shine/lib/map.lua
+++ b/lua/shine/lib/map.lua
@@ -4,18 +4,13 @@
 ]]
 
 local Clamp = math.Clamp
-local rawset = rawset
 local TableRemove = table.remove
 
 local Map = {}
 Map.__index = Map
 
-setmetatable( Map, { __call = function( self )
-	return setmetatable( {}, self ):Init()
-end } )
-
 function Shine.Map()
-	return Map()
+	return setmetatable( {}, Map ):Init()
 end
 
 function Map:Init()
@@ -46,14 +41,12 @@ function Map:Add( Key, Value )
 
 	if self.MemberLookup[ Key ] ~= nil then
 		self.MemberLookup[ Key ] = Value
-
 		return
 	end
 
 	local NumMembers = self.NumMembers + 1
 
 	self.NumMembers = NumMembers
-
 	self.Keys[ NumMembers ] = Key
 	self.MemberLookup[ Key ] = Value
 end
@@ -75,11 +68,11 @@ end
 	Output: The removed key, value pair if it existed in the map, otherwise nil.
 ]]
 function Map:Remove( Key )
-	if not self.MemberLookup[ Key ] then return nil end
+	if self.MemberLookup[ Key ] == nil then return nil end
 
 	local Keys = self.Keys
 
-	--Optimise removal if it's the current key.
+	-- Optimise removal if it's the current key.
 	if Keys[ self.Position ] == Key then
 		return self:RemoveAtPosition()
 	end

--- a/test/lib/map.lua
+++ b/test/lib/map.lua
@@ -40,6 +40,15 @@ UnitTest:Test( "IterationOrder", function( Assert )
 	end
 end )
 
+UnitTest:Test( "RemovalOfFalse", function( Assert )
+	local Map = Map()
+	Map:Add( 1, false )
+
+	Assert.False( "Map didn't store false!", Map:Get( 1 ) )
+	Map:Remove( 1 )
+	Assert.Nil( "Map didn't remove false!", Map:Get( 1 ) )
+end )
+
 UnitTest:Test( "IterationRemoval", function( Assert )
 	local Map = Map()
 


### PR DESCRIPTION
- Added `HighlightTeamSwaps` option to the "voterandom" plugin. When a player joins a new team, their entry on the scoreboard will be translucent and slowly fade in for 10 seconds after the change of team.
- Fixed the `Map` object not removing keys mapped to `false`.
- Fixed timer tracebacks showing the error handler function.