### PR TITLE
Add master badge table and cleanup badges plugin

### DIFF
--- a/lua/shine/extensions/afkkick.lua
+++ b/lua/shine/extensions/afkkick.lua
@@ -138,13 +138,17 @@ function Plugin:KickClient( Client )
 	Server.DisconnectClient( Client )
 end
 
+function Plugin:CanKickForConnectingClient()
+	return GetNumPlayersTotal() >= GetMaxPlayers()
+end
+
 --[[
 	On a new connection attempt when the server is full, kick the longest AFK player past
 	the kick time.
 ]]
 function Plugin:CheckConnectionAllowed( ID )
 	if not self.Config.KickOnConnect then return end
-	if GetNumPlayersTotal() < GetMaxPlayers() then return end
+	if not self:CanKickForConnectingClient() then return end
 
 	local AFKForLongest
 	local TimeAFK = 0

--- a/test/extensions/afkkick.lua
+++ b/test/extensions/afkkick.lua
@@ -1,0 +1,57 @@
+--[[
+	AFK kick plugin test.
+]]
+
+local UnitTest = Shine.UnitTest
+local AFKKick = UnitTest:LoadExtension( "afkkick" )
+if not AFKKick then return end
+
+local OldKickClient = AFKKick.KickClient
+local OldPrint = AFKKick.Print
+local OldCanKickForConnectingClient = AFKKick.CanKickForConnectingClient
+local OldGetClientInfo = Shine.GetClientInfo
+
+AFKKick.Print = function() end
+Shine.GetClientInfo = function() return "" end
+AFKKick.CanKickForConnectingClient = function() return true end
+
+UnitTest:Test( "KickOnConnect", function( Assert )
+	AFKKick.Config.KickOnConnect = true
+	AFKKick.Config.KickTime = 2
+
+	AFKKick.Users = {
+		[ 1 ] = {
+			AFKAmount = 2.5 * 60
+		},
+		[ 2 ] = {
+			AFKAmount = 0.5
+		},
+		[ 3 ] = {
+			AFKAmount = 5 * 60
+		}
+	}
+
+	-- Should kick client 3
+	local Kicked
+	AFKKick.KickClient = function( self, Client )
+		Assert:Equals( 3, Client )
+		Kicked = true
+	end
+
+	Assert:Nil( AFKKick:CheckConnectionAllowed( 123456 ) )
+	Assert:True( Kicked )
+
+	-- Should now not kick anyone.
+	AFKKick.Config.KickTime = 10
+	Kicked = false
+
+	Assert:Nil( AFKKick:CheckConnectionAllowed( 123456 ) )
+	Assert:False( Kicked )
+end, function()
+	AFKKick.Config.KickOnConnect = false
+end )
+
+AFKKick.Print = OldPrint
+AFKKick.KickClient = OldKickClient
+AFKKick.CanKickForConnectingClient = OldCanKickForConnectingClient
+Shine.GetClientInfo = OldGetClientInfo

--- a/test/extensions/badges.lua
+++ b/test/extensions/badges.lua
@@ -28,7 +28,7 @@ end
 
 UnitTest:Test( "GetMasterBadgeLookup", function( Assert )
 	local MasterBadgeTable
-	Assert:Nil( Badges:GetMasterBadgeLookup( MasterBadgeTable )	)
+	Assert:Nil( Badges:GetMasterBadgeLookup( MasterBadgeTable ) )
 
 	MasterBadgeTable = {
 		[ "1" ] = {

--- a/test/extensions/badges.lua
+++ b/test/extensions/badges.lua
@@ -1,0 +1,143 @@
+--[[
+	Badges plugin unit test.
+]]
+
+local UnitTest = Shine.UnitTest
+local Badges = UnitTest:LoadExtension( "badges" )
+if not Badges then return end
+
+local TableInsertUnique = table.InsertUnique
+
+local Assigned = {}
+local OldGiveBadge = GiveBadge
+
+function GiveBadge( ID, Badge, Row )
+	Row = Row or Badges.DefaultRow
+
+	local BadgeRows = Assigned[ ID ]
+	if not BadgeRows then
+		BadgeRows = {}
+		Assigned[ ID ] = BadgeRows
+	end
+
+	BadgeRows[ Row ] = BadgeRows[ Row ] or {}
+	TableInsertUnique( BadgeRows[ Row ], Badge )
+
+	return true
+end
+
+UnitTest:Test( "GetMasterBadgeLookup", function( Assert )
+	local MasterBadgeTable
+	Assert:Nil( Badges:GetMasterBadgeLookup( MasterBadgeTable )	)
+
+	MasterBadgeTable = {
+		[ "1" ] = {
+			"test1"
+		},
+		[ "2" ] = {
+			"test2", "test2b"
+		},
+		[ "8" ] = {
+			"test8"
+		}
+	}
+
+	local Lookup = Badges:GetMasterBadgeLookup( MasterBadgeTable )
+	Assert:NotNil( Lookup )
+	Assert:Equals( 1, Lookup.test1 )
+	Assert:Equals( 2, Lookup.test2 )
+	Assert:Equals( 2, Lookup.test2b )
+	Assert:Equals( 8, Lookup.test8 )
+end )
+
+UnitTest:Test( "MapBadgesToRows", function( Assert )
+	local BadgeList = { "test1", "test2", "test2b", "test8" }
+	local Lookup = {
+		test1 = 1, test2 = 2, test2b = 2, test8 = 8
+	}
+
+	local Rows = Badges:MapBadgesToRows( BadgeList, Lookup )
+	Assert:NotNil( Rows )
+
+	Assert:NotNil( Rows[ 1 ] )
+	Assert:NotNil( Rows[ 2 ] )
+	Assert:NotNil( Rows[ 8 ] )
+
+	Assert:ArrayEquals( { "test1" }, Rows[ 1 ] )
+	Assert:ArrayEquals( { "test2", "test2b" }, Rows[ 2 ] )
+	Assert:ArrayEquals( { "test8" }, Rows[ 8 ] )
+end )
+
+UnitTest:Test( "AssignBadgesToID", function( Assert )
+	local ID = 123456
+
+	-- No master table, one entry.
+	Badges:AssignBadgesToID( ID, {
+		Badge = "cake"
+	} )
+
+	Assert:NotNil( Assigned[ ID ] )
+	Assert:NotNil( Assigned[ ID ][ Badges.DefaultRow ] )
+	Assert:Contains( Assigned[ ID ][ Badges.DefaultRow ], "cake" )
+
+	local MasterTable = {
+		test1 = 1,
+		test2 = 2,
+		test3 = 3
+	}
+
+	-- Master table, one entry.
+	Badges:AssignBadgesToID( ID, {
+		Badge = "test1"
+	}, MasterTable )
+
+	Assert:NotNil( Assigned[ ID ][ MasterTable.test1 ] )
+	Assert:Contains( Assigned[ ID ][ MasterTable.test1 ], "test1" )
+
+	-- Master table, multiple entries.
+	Badges:AssignBadgesToID( ID, {
+		Badges = { "test2", "test3" }
+	}, MasterTable )
+
+	Assert:NotNil( Assigned[ ID ][ MasterTable.test2 ] )
+	Assert:NotNil( Assigned[ ID ][ MasterTable.test3 ] )
+	Assert:Contains( Assigned[ ID ][ MasterTable.test2 ], "test2" )
+	Assert:Contains( Assigned[ ID ][ MasterTable.test3 ], "test3" )
+
+	-- No master table, multiple entries.
+	Badges:AssignBadgesToID( ID, {
+		Badges = { "morecake", "somuchcake" }
+	} )
+	Assert:Contains( Assigned[ ID ][ Badges.DefaultRow ], "morecake" )
+	Assert:Contains( Assigned[ ID ][ Badges.DefaultRow ], "somuchcake" )
+
+	-- No master table, row based entry.
+	Badges:AssignBadgesToID( ID, {
+		Badges = {
+			[ "1" ] = { "ranoutofcake" },
+			[ "8" ] = { "ohwell" }
+		}
+	} )
+	Assert:Contains( Assigned[ ID ][ 1 ], "ranoutofcake" )
+	Assert:NotNil( Assigned[ ID ][ 8 ] )
+	Assert:Contains( Assigned[ ID ][ 8 ], "ohwell" )
+end, function()
+	Assigned = {}
+end )
+
+UnitTest:Test( "AssignGroupBadge", function( Assert )
+	local ID = 123456
+	local Group = {
+		Badges = { "cake", "morecake", "somuchcake" }
+	}
+
+	Badges:AssignGroupBadge( ID, "Test", Group )
+
+	-- Should assign all given badges, and the group name.
+	Assert:NotNil( Assigned[ ID ] )
+	Assert:NotNil( Assigned[ ID ][ Badges.DefaultRow ] )
+	Assert:ArrayEquals( { "cake", "morecake", "somuchcake", "test" },
+		Assigned[ ID ][ Badges.DefaultRow ] )
+end )
+
+GiveBadge = OldGiveBadge

--- a/test/test_init.lua
+++ b/test/test_init.lua
@@ -105,6 +105,14 @@ UnitTest.Assert = {
 	Exists = function( Table, Key ) return Table[ Key ] ~= nil end,
 	NotExists = function( Table, Key ) return Table[ Key ] == nil end,
 
+	Contains = function( Table, Value )
+		for i = 1, #Table do
+			if Table[ i ] == Value then return true end
+		end
+
+		return false
+	end,
+
 	ArrayEquals = function( Array, OtherArray )
 		if #Array ~= #OtherArray then return false end
 


### PR DESCRIPTION
Lets you set a globally defined set of rows, then all groups will use that to determine which rows to place their badges in.