### PR TITLE
Fix small mistake in assigning group badges

### DIFF
--- a/lua/shine/extensions/badges.lua
+++ b/lua/shine/extensions/badges.lua
@@ -165,7 +165,6 @@ function Plugin:Setup()
 			self:AssignBadgesToID( ID, User, MasterBadgeTable )
 			self:AssignGroupBadge( ID, GroupName, UserData.Groups[ GroupName ], {},
 				MasterBadgeTable )
-			}
 		end
 	end
 end
@@ -186,7 +185,6 @@ function Plugin:ClientConnect( Client )
 	self.AssignedGuests[ ID ] = true
 	self:AssignGroupBadge( ID, nil, DefaultGroup, {},
 		self:GetMasterBadgeLookup( Shine.UserData.Badges ) )
-	}
 end
 
 Shine:RegisterExtension( "badges", Plugin )

--- a/lua/shine/extensions/badges.lua
+++ b/lua/shine/extensions/badges.lua
@@ -163,8 +163,9 @@ function Plugin:Setup()
 			local GroupName = User.Group
 
 			self:AssignBadgesToID( ID, User, MasterBadgeTable )
-			self:AssignGroupBadge( ID, GroupName, UserData.Groups[ GroupName ],
+			self:AssignGroupBadge( ID, GroupName, UserData.Groups[ GroupName ], {},
 				MasterBadgeTable )
+			}
 		end
 	end
 end
@@ -183,8 +184,9 @@ function Plugin:ClientConnect( Client )
 	if UserData or self.AssignedGuests[ ID ] then return end
 
 	self.AssignedGuests[ ID ] = true
-	self:AssignGroupBadge( ID, nil, DefaultGroup,
+	self:AssignGroupBadge( ID, nil, DefaultGroup, {},
 		self:GetMasterBadgeLookup( Shine.UserData.Badges ) )
+	}
 end
 
 Shine:RegisterExtension( "badges", Plugin )


### PR DESCRIPTION
Forgot to account for the group lookup table argument.