### PR TITLE
Make the master badge table a multimap, oscillate swapped team player entries

### DIFF
--- a/lua/shine/extensions/voterandom/shared.lua
+++ b/lua/shine/extensions/voterandom/shared.lua
@@ -83,10 +83,14 @@ local function GetLocalPlayerTeam()
 	return Player:GetTeamNumber()
 end
 
+local Abs = math.abs
 local CopyColour = Shine.GUI.CopyColour
+local Cos = math.cos
+
 local FadeAlphaMin = 0.3
 local FadeAlphaMult = 1 - FadeAlphaMin
 local HighlightDuration = 10
+local OscillationMultiplier = HighlightDuration * math.pi * 0.5
 
 local function FadeRowIn( Row, Entry, Team, OurTeam, TeamNumber, TimeSinceLastChange )
 	if not Entry then return end
@@ -95,7 +99,7 @@ local function FadeRowIn( Row, Entry, Team, OurTeam, TeamNumber, TimeSinceLastCh
 	local OriginalColour = IsCommander and GUIScoreboard.kCommanderFontColor or Team.Color
 
 	-- Fade the entry in for a short time after joining a team.
-	local Mult = FadeAlphaMin + ( TimeSinceLastChange / HighlightDuration ) * FadeAlphaMult
+	local Mult = FadeAlphaMin + Abs( Cos( TimeSinceLastChange / HighlightDuration * OscillationMultiplier ) ) * FadeAlphaMult
 	local HighlightColour = CopyColour( OriginalColour )
 	HighlightColour.a = Mult * OriginalColour.a
 

--- a/lua/shine/lib/map.lua
+++ b/lua/shine/lib/map.lua
@@ -285,6 +285,8 @@ end
 function Multimap:Init( Values )
 	Map.Init( self )
 
+	self.Count = 0
+
 	if not Values then return self end
 
 	if getmetatable( Values ) == Multimap then
@@ -307,6 +309,14 @@ function Multimap:Init( Values )
 end
 
 --[[
+	Returns the number of distinct key-value pairs in the multimap,
+	not the number of keys.
+]]
+function Multimap:GetCount()
+	return self.Count
+end
+
+--[[
 	Adds a new value under the given key if the given key-value pair has not
 	been mapped already.
 ]]
@@ -315,8 +325,10 @@ function Multimap:Add( Key, Value )
 	if not Entry then
 		Entry = NewMap()
 		Map.Add( self, Key, Entry )
+
+		self.Count = self.Count + 1
 	elseif Entry:Get( Value ) == nil then
-		self.NumMembers = self.NumMembers + 1
+		self.Count = self.Count + 1
 	end
 
 	Entry:Add( Value, Value )
@@ -332,7 +344,7 @@ function Multimap:RemoveKeyValue( Key, Value )
 
 	local Removed = Entry:Remove( Value ) ~= nil
 	if Removed then
-		self.NumMembers = self.NumMembers - 1
+		self.Count = self.Count - 1
 	end
 
 	return Removed

--- a/lua/shine/lib/map.lua
+++ b/lua/shine/lib/map.lua
@@ -9,9 +9,10 @@ local TableRemove = table.remove
 local Map = {}
 Map.__index = Map
 
-function Shine.Map()
+local function NewMap()
 	return setmetatable( {}, Map ):Init()
 end
+Shine.Map = NewMap
 
 function Map:Init()
 	self.Keys = {}
@@ -256,4 +257,106 @@ function Map:IterateBackwards()
 	self.Position = self.NumMembers + 1
 
 	return GetPrevious, self
+end
+
+local getmetatable = getmetatable
+local pairs = pairs
+local TableRemoveByValue = table.RemoveByValue
+
+--[[
+	A multimap is a map that can map multiple values per key. It abstracts away the idiom of
+	storing lists in a map structure.
+]]
+local Multimap = setmetatable( {}, { __index = Map } )
+Multimap.__index = Multimap
+
+function Shine.Multimap( Values )
+	return setmetatable( {}, Multimap ):Init( Values )
+end
+
+--[[
+	Initialises the multimap.
+
+	If passed another multimap, it will copy all key-value pairs into this multimap.
+
+	If passed a normal table, it will copy all key-value pairs under the assumption
+	that all values are array-like.
+]]
+function Multimap:Init( Values )
+	Map.Init( self )
+
+	if not Values then return self end
+
+	if getmetatable( Values ) == Multimap then
+		for Key, List in Values:Iterate() do
+			for Value in List:Iterate() do
+				self:Add( Key, Value )
+			end
+		end
+
+		return self
+	end
+
+	for Key, List in pairs( Values ) do
+		for i = 1, #List do
+			self:Add( Key, List[ i ] )
+		end
+	end
+
+	return self
+end
+
+--[[
+	Adds a new value under the given key if the given key-value pair has not
+	been mapped already.
+]]
+function Multimap:Add( Key, Value )
+	local Entry = Map.Get( self, Key )
+	if not Entry then
+		Entry = NewMap()
+		Map.Add( self, Key, Entry )
+	elseif Entry:Get( Value ) == nil then
+		self.NumMembers = self.NumMembers + 1
+	end
+
+	Entry:Add( Value, Value )
+end
+
+--[[
+	Removes a key-value pair from the multimap, if it exists. Returns true if the
+	given pair was found and removed, false otherwise.
+]]
+function Multimap:RemoveKeyValue( Key, Value )
+	local Entry = Map.Get( self, Key )
+	if not Entry then return end
+
+	local Removed = Entry:Remove( Value ) ~= nil
+	if Removed then
+		self.NumMembers = self.NumMembers - 1
+	end
+
+	return Removed
+end
+
+--[[
+	Returns a table will all values for the given key. Avoid modifying this table,
+	or you will disrupt the multimap.
+]]
+function Multimap:Get( Key )
+	local Entry = Map.Get( self, Key )
+	if not Entry then return nil end
+
+	return Entry.Keys
+end
+
+--[[
+	Returns a table copy of the multimap as a standard Lua table of keys and
+	table of values.
+]]
+function Multimap:AsTable()
+	local Table = {}
+	for Row, List in self:Iterate() do
+		Table[ Row ] = List.Keys
+	end
+	return Table
 end

--- a/test/extensions/badges.lua
+++ b/test/extensions/badges.lua
@@ -38,22 +38,22 @@ UnitTest:Test( "GetMasterBadgeLookup", function( Assert )
 			"test2", "test2b"
 		},
 		[ "8" ] = {
-			"test8"
+			"test8", "test1"
 		}
 	}
 
 	local Lookup = Badges:GetMasterBadgeLookup( MasterBadgeTable )
 	Assert:NotNil( Lookup )
-	Assert:Equals( 1, Lookup.test1 )
-	Assert:Equals( 2, Lookup.test2 )
-	Assert:Equals( 2, Lookup.test2b )
-	Assert:Equals( 8, Lookup.test8 )
+	Assert:ArrayEquals( { 1, 8 }, Lookup:Get( "test1" ) )
+	Assert:ArrayEquals( { 2 }, Lookup:Get( "test2" ) )
+	Assert:ArrayEquals( { 2 }, Lookup:Get( "test2b" ) )
+	Assert:ArrayEquals( { 8 }, Lookup:Get( "test8" ) )
 end )
 
 UnitTest:Test( "MapBadgesToRows", function( Assert )
 	local BadgeList = { "test1", "test2", "test2b", "test8" }
-	local Lookup = {
-		test1 = 1, test2 = 2, test2b = 2, test8 = 8
+	local Lookup = Shine.Multimap{
+		test1 = { 1, 8 }, test2 = { 2 }, test2b = { 2 }, test8 = { 8 }
 	}
 
 	local Rows = Badges:MapBadgesToRows( BadgeList, Lookup )
@@ -65,7 +65,7 @@ UnitTest:Test( "MapBadgesToRows", function( Assert )
 
 	Assert:ArrayEquals( { "test1" }, Rows[ 1 ] )
 	Assert:ArrayEquals( { "test2", "test2b" }, Rows[ 2 ] )
-	Assert:ArrayEquals( { "test8" }, Rows[ 8 ] )
+	Assert:ArrayEquals( { "test1", "test8" }, Rows[ 8 ] )
 end )
 
 UnitTest:Test( "AssignBadgesToID", function( Assert )
@@ -80,10 +80,10 @@ UnitTest:Test( "AssignBadgesToID", function( Assert )
 	Assert:NotNil( Assigned[ ID ][ Badges.DefaultRow ] )
 	Assert:Contains( Assigned[ ID ][ Badges.DefaultRow ], "cake" )
 
-	local MasterTable = {
-		test1 = 1,
-		test2 = 2,
-		test3 = 3
+	local MasterTable = Shine.Multimap{
+		test1 = { 1 },
+		test2 = { 2 },
+		test3 = { 3 }
 	}
 
 	-- Master table, one entry.
@@ -91,18 +91,18 @@ UnitTest:Test( "AssignBadgesToID", function( Assert )
 		Badge = "test1"
 	}, MasterTable )
 
-	Assert:NotNil( Assigned[ ID ][ MasterTable.test1 ] )
-	Assert:Contains( Assigned[ ID ][ MasterTable.test1 ], "test1" )
+	Assert:NotNil( Assigned[ ID ][ 1 ] )
+	Assert:Contains( Assigned[ ID ][ 1 ], "test1" )
 
 	-- Master table, multiple entries.
 	Badges:AssignBadgesToID( ID, {
 		Badges = { "test2", "test3" }
 	}, MasterTable )
 
-	Assert:NotNil( Assigned[ ID ][ MasterTable.test2 ] )
-	Assert:NotNil( Assigned[ ID ][ MasterTable.test3 ] )
-	Assert:Contains( Assigned[ ID ][ MasterTable.test2 ], "test2" )
-	Assert:Contains( Assigned[ ID ][ MasterTable.test3 ], "test3" )
+	Assert:NotNil( Assigned[ ID ][ 2 ] )
+	Assert:NotNil( Assigned[ ID ][ 3 ] )
+	Assert:Contains( Assigned[ ID ][ 2 ], "test2" )
+	Assert:Contains( Assigned[ ID ][ 3 ], "test3" )
 
 	-- No master table, multiple entries.
 	Badges:AssignBadgesToID( ID, {

--- a/test/lib/map.lua
+++ b/test/lib/map.lua
@@ -148,3 +148,59 @@ UnitTest:Test( "EmptyMapIterators", function( Assert )
 
 	Assert.Equals( "Generic for backwards on an empty map iterated > 0 times!", 0, i )
 end )
+
+local Multimap = Shine.Multimap
+
+UnitTest:Test( "Multimap:Add()/Get()/GetCount()", function( Assert )
+	local Map = Multimap()
+
+	Map:Add( 1, 1 )
+	Map:Add( 1, 2 )
+	Map:Add( 1, 3 )
+	Map:Add( 2, 1 )
+	Map:Add( 3, 1 )
+	Map:Add( 3, 2 )
+
+	Assert:ArrayEquals( { 1, 2, 3 }, Map:Get( 1 ) )
+	Assert:ArrayEquals( { 1 }, Map:Get( 2 ) )
+	Assert:ArrayEquals( { 1, 2 }, Map:Get( 3 ) )
+
+	Assert:Equals( 6, Map:GetCount() )
+end )
+
+UnitTest:Test( "Multimap:RemoveKeyValue()", function( Assert )
+	local Map = Multimap()
+	Map:Add( 1, 1 )
+	Map:Add( 1, 2 )
+	Map:Add( 1, 3 )
+
+	Assert:ArrayEquals( { 1, 2, 3 }, Map:Get( 1 ) )
+	Assert:Equals( 3, Map:GetCount() )
+
+	Map:RemoveKeyValue( 1, 2 )
+	Assert:ArrayEquals( { 1, 3 }, Map:Get( 1 ) )
+	Assert:Equals( 2, Map:GetCount() )
+end )
+
+UnitTest:Test( "Multimap from table", function( Assert )
+	local Map = Multimap{
+		{ 1, 2, 3 }, { 1 }, { 1, 2 }
+	}
+
+	Assert:ArrayEquals( { 1, 2, 3 }, Map:Get( 1 ) )
+	Assert:ArrayEquals( { 1 }, Map:Get( 2 ) )
+	Assert:ArrayEquals( { 1, 2 }, Map:Get( 3 ) )
+
+	Assert:Equals( 6, Map:GetCount() )
+end )
+
+UnitTest:Test( "Multimap from multimap", function( Assert )
+	local Map = Multimap()
+	Map:Add( 1, 1 )
+	Map:Add( 1, 2 )
+	Map:Add( 1, 3 )
+
+	local Map2 = Multimap( Map )
+	Assert:ArrayEquals( { 1, 2, 3 }, Map2:Get( 1 ) )
+	Assert:Equals( 3, Map2:GetCount() )
+end )


### PR DESCRIPTION
- Specifying badges in multiple rows in the master table will now put them in those multiple rows when given in a group's `Badges` array.
- Team entries in the scoreboard now oscillate between translucent and opaque after a player swaps teams, rather than just fading in.