### PR TITLE
External API support, and some feature requests/additions

### DIFF
--- a/lua/shine/cl_init.lua
+++ b/lua/shine/cl_init.lua
@@ -12,6 +12,7 @@ local Scripts = {
 	"lib/comparator.lua",
 	"lib/sorting.lua",
 	"lib/stream.lua",
+	"lib/queue.lua",
 	"lib/utf8.lua",
 	"lib/class.lua",
 	"lib/math.lua",

--- a/lua/shine/core/server/config.lua
+++ b/lua/shine/core/server/config.lua
@@ -65,6 +65,10 @@ local DefaultConfig = {
 		workshopupdater = false
 	},
 
+	APIKeys = {
+		Steam = ""
+	},
+
 	EqualsCanTarget = false, --Defines whether users with the same immunity can target each other or not.
 
 	NotifyOnCommand = false, --Should we display a notification for commands such as kick, ban etc?

--- a/lua/shine/extensions/adverts.lua
+++ b/lua/shine/extensions/adverts.lua
@@ -4,16 +4,18 @@
 
 local Shine = Shine
 
+local TableQuickCopy = table.QuickCopy
+local TableQuickShuffle = table.QuickShuffle
 local TableRemove = table.remove
 local type = type
 
 local Plugin = {}
-Plugin.Version = "1.0"
+Plugin.Version = "1.1"
 Plugin.PrintName = "Adverts"
 
 Plugin.HasConfig = true
+Plugin.CheckConfigTypes = true
 Plugin.ConfigName = "Adverts.json"
-
 Plugin.DefaultConfig = {
 	Adverts = {
 		{
@@ -31,16 +33,15 @@ Plugin.DefaultConfig = {
 			B = 255
 		}
 	},
-	Interval = 60
+	Interval = 60,
+	RandomiseOrder = false
 }
-
-Plugin.CheckConfigTypes = true
 
 Plugin.TimerName = "Adverts"
 
 function Plugin:Initialise()
+	self.AdvertsList = TableQuickCopy( self.Config.Adverts )
 	self:SetupTimer()
-
 	self.Enabled = true
 
 	return true
@@ -52,49 +53,56 @@ function Plugin:ParseAdvert( ID, Advert )
 	if IsType( Advert, "string" ) then
 		Shine:NotifyColour( nil, 255, 255, 255, Advert )
 
-		return
+		return true
 	end
 
-	if IsType( Advert, "table" ) then
-		local Message = Advert.Message
+	if not IsType( Advert, "table" ) then
+		self:Print( "Misconfigured advert #%i, neither a table nor a string.", true, ID )
 
-		if not Message then
-			self:Print( "Misconfigured advert #%i, missing \"Message\" value.",
-				true, ID )
+		TableRemove( self.AdvertsList, ID )
 
-			TableRemove( self.Config.Adverts, ID )
-
-			return
-		end
-
-		local R = Advert.R or Advert.r or 255
-		local G = Advert.G or Advert.g or 255
-		local B = Advert.B or Advert.b or 255
-
-		local Type = Advert.Type
-
-		if not Type or Type == "chat" then
-			Shine:NotifyColour( nil, R, G, B, Message )
-		else
-			local Position = ( Advert.Position or "top" ):lower()
-
-			local X, Y = 0.5, 0.2
-			local Align = 1
-
-			if Position == "bottom" then
-				X, Y = 0.5, 0.8
-			end
-
-			Shine.ScreenText.Add( 20, {
-				X = X, Y = Y,
-				Text = Message,
-				Duration = 7,
-				R = R, G = G, B = B,
-				Alignment = Align,
-				Size = 2, FadeIn = 1
-			} )
-		end
+		return false
 	end
+
+	local Message = Advert.Message
+	if not Message then
+		self:Print( "Misconfigured advert #%i, missing \"Message\" value.",
+			true, ID )
+
+		TableRemove( self.AdvertsList, ID )
+
+		return false
+	end
+
+	local R = Advert.R or Advert.r or 255
+	local G = Advert.G or Advert.g or 255
+	local B = Advert.B or Advert.b or 255
+
+	local Type = Advert.Type
+
+	if not Type or Type == "chat" then
+		Shine:NotifyColour( nil, R, G, B, Message )
+	else
+		local Position = ( Advert.Position or "top" ):lower()
+
+		local X, Y = 0.5, 0.2
+		local Align = 1
+
+		if Position == "bottom" then
+			X, Y = 0.5, 0.8
+		end
+
+		Shine.ScreenText.Add( 20, {
+			X = X, Y = Y,
+			Text = Message,
+			Duration = 7,
+			R = R, G = G, B = B,
+			Alignment = Align,
+			Size = 2, FadeIn = 1
+		} )
+	end
+
+	return true
 end
 
 function Plugin:SetupTimer()
@@ -102,13 +110,21 @@ function Plugin:SetupTimer()
 		self:DestroyTimer( self.TimerName )
 	end
 
-	if #self.Config.Adverts == 0 then return end
+	if #self.AdvertsList == 0 then return end
 
 	local Message = 1
 
 	self:CreateTimer( self.TimerName, self.Config.Interval, -1, function()
-		self:ParseAdvert( Message, self.Config.Adverts[ Message ] )
-		Message = ( Message % #self.Config.Adverts ) + 1
+		-- Back to the start, randomise the order again.
+		if Message == 1 and self.Config.RandomiseOrder then
+			TableQuickShuffle( self.AdvertsList )
+		end
+
+		if self:ParseAdvert( Message, self.AdvertsList[ Message ] ) then
+			Message = ( Message % #self.AdvertsList ) + 1
+		elseif #self.AdvertList == 0 then
+			self:DestroyTimer( self.TimerName )
+		end
 	end )
 end
 

--- a/lua/shine/extensions/afkkick.lua
+++ b/lua/shine/extensions/afkkick.lua
@@ -445,10 +445,6 @@ end
 
 --Override the built in randomise ready room vote to not move AFK players.
 Shine.Hook.Add( "OnFirstThink", "AFKKick_OverrideVote", function()
-	local PlayingTeamNumbers = {
-		true, true
-	}
-
 	do
 		local function CheckPlayerIsAFK( Player )
 			if not Player then return end
@@ -461,7 +457,7 @@ Shine.Hook.Add( "OnFirstThink", "AFKKick_OverrideVote", function()
 				return
 			end
 
-			if PlayingTeamNumbers[ Player:GetTeamNumber() ] then
+			if Shine.IsPlayingTeam( Player:GetTeamNumber() ) then
 				local Gamerules = GetGamerules()
 
 				pcall( Gamerules.JoinTeam, Gamerules, Player,
@@ -487,7 +483,7 @@ Shine.Hook.Add( "OnFirstThink", "AFKKick_OverrideVote", function()
 		if not Client or Plugin:IsAFKFor( Client, 60 ) then
 			ShouldKeep = false
 
-			if Client and PlayingTeamNumbers[ Player:GetTeamNumber() ] then
+			if Client and Shine.IsPlayingTeam( Player:GetTeamNumber() ) then
 				local Gamerules = GetGamerules()
 
 				pcall( Gamerules.JoinTeam, Gamerules, Player, kTeamReadyRoom, nil, true )

--- a/lua/shine/extensions/afkkick.lua
+++ b/lua/shine/extensions/afkkick.lua
@@ -267,8 +267,9 @@ function Plugin:OnProcessMove( Player, Input )
 	end
 
 	--Ignore players waiting to respawn/watching the end of the game.
-	if Player:GetIsWaitingForTeamBalance() or ( Player.GetIsRespawning
-	and Player:GetIsRespawning() ) or Player:isa( "TeamSpectator" ) then
+	if Player:isa( "TeamSpectator" )
+	or ( Player.GetIsWaitingForTeamBalance and Player:GetIsWaitingForTeamBalance() )
+	or ( Player.GetIsRespawning and Player:GetIsRespawning() ) then
 		self:ResetAFKTime( Client )
 
 		return

--- a/lua/shine/extensions/ban/server.lua
+++ b/lua/shine/extensions/ban/server.lua
@@ -323,12 +323,11 @@ end
 	Checks bans on startup.
 ]]
 function Plugin:CheckBans()
-	local CurTime = Time()
 	local Bans = self.Config.Banned
 	local Edited
 
 	for ID, Data in pairs( Bans ) do
-		if Data.UnbanTime and Data.UnbanTime ~= 0 and Data.UnbanTime < CurTime then
+		if self:IsBanExpired( Data ) then
 			self:RemoveBan( ID, true )
 			Edited = true
 		end

--- a/lua/shine/extensions/ban/server.lua
+++ b/lua/shine/extensions/ban/server.lua
@@ -663,7 +663,7 @@ function Plugin:CheckFamilySharing( ID, NoAPIRequest )
 	if not self.Config.CheckFamilySharing then return false end
 
 	local RequestParams = {
-		SteamID = ID
+		steamid = ID
 	}
 
 	local Sharer = Shine.ExternalAPIHandler:GetCachedValue( "Steam", "IsPlayingSharedGame", RequestParams )

--- a/lua/shine/extensions/chatbox/client.lua
+++ b/lua/shine/extensions/chatbox/client.lua
@@ -615,6 +615,10 @@ do
 			Setup = function( self, Object, Data )
 				Object:SetBounds( unpack( Data.Bounds ) )
 
+				if Data.OnSlide then
+					Object.OnSlide = Data.OnSlide
+				end
+
 				if IsType( Data.ConfigValue, "string" ) then
 					Object.OnValueChanged = function( Object, Value )
 						UpdateConfigValue( self, Data.ConfigValue, Value )
@@ -692,6 +696,9 @@ do
 				if not UpdateConfigValue( self, "Opacity", Value ) then return end
 
 				UpdateOpacity( self, Value )
+			end,
+			OnSlide = function( Slider, Value )
+				UpdateOpacity( Plugin, Value * 0.01 )
 			end,
 			Bounds = { 0, 100 },
 			Values = function( self )

--- a/lua/shine/extensions/commbans/shared.lua
+++ b/lua/shine/extensions/commbans/shared.lua
@@ -10,6 +10,7 @@ Shine:RegisterExtension( "commbans", Plugin, {
 	Base = "ban",
 	BlacklistKeys = {
 		CheckConnectionAllowed = true,
+		ClientConnect = true,
 		OnWebConfigLoaded = true,
 		BanNetworkData = true,
 		BanNetworkedClients = true,

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -1268,7 +1268,7 @@ function Plugin:JoinTeam( Gamerules, Player, NewTeam, Force, ShineForce )
 	if Immune then return end
 
 	local Team = Player:GetTeamNumber()
-	local OnPlayingTeam = Team == 1 or Team == 2
+	local OnPlayingTeam = Shine.IsPlayingTeam( Team )
 
 	local NumTeam1 = Gamerules.team1:GetNumPlayers()
 	local NumTeam2 = Gamerules.team2:GetNumPlayers()

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -96,7 +96,8 @@ Plugin.DefaultConfig = {
 	AlwaysEnabled = false, --Should the plugin be always forcing each round?
 
 	ReconnectLogTime = 0, --How long (in seconds) after a shuffle to log reconnecting players for?
-	HighlightTeamSwaps = false -- Should players swapping teams be highlighted on the scoreboard?
+	HighlightTeamSwaps = false, -- Should players swapping teams be highlighted on the scoreboard?
+	DisplayStandardDeviations = false -- Should the scoreboard show each team's standard deviation of skill?
 }
 Plugin.CheckConfig = true
 Plugin.CheckConfigTypes = true
@@ -161,6 +162,8 @@ function Plugin:Initialise()
 	self.ForceRandom = self.Config.AlwaysEnabled
 
 	self.dt.HighlightTeamSwaps = self.Config.HighlightTeamSwaps
+	self.dt.DisplayStandardDeviations = self.Config.DisplayStandardDeviations
+		and BalanceMode == self.MODE_HIVE
 
 	self.Enabled = true
 

--- a/lua/shine/init.lua
+++ b/lua/shine/init.lua
@@ -10,6 +10,7 @@ local Scripts = {
 	"lib/comparator.lua",
 	"lib/sorting.lua",
 	"lib/stream.lua",
+	"lib/queue.lua",
 	"lib/string.lua",
 	"lib/utf8.lua",
 	"lib/math.lua",

--- a/lua/shine/lib/external_apis.lua
+++ b/lua/shine/lib/external_apis.lua
@@ -149,6 +149,8 @@ if Server then
 	ExternalAPIHandler.CacheLifeTime = 60 * 60 * 24
 
 	function ExternalAPIHandler:SaveCache()
+		if not next( self.Cache ) and not self.LoadedFromDisk then return end
+
 		Shine.SaveJSONFile( self.Cache, APICacheFile )
 	end
 
@@ -177,7 +179,10 @@ if Server then
 	end
 
 	Shine.Hook.Add( "PostloadConfig", "ExternalAPIHandlerCache", function()
-		ExternalAPIHandler.Cache = Shine.LoadJSONFile( APICacheFile ) or ExternalAPIHandler.Cache
+		local DiskCache = Shine.LoadJSONFile( APICacheFile )
+		ExternalAPIHandler.Cache = DiskCache or ExternalAPIHandler.Cache
+		ExternalAPIHandler.LoadedFromDisk = DiskCache ~= nil
+
 		TrimCache( ExternalAPIHandler.Cache )
 
 		for Name, Key in pairs( Shine.Config.APIKeys ) do

--- a/lua/shine/lib/external_apis.lua
+++ b/lua/shine/lib/external_apis.lua
@@ -181,7 +181,7 @@ if Server then
 	Shine.Hook.Add( "PostloadConfig", "ExternalAPIHandlerCache", function()
 		local DiskCache = Shine.LoadJSONFile( APICacheFile )
 		ExternalAPIHandler.Cache = DiskCache or ExternalAPIHandler.Cache
-		ExternalAPIHandler.LoadedFromDisk = DiskCache ~= nil
+		ExternalAPIHandler.LoadedFromDisk = DiskCache ~= false
 
 		TrimCache( ExternalAPIHandler.Cache )
 

--- a/lua/shine/lib/external_apis.lua
+++ b/lua/shine/lib/external_apis.lua
@@ -1,0 +1,284 @@
+--[[
+	Handles external API endpoints, such as the Steam API.
+]]
+
+local Shine = Shine
+
+local OSTime = os.time
+local StringFormat = string.format
+local tostring = tostring
+
+local APIs = {
+	Steam = {
+		URL = "http://api.steampowered.com/",
+		Params = {
+			APIKey = tostring
+		},
+		EndPoints = {
+			-- Determines if a player is playing with a family shared account.
+			-- Callback returns the NS2ID of the player sharing the game, or false if the player owns the game.
+			IsPlayingSharedGame = {
+				Protocol = "GET",
+				URL = "IPlayerService/IsPlayingSharedGame/v0001/?key={APIKey}&steamid={SteamID}&appid_playing=4920&format=json",
+				Params = {
+					SteamID = Shine.NS2IDTo64
+				},
+				GetCacheKey = function( Params ) return tostring( Params.SteamID ) end,
+				ResponseTransformer = function( Response )
+					-- Do not cache on invalid JSON.
+					if not Response then return nil end
+
+					local Lender = Response.lender_steamid
+					if not Lender or Lender == "0" then return false end
+
+					return Shine.SteamID64ToNS2ID( Lender )
+				end
+			}
+		}
+	}
+}
+
+local APICallers = {}
+
+--[[
+	Registers an external API.
+
+	Data should contain the following fields:
+	- Params: If provided, a list of parameters that are always required, e.g. an API key.
+	- URL: The base URL all endpoints start with.
+]]
+function Shine.RegisterExternalAPI( APIName, Data )
+	APIData[ APIName ] = Data
+end
+
+do
+	local Decode = json.decode
+	local StringGSub = string.gsub
+
+	--[[
+		Registers an endpoint under the given API.
+
+		Data should contain the following fields:
+		- GetCacheKey: If provided, should be a function that returns a single string that
+		  uniquely identifies the given request parameters.
+
+		- Params: A table of functions which receive a single value, and return a string.
+		  These will be used to convert the provided request parameters.
+
+		- Protocol: The protocol the API requires, e.g. "GET" or "POST".
+
+		- ResponseTransformer: A function that receives the JSON object from the response,
+		  and should return a value representing the response.
+
+		- URL: The path to append to the API's primary URL. Request parameters should be
+		  placed using {Param}.
+	]]
+	local function RegisterEndPoint( APIName, EndPointName, Data )
+		local APIData = APIs[ APIName ]
+		if not APIData then
+			error( "Attempted to register an endpoint before its API", 2 )
+		end
+
+		APIData[ EndPointName ] = Data
+		APICallers[ APIName ] = APICallers[ APIName ] or {}
+
+		local URL = APIData.URL..Data.URL
+		local IsPOST = Data.Protocol == "POST"
+
+		setmetatable( Data.Params, { __index = APIData.Params } )
+
+		APICallers[ APIName ][ EndPointName ] = function( RequestParams, Callbacks, Attempts )
+			Attempts = Attempts or 1
+
+			-- Parse the request parameters using the set converters.
+			local RequestURL = StringGSub( URL, "{([^}]+)}", function( Match )
+				if not RequestParams[ Match ] then
+					error( StringFormat( "Missing request parameter: '%s'", Match ), 3 )
+				end
+				return Data.Params[ Match ]( RequestParams[ Match ] )
+			end )
+
+			local OldOnSuccess = Callbacks.OnSuccess
+			Callbacks.OnSuccess = function( Response )
+				OldOnSuccess( Data.ResponseTransformer( Decode( Response ) ) )
+			end
+
+			if IsPOST then
+				Shine.HTTPRequestWithRetry( RequestURL, Data.Protocol, RequestParams.POST, Callbacks, Attempts )
+			else
+				Shine.HTTPRequestWithRetry( RequestURL, Data.Protocol, Callbacks, Attempts )
+			end
+		end
+	end
+	Shine.RegisterExternalAPIEndPoint = RegisterEndPoint
+
+	for APIName, APIData in pairs( APIs ) do
+		for EndPointName, Data in pairs( APIData.EndPoints ) do
+			RegisterEndPoint( APIName, EndPointName, Data )
+		end
+	end
+end
+
+local ExternalAPIHandler = {
+	Cache = {},
+	Queue = Shine.Queue()
+}
+Shine.ExternalAPIHandler = ExternalAPIHandler
+
+-- Only cache to disk on the server, not the client.
+if Server then
+	local APICacheFile = "config://shine/ExternalAPICache.json"
+
+	ExternalAPIHandler.CacheLifeTime = 60 * 60 * 24
+
+	function ExternalAPIHandler:SaveCache()
+		Shine.SaveJSONFile( self.Cache, APICacheFile )
+	end
+
+	-- Delete any cached responses older than the cache life time.
+	local function TrimCache( Cache )
+		local Time = OSTime()
+
+		-- Horrible nested loops, but it's only run once on startup.
+		for APIName, EndPointCaches in pairs( Cache ) do
+			for EndPointName, EndPointCache in pairs( EndPointCaches ) do
+				for CacheKey, CacheEntry in pairs( EndPointCache ) do
+					if CacheEntry.ExpiryTime < Time then
+						EndPointCache[ CacheKey ] = nil
+					end
+				end
+
+				if not next( EndPointCache ) then
+					EndPointCaches[ EndPointName ] = nil
+				end
+			end
+
+			if not next( EndPointCaches ) then
+				Cache[ APIName ] = nil
+			end
+		end
+	end
+
+	Shine.Hook.Add( "PostloadConfig", "ExternalAPIHandlerCache", function()
+		ExternalAPIHandler.Cache = Shine.LoadJSONFile( APICacheFile ) or ExternalAPIHandler.Cache
+		TrimCache( ExternalAPIHandler.Cache )
+	end )
+
+	Shine.Hook.Add( "MapChange", "ExternalAPIHandlerCache", function()
+		ExternalAPIHandler:SaveCache()
+	end )
+end
+
+--[[
+	Returns the requested endpoint definition, if it exists.
+]]
+function ExternalAPIHandler:GetEndPoint( APIName, EndPointName )
+	return APIs[ APIName ] and APIs[ APIName ][ EndPointName ]
+end
+
+function ExternalAPIHandler:VerifyEndPoint( APIName, EndPointName )
+	local EndPoint = self:GetEndPoint( APIName, EndPointName )
+	if not EndPoint then
+		error( StringFormat( "Attempted to use a non-existent API endpoint (%s.%s)", APIName, EndPointName ), 3 )
+	end
+	return EndPoint
+end
+
+--[[
+	Returns the value cached for the given API, endpoint and request parameters.
+	This will be nil if no value is stored.
+]]
+function ExternalAPIHandler:GetCachedValue( APIName, EndPointName, Params )
+	local EndPoint = self:VerifyEndPoint( APIName, EndPointName )
+
+	-- Endpoints decide how their parameters should map in the cache (if at all).
+	local CacheKey = EndPoint.GetCacheKey and EndPoint.GetCacheKey( Params )
+	local EndPointCache = self.Cache[ APIName ] and self.Cache[ APIName ][ EndPointName ]
+	if not EndPointCache or CacheKey == nil then
+		return nil
+	end
+
+	-- Refresh the expiry time on access.
+	local CacheEntry = EndPointCache[ CacheKey ]
+	if CacheEntry then
+		CacheEntry.ExpiryTime = OSTime() + self.CacheLifeTime
+	end
+
+	return CacheEntry and CacheEntry.Value
+end
+
+do
+	local OnError = Shine.BuildErrorHandler( "External API callback error" )
+	local TableBuild = table.Build
+	local xpcall = xpcall
+
+	function ExternalAPIHandler:AddToCache( APIName, EndPointName, Params, Result )
+		local EndPoint = self:GetEndPoint( APIName, EndPointName )
+		local CacheKey = EndPoint.GetCacheKey and EndPoint.GetCacheKey( Params )
+		if CacheKey == nil then return end
+
+		local Cached = TableBuild( self.Cache, APIName, EndPointName )
+		Cached[ CacheKey ] = {
+			Value = Result,
+			ExpiryTime = OSTime() + self.CacheLifeTime
+		}
+	end
+
+	--[[
+		Performs a request to a registered external API URL.
+
+		Inputs:
+			1. APIName - The name of the API.
+			2. EndPointName - The name of the endpoint under the API.
+			3. Params - The request parameters, endpoint dependent.
+			4. Callbacks - A table containing functions "OnSuccess", "OnFailure" and
+			   optionally "OnTimeout". "OnSuccess" receives the response from the API (transformed by
+			   the endpoint definition if it has a transformer function).
+			5. Attempts - Optional maximum number of retry attempts, defaults to only 1 attempt.
+	]]
+	function ExternalAPIHandler:PerformRequest( APIName, EndPointName, Params, Callbacks, Attempts )
+		local EndPoint = self:VerifyEndPoint( APIName, EndPointName )
+		local Caller = APICallers[ APIName ][ EndPointName ]
+
+		-- Cache the result and advance the queue on success.
+		local OldOnSuccess = Callbacks.OnSuccess
+		Callbacks.OnSuccess = function( Result )
+			self:AddToCache( APIName, EndPointName, Params, Result )
+
+			xpcall( OldOnSuccess, OnError, Result )
+
+			self:ProcessQueue()
+		end
+
+		-- Advance the queue on failure.
+		local OldOnFailure = Callbacks.OnFailure
+		Callbacks.OnFailure = function()
+			xpcall( OldOnFailure, OnError )
+
+			self:ProcessQueue()
+		end
+
+		self.Queue:Add( {
+			Caller = Caller,
+			Args = { Params, Callbacks, Attempts }
+		} )
+
+		-- Waiting on previous request(s) to finish.
+		if self.Queue:GetCount() > 1 then return end
+
+		self:ProcessQueue()
+	end
+end
+
+--[[
+	Internal function, do not call. This is called automatically as requests
+	are added and satisfied.
+
+	Advanced the request queue, if there are still requests pending.
+]]
+function ExternalAPIHandler:ProcessQueue()
+	local Queued = self.Queue:Pop()
+	if not Queued then return end
+
+	Queued.Caller( unpack( Queued.Args ) )
+end

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -102,6 +102,17 @@ function ControlMeta:SetupFromTable( Table )
 	end
 end
 
+do
+	local TableShallowMerge = table.ShallowMerge
+
+	--[[
+		Use to more easily setup multiple callback methods.
+	]]
+	function ControlMeta:AddMethods( Methods )
+		TableShallowMerge( Methods, self, true )
+	end
+end
+
 --[[
 	Sets a control's parent manually.
 ]]

--- a/lua/shine/lib/gui/objects/checkbox.lua
+++ b/lua/shine/lib/gui/objects/checkbox.lua
@@ -76,9 +76,7 @@ function CheckBox:SetChecked( Value, DontFade )
 			end )
 		end
 
-		if self.OnChecked then
-			self:OnChecked( true )
-		end
+		self:OnChecked( true )
 
 		return
 	end
@@ -93,9 +91,7 @@ function CheckBox:SetChecked( Value, DontFade )
 		end )
 	end
 
-	if self.OnChecked then
-		self:OnChecked( false )
-	end
+	self:OnChecked( false )
 end
 
 function CheckBox:OnMouseDown( Key, DoubleClick )
@@ -160,6 +156,10 @@ function CheckBox:AddLabel( Text )
 	end
 
 	self.Label = Label
+end
+
+function CheckBox:OnChecked( Checked )
+
 end
 
 SGUI.AddBoundProperty( CheckBox, "Font", "Label" )

--- a/lua/shine/lib/gui/objects/slider.lua
+++ b/lua/shine/lib/gui/objects/slider.lua
@@ -141,9 +141,7 @@ function Slider:SetValue( Value )
 	self.HandlePos.x = self.Width * self.Fraction
 
 	self.Handle:SetPosition( self.HandlePos )
-
 	self.Label:SetText( tostring( self.Value ) )
-
 	self:SizeLines()
 end
 
@@ -156,11 +154,9 @@ function Slider:SetFraction( Fraction )
 	self.Fraction = Clamp( ( self.Value - self.Min ) / self.Range, 0, 1 )
 
 	self.HandlePos.x = self.Width * self.Fraction
-
 	self.Handle:SetPosition( self.HandlePos )
 
 	self.Label:SetText( tostring( self.Value ) )
-
 	self:SizeLines()
 end
 
@@ -227,9 +223,7 @@ function Slider:OnMouseUp( Key )
 		self.Dragging = false
 	end
 
-	if self.OnValueChanged then
-		self:OnValueChanged( self:GetValue() )
-	end
+	self:OnValueChanged( self:GetValue() )
 
 	return true
 end
@@ -244,7 +238,26 @@ function Slider:OnMouseMove( Down )
 
 	self.CurPos.x = Clamp( self.StartingPos.x + Diff, 0, self.Width )
 
+	local OldValue = self.Value
 	self:SetFraction( self.CurPos.x / self.Width )
+
+	if OldValue ~= self.Value then
+		self:OnSlide( self.Value )
+	end
+end
+
+--[[
+	Called when the slider has stopped being moved.
+]]
+function Slider:OnValueChanged( Value )
+
+end
+
+--[[
+	Called as the slider is being moved.
+]]
+function Slider:OnSlide( Value )
+
 end
 
 SGUI:Register( "Slider", Slider )

--- a/lua/shine/lib/gui/objects/textentry.lua
+++ b/lua/shine/lib/gui/objects/textentry.lua
@@ -338,9 +338,7 @@ function TextEntry:RemoveSelectedText()
 	self.TextObj:SetText( self.Text )
 	self:SetCaretPos( self.Column )
 
-	if self.OnTextChanged then
-		self:OnTextChanged( Text, self.Text )
-	end
+	self:OnTextChanged( Text, self.Text )
 end
 
 function TextEntry:UpdateSelectionBounds( SkipAnim, XOverride )
@@ -526,6 +524,10 @@ function TextEntry:QueueUndo()
 	self.UndoTimer:Debounce()
 end
 
+function TextEntry:OnTextChanged( OldText, NewText )
+
+end
+
 --[[
 	Inserts a character wherever the caret is.
 ]]
@@ -555,10 +557,7 @@ function TextEntry:AddCharacter( Char, SkipUndo )
 
 	self.TextObj:SetText( self.Text )
 	self:SetCaretPos( self.Column )
-
-	if self.OnTextChanged then
-		self:OnTextChanged( Text, self.Text )
-	end
+	self:OnTextChanged( Text, self.Text )
 
 	if self.PlaceholderText then
 		self.PlaceholderText:SetIsVisible( false )
@@ -602,9 +601,7 @@ function TextEntry:RemoveWord( Forward )
 	self.TextObj:SetText( self.Text )
 	self:SetCaretPos( StringUTF8Length( Before ) )
 
-	if self.OnTextChanged then
-		self:OnTextChanged( Text, self.Text )
-	end
+	self:OnTextChanged( Text, self.Text )
 end
 
 --[[
@@ -659,9 +656,7 @@ function TextEntry:RemoveCharacter( Forward )
 	self.TextObj:SetText( self.Text )
 	self:SetCaretPos( self.Column )
 
-	if self.OnTextChanged then
-		self:OnTextChanged( Text, self.Text )
-	end
+	self:OnTextChanged( Text, self.Text )
 end
 
 function TextEntry:PlayerType( Char )
@@ -836,10 +831,7 @@ function TextEntry:RestoreState( State )
 
 	self:SetText( State.Text, true )
 	self:SetCaretPos( State.CaretPos )
-
-	if self.OnTextChanged then
-		self:OnTextChanged( Text, self.Text )
-	end
+	self:OnTextChanged( Text, self.Text )
 end
 
 function TextEntry:Undo()
@@ -968,13 +960,27 @@ function TextEntry:OnFocusChange( NewFocus, ClickingOtherElement )
 		end
 
 		self.Caret:SetColor( Clear )
+		self:OnLoseFocus()
 
 		return
 	end
 
 	self:StopFade( self.InnerBox )
-	self.Enabled = true
 	self.InnerBox:SetColor( self.FocusColour )
+
+	if not self.Enabled then
+		self:OnGainFocus()
+	end
+
+	self.Enabled = true
+end
+
+function TextEntry:OnGainFocus()
+
+end
+
+function TextEntry:OnLoseFocus()
+
 end
 
 SGUI:Register( "TextEntry", TextEntry )

--- a/lua/shine/lib/map.lua
+++ b/lua/shine/lib/map.lua
@@ -261,7 +261,6 @@ end
 
 local getmetatable = getmetatable
 local pairs = pairs
-local TableRemoveByValue = table.RemoveByValue
 
 --[[
 	A multimap is a map that can map multiple values per key. It abstracts away the idiom of

--- a/lua/shine/lib/math.lua
+++ b/lua/shine/lib/math.lua
@@ -110,3 +110,24 @@ function math.EaseOut( Progress, Power )
 	Progress = 1 - Progress
 	return 1 - Progress ^ Power
 end
+
+do
+	local Sqrt = math.sqrt
+	local TableAverage = table.Average
+
+	--[[
+		Computes the standard deviation of a table of values.
+	]]
+	function math.StandardDeviation( Values )
+		local Sum = 0
+		local Count = #Values
+		if Count == 0 then return 0 end
+
+		local Average = TableAverage( Values )
+		for i = 1, Count do
+			Sum = Sum + ( Values[ i ] - Average ) ^ 2
+		end
+
+		return Sqrt( Sum / Count )
+	end
+end

--- a/lua/shine/lib/player.lua
+++ b/lua/shine/lib/player.lua
@@ -386,7 +386,7 @@ do
 
 	--[[
 		Lua in NS2 uses double precision floats, which cannot express a 64 bit
-		integer entirely. Thus, the first 4 digits are ignored, as the 32bit
+		integer entirely. Thus, the first 5 digits are ignored, as the 32bit
 		Steam ID should never bring the 64 bit ID to the point where it has to increment
 		any of those digits.
 	]]

--- a/lua/shine/lib/player.lua
+++ b/lua/shine/lib/player.lua
@@ -40,6 +40,14 @@ function Shine:GetTeamName( Team, Capitals, Singular )
 	return Names[ Team ][ 2 ]
 end
 
+do
+	local PlayingTeams = { true, true }
+
+	function Shine.IsPlayingTeam( TeamNumber )
+		return PlayingTeams[ TeamNumber ] or false
+	end
+end
+
 if Client then return end
 
 local Abs = math.abs

--- a/lua/shine/lib/player.lua
+++ b/lua/shine/lib/player.lua
@@ -379,6 +379,27 @@ function Shine.SteamIDToNS2( ID )
 	end
 end
 
+do
+	local RemovedDigits = 6
+	local SteamID64Int = 197960265728
+	local StringSub = string.sub
+
+	--[[
+		Lua in NS2 uses double precision floats, which cannot express a 64 bit
+		integer entirely. Thus, the first 4 digits are ignored, as the 32bit
+		Steam ID should never bring the 64 bit ID to the point where it has to increment
+		any of those digits.
+	]]
+	function Shine.NS2IDTo64( ID )
+		return StringFormat( "76561%s", ID + SteamID64Int )
+	end
+
+	function Shine.SteamID64ToNS2ID( SteamID64 )
+		local UsableInt = tonumber( StringSub( SteamID64, RemovedDigits ) )
+		return UsableInt - SteamID64Int
+	end
+end
+
 function Shine:GetClientBySteamID( ID )
 	if not IsType( ID, "string" ) then return nil end
 

--- a/lua/shine/lib/query.lua
+++ b/lua/shine/lib/query.lua
@@ -110,7 +110,6 @@ local DefaultTimeout = 5
 ]]
 function Shine.TimedHTTPRequest( URL, Protocol, Params, OnSuccess, OnTimeout, Timeout )
 	local NeedParams = true
-
 	if Protocol ~= "POST" then
 		Timeout = OnTimeout
 		OnTimeout = OnSuccess
@@ -153,6 +152,14 @@ end
 function Shine.HTTPRequestWithRetry( URL, Protocol, Params, Callbacks, MaxAttempts, Timeout )
 	MaxAttempts = MaxAttempts or 3
 
+	local NeedParams = true
+	if Protocol ~= "POST" then
+		Timeout = MaxAttempts
+		MaxAttempts = Callbacks
+		Callbacks = Params
+		NeedParams = false
+	end
+
 	local Attempts = 0
 	local Submit
 
@@ -172,7 +179,11 @@ function Shine.HTTPRequestWithRetry( URL, Protocol, Params, Callbacks, MaxAttemp
 	end
 
 	Submit = function()
-		Shine.TimedHTTPRequest( URL, Protocol, Params, Callbacks.OnSuccess, OnTimeout, Timeout )
+		if NeedsParams then
+			Shine.TimedHTTPRequest( URL, Protocol, Params, Callbacks.OnSuccess, OnTimeout, Timeout )
+		else
+			Shine.TimedHTTPRequest( URL, Protocol, Callbacks.OnSuccess, OnTimeout, Timeout )
+		end
 	end
 
 	Submit()

--- a/lua/shine/lib/query.lua
+++ b/lua/shine/lib/query.lua
@@ -3,11 +3,11 @@
 ]]
 
 local HTTPRequest = Shared.SendHTTPRequest
+local IsType = Shine.IsType
 local Time = os.clock
 
 do
 	local Encode, Decode = json.encode, json.decode
-	local IsType = Shine.IsType
 	local StringFormat = string.format
 	local tostring = tostring
 
@@ -110,7 +110,8 @@ local DefaultTimeout = 5
 ]]
 function Shine.TimedHTTPRequest( URL, Protocol, Params, OnSuccess, OnTimeout, Timeout )
 	local NeedParams = true
-	if Protocol ~= "POST" then
+
+	if Protocol ~= "POST" and not IsType( Params, "table" ) then
 		Timeout = OnTimeout
 		OnTimeout = OnSuccess
 		OnSuccess = Params
@@ -153,7 +154,7 @@ function Shine.HTTPRequestWithRetry( URL, Protocol, Params, Callbacks, MaxAttemp
 	MaxAttempts = MaxAttempts or 3
 
 	local NeedParams = true
-	if Protocol ~= "POST" then
+	if Protocol ~= "POST" and not IsType( Callbacks, "table" ) then
 		Timeout = MaxAttempts
 		MaxAttempts = Callbacks
 		Callbacks = Params
@@ -179,7 +180,7 @@ function Shine.HTTPRequestWithRetry( URL, Protocol, Params, Callbacks, MaxAttemp
 	end
 
 	Submit = function()
-		if NeedsParams then
+		if NeedParams then
 			Shine.TimedHTTPRequest( URL, Protocol, Params, Callbacks.OnSuccess, OnTimeout, Timeout )
 		else
 			Shine.TimedHTTPRequest( URL, Protocol, Callbacks.OnSuccess, OnTimeout, Timeout )

--- a/lua/shine/lib/query.lua
+++ b/lua/shine/lib/query.lua
@@ -188,3 +188,5 @@ function Shine.HTTPRequestWithRetry( URL, Protocol, Params, Callbacks, MaxAttemp
 
 	Submit()
 end
+
+Script.Load( "lua/shine/lib/external_apis.lua" )

--- a/lua/shine/lib/queue.lua
+++ b/lua/shine/lib/queue.lua
@@ -57,6 +57,9 @@ function Queue:Pop()
 
 	self.Size = self.Size - 1
 	self.FirstNode = Node.Next
+	if self.Size == 0 then
+		self.LastNode = nil
+	end
 
 	return Node.Value
 end

--- a/lua/shine/lib/queue.lua
+++ b/lua/shine/lib/queue.lua
@@ -1,0 +1,120 @@
+--[[
+	A simple linked queue structure.
+]]
+
+local Queue = {}
+Queue.__index = Queue
+
+do
+	local setmetatable = setmetatable
+
+	function Shine.Queue()
+		return setmetatable( {}, Queue ):Init()
+	end
+end
+
+function Queue:Init()
+	self.Size = 0
+	self.Nodes = {}
+
+	return self
+end
+
+function Queue:GetCount()
+	return self.Size
+end
+
+function Queue:Add( Value )
+	local Previous = self.LastNode
+	local Next = {
+		Value = Value,
+		Previous = Previous
+	}
+
+	self.Nodes[ Next ] = Next
+
+	if Previous then
+		Previous.Next = Next
+	else
+		self.FirstNode = Next
+	end
+
+	self.LastNode = Next
+	self.Size = self.Size + 1
+end
+
+function Queue:Pop()
+	if self.Size == 0 then
+		return nil
+	end
+
+	local Node = self.FirstNode
+	self.Nodes[ Node ] = nil
+
+	if Node.Next then
+		Node.Next.Previous = nil
+	end
+
+	self.Size = self.Size - 1
+	self.FirstNode = Node.Next
+
+	return Node.Value
+end
+
+function Queue:Peek()
+	return self.FirstNode and self.FirstNode.Value
+end
+
+function Queue:HasNext()
+	return ( self.CurrentNode and self.CurrentNode.Next or self.FirstNode ) ~= nil
+end
+
+function Queue:GetNext()
+	if not self.CurrentNode then return nil end
+
+	local Value = self.CurrentNode.Value
+	self.CurrentNode = self.CurrentNode.Next
+
+	return Value
+end
+
+do
+	local GetNext = Queue.GetNext
+	local function Nope() end
+
+	function Queue:Iterate()
+		if self.Size == 0 then return Nope end
+
+		self.CurrentNode = self.FirstNode
+
+		return GetNext, self
+	end
+end
+
+-- Avoid this, because it's not really how you should use a queue.
+function Queue:Remove( Node )
+	if not self.Nodes[ Node ] then return end
+
+	if Node.Previous then
+		Node.Previous.Next = Node.Next
+	end
+
+	if Node.Next then
+		Node.Next.Previous = Node.Previous
+	end
+
+	if self.CurrentNode == Node then
+		self.CurrentNode = Node.Previous
+	end
+
+	if self.FirstNode == Node then
+		self.FirstNode = Node.Next
+	end
+
+	if self.LastNode == Node then
+		self.LastNode = Node.Previous
+	end
+
+	self.Size = self.Size - 1
+	self.Nodes[ Node ] = nil
+end

--- a/lua/shine/lib/table.lua
+++ b/lua/shine/lib/table.lua
@@ -171,32 +171,38 @@ function table.FixArray( Table )
 	end
 end
 
---[[
-	Shuffles a table randomly.
-]]
-function table.Shuffle( Table )
-	local SortTable = {}
-	local NewTable = {}
-
-	local Count = 0
-
-	for Index, Value in pairs( Table ) do
-		SortTable[ Value ] = Random()
-
-		--Add the value to a new table to get rid of potential holes in the array.
-		Count = Count + 1
-		NewTable[ Count ] = Value
-
-		Table[ Index ] = nil
+do
+	--[[
+		Shuffles a table randomly assuming there are no gaps.
+	]]
+	local function QuickShuffle( Table )
+		for i = #Table, 2, -1 do
+			local j = Random( i )
+			Table[ i ], Table[ j ] = Table[ j ], Table[ i ]
+		end
 	end
+	table.QuickShuffle = QuickShuffle
 
-	TableSort( NewTable, function( A, B )
-		return SortTable[ A ] > SortTable[ B ]
-	end )
+	--[[
+		Shuffles a table randomly, accounting for gaps in the array structure.
+	]]
+	function table.Shuffle( Table )
+		local NewTable = {}
+		local Count = 0
 
-	--Repopulate the input table with our sorted table. This won't have holes.
-	for i = 1, Count do
-		Table[ i ] = NewTable[ i ]
+		for Index, Value in pairs( Table ) do
+			--Add the value to a new table to get rid of potential holes in the array.
+			Count = Count + 1
+			NewTable[ Count ] = Value
+			Table[ Index ] = nil
+		end
+
+		QuickShuffle( NewTable )
+
+		--Repopulate the input table with our sorted table. This won't have holes.
+		for i = 1, Count do
+			Table[ i ] = NewTable[ i ]
+		end
 	end
 end
 
@@ -366,6 +372,19 @@ local function CopyTable( Table, LookupTable )
 	return Copy
 end
 table.Copy = CopyTable
+
+--[[
+	Copies an array-like structure without recursion.
+]]
+function table.QuickCopy( Table )
+	local Copy = {}
+
+	for i = 1, #Table do
+		Copy[ i ] = Table[ i ]
+	end
+
+	return Copy
+end
 
 function table.Count( Table )
 	local i = 0

--- a/lua/shine/lib/table.lua
+++ b/lua/shine/lib/table.lua
@@ -96,18 +96,27 @@ function table.Mixin( Source, Destination, Keys )
 	end
 end
 
---[[
-	Merges any missing keys in the destination table from the source table.
-	Does not recurse.
-]]
-function table.ShallowMerge( Source, Destination )
-	for Key, Value in pairs( Source ) do
-		if Destination[ Key ] == nil then
-			Destination[ Key ] = Value
-		end
+do
+	local rawget = rawget
+	local function Get( Table, Key )
+		return Table[ Key ]
 	end
 
-	return Destination
+	--[[
+		Merges any missing keys in the destination table from the source table.
+		Does not recurse.
+	]]
+	function table.ShallowMerge( Source, Destination, Raw )
+		local Getter = Raw and rawget or Get
+
+		for Key, Value in pairs( Source ) do
+			if Getter( Destination, Key ) == nil then
+				Destination[ Key ] = Value
+			end
+		end
+
+		return Destination
+	end
 end
 
 --[[

--- a/lua/shine/lib/table.lua
+++ b/lua/shine/lib/table.lua
@@ -5,6 +5,7 @@
 local IsType = Shine.IsType
 local pairs = pairs
 local Random = math.random
+local select = select
 local TableRemove = table.remove
 local TableSort = table.sort
 
@@ -27,6 +28,23 @@ do
 
 		return true
 	end
+end
+
+--[[
+	Takes a base table and a list of keys, and populates down to the last key with tables.
+]]
+function table.Build( Base, ... )
+	for i = 1, select( "#", ... ) do
+		local Key = select( i, ... )
+		local Entry = Base[ Key ]
+		if not Entry then
+			Entry = {}
+			Base[ Key ] = Entry
+		end
+		Base = Entry
+	end
+
+	return Base
 end
 
 --[[

--- a/lua/shine/lib/utf8.lua
+++ b/lua/shine/lib/utf8.lua
@@ -2142,12 +2142,11 @@ end
 	Input: String
 	Output: Number of UTF-8 characters.
 ]]
-local function UTF8Length( String )
+function string.UTF8Length( String )
 	TypeCheck( String, "string", 1, "UTF8Length" )
 
 	return #UTF8Encode( String )
 end
-string.UTF8Length = UTF8Length
 
 --[[
 	Returns the part of the string between Start and End where Start and End are UTF-8
@@ -2156,7 +2155,7 @@ string.UTF8Length = UTF8Length
 	Inputs: String, starting character position, ending character position.
 	Output: String between the two points.
 ]]
-local function UTF8Sub( String, Start, End )
+function string.UTF8Sub( String, Start, End )
 	End = End or -1
 
 	TypeCheck( String, "string", 1, "UTF8Sub" )
@@ -2176,7 +2175,6 @@ local function UTF8Sub( String, Start, End )
 
 	return TableConcat( Chars, "", Max( StartChar, 1 ), Min( EndChar, UTF8Length ) )
 end
-string.UTF8Sub = UTF8Sub
 
 --[[
 	Replaces UTF-8 characters based on a mapping table.

--- a/test/lib/math.lua
+++ b/test/lib/math.lua
@@ -15,3 +15,16 @@ UnitTest:Test( "GenerateSequence", function( Assert )
 	Assert:Equals( 9, Counts[ 1 ] )
 	Assert:Equals( 9, Counts[ 2 ] )
 end, nil, 100 )
+
+UnitTest:Test( "StandardDeviation", function( Assert )
+	-- Empty data should return 0, not nan.
+	local Data = {}
+	Assert:Equals( 0, math.StandardDeviation( Data ) )
+
+	-- All identical values have a standard deviation of 0.
+	Data = { 1000, 1000, 1000, 1000 }
+	Assert:Equals( 0, math.StandardDeviation( Data ) )
+
+	Data = { 1000, 1200, 1100, 900 }
+	Assert:Equals( 112, math.ceil( math.StandardDeviation( Data ) ) )
+end )

--- a/test/lib/queue.lua
+++ b/test/lib/queue.lua
@@ -1,0 +1,72 @@
+--[[
+	Queue object unit tests.
+]]
+
+local UnitTest = Shine.UnitTest
+
+UnitTest:Test( "Add", function( Assert )
+	local Queue = Shine.Queue()
+	Queue:Add( 1 )
+
+	local FirstNode = Queue.FirstNode
+	Assert:NotNil( FirstNode )
+	Assert:Nil( FirstNode.Previous )
+	Assert:Nil( FirstNode.Next )
+	Assert:Equals( FirstNode, Queue.LastNode )
+	Assert:Equals( 1, FirstNode.Value )
+	Assert:Equals( 1, Queue:GetCount() )
+
+	Queue:Add( 2 )
+	Assert:Equals( FirstNode, Queue.FirstNode )
+	Assert:NotNil( FirstNode.Next )
+	Assert:Equals( FirstNode.Next.Previous, FirstNode )
+	Assert:Nil( FirstNode.Next.Next )
+	Assert:Equals( FirstNode.Next, Queue.LastNode )
+	Assert:Equals( 2, FirstNode.Next.Value )
+	Assert:Equals( 2, Queue:GetCount() )
+end )
+
+UnitTest:Test( "Pop", function( Assert )
+	local Queue = Shine.Queue()
+	for i = 1, 5 do
+		Queue:Add( i )
+	end
+
+	for i = 1, 4 do
+		Queue:Pop()
+
+		local FirstNode = Queue.FirstNode
+		Assert:NotNil( FirstNode )
+		Assert:Nil( FirstNode.Previous )
+		Assert:Equals( i + 1, FirstNode.Value )
+		Assert:Equals( 5 - i, Queue:GetCount() )
+	end
+
+	Queue:Pop()
+	Assert:Nil( Queue.FirstNode )
+	Assert:Equals( 0, Queue:GetCount() )
+end )
+
+UnitTest:Test( "Iterate", function( Assert )
+	local Queue = Shine.Queue()
+	local ExpectedIterations = 20
+	for i = 1, ExpectedIterations do
+		Queue:Add( i )
+	end
+
+	local i = 0
+	for Value in Queue:Iterate() do
+		i = i + 1
+		Assert:Equals( i, Value )
+	end
+	Assert:Equals( ExpectedIterations, i )
+end )
+
+UnitTest:Test( "EmptyIterate", function( Assert )
+	local Queue = Shine.Queue()
+	local i = 0
+	for Value in Queue:Iterate() do
+
+	end
+	Assert:Equals( 0, i )
+end )

--- a/test/lib/queue.lua
+++ b/test/lib/queue.lua
@@ -44,6 +44,7 @@ UnitTest:Test( "Pop", function( Assert )
 
 	Queue:Pop()
 	Assert:Nil( Queue.FirstNode )
+	Assert:Nil( Queue.LastNode )
 	Assert:Equals( 0, Queue:GetCount() )
 end )
 
@@ -69,4 +70,25 @@ UnitTest:Test( "EmptyIterate", function( Assert )
 
 	end
 	Assert:Equals( 0, i )
+end )
+
+UnitTest:Test( "Add, then pop, then add", function( Assert )
+	local Data = {}
+	local Queue = Shine.Queue()
+
+	Queue:Add( Data )
+	Assert:Equals( 1, Queue:GetCount() )
+	Assert:Equals( Data, Queue.FirstNode.Value )
+	Assert:Equals( Data, Queue.LastNode.Value )
+
+	-- Popping should clear both the first and last node on the last pop.
+	Queue:Pop()
+	Assert:Equals( 0, Queue:GetCount() )
+	Assert:Nil( Queue.FirstNode )
+	Assert:Nil( Queue.LastNode )
+
+	Queue:Add( Data )
+	Assert:Equals( 1, Queue:GetCount() )
+	Assert:Equals( Data, Queue.FirstNode.Value )
+	Assert:Equals( Data, Queue.LastNode.Value )
 end )

--- a/test/lib/table.lua
+++ b/test/lib/table.lua
@@ -85,3 +85,22 @@ UnitTest:Test( "Build", function( Assert )
 
 	Assert:Equals( Base.Child.SubChild.ReallySubChild, ReallySubChild )
 end )
+
+UnitTest:Test( "QuickShuffle", function( Assert )
+	local Data = { 1, 2, 3, 4, 5, 6 }
+	table.QuickShuffle( Data )
+	Assert:Equals( 6, #Data )
+	for i = 1, 6 do
+		Assert:NotNil( Data[ i ] )
+	end
+end )
+
+UnitTest:Test( "QuickCopy", function( Assert )
+	local Table = { 1, 2, {}, 4 }
+	local Copy = table.QuickCopy( Table )
+
+	Assert:NotEquals( Table, Copy )
+	for i = 1, #Table do
+		Assert:Equals( Table[ i ], Copy[ i ] )
+	end
+end )

--- a/test/lib/table.lua
+++ b/test/lib/table.lua
@@ -74,3 +74,14 @@ UnitTest:Test( "InsertUnique", function( Assert )
 	Assert:False( Inserted )
 	Assert:ArrayEquals( { 1, 2, 3, 4 }, Table )
 end )
+
+UnitTest:Test( "Build", function( Assert )
+	local Base = {}
+	local ReallySubChild = table.Build( Base, "Child", "SubChild", "ReallySubChild" )
+
+	Assert:IsType( Base.Child, "table" )
+	Assert:IsType( Base.Child.SubChild, "table" )
+	Assert:IsType( Base.Child.SubChild.ReallySubChild, "table" )
+
+	Assert:Equals( Base.Child.SubChild.ReallySubChild, ReallySubChild )
+end )

--- a/test/lib/table.lua
+++ b/test/lib/table.lua
@@ -45,6 +45,24 @@ UnitTest:Test( "ShallowMerge", function( Assert )
 
 	Assert:False( Destination.Cake )
 	Assert:False( Destination.MoreCake )
+
+	-- Add an inherited value.
+	setmetatable( Destination, {
+		__index = {
+			InheritedKey = true
+		}
+	} )
+	Source.InheritedKey = false
+
+	-- Default is standard indexing, so it will see the inherited value.
+	table.ShallowMerge( Source, Destination )
+
+	Assert:True( Destination.InheritedKey )
+
+	-- Now the raw flag means it will override the inherited value.
+	table.ShallowMerge( Source, Destination, true )
+
+	Assert:False( Destination.InheritedKey )
 end )
 
 UnitTest:Test( "HasValue", function( Assert )

--- a/test/test_init.lua
+++ b/test/test_init.lua
@@ -123,7 +123,9 @@ UnitTest.Assert = {
 		end
 
 		return true
-	end
+	end,
+
+	IsType = IsType
 }
 
 for Name, Func in pairs( UnitTest.Assert ) do


### PR DESCRIPTION
- Added an easy to use external API system that allows for hitting web APIs and automatically handling result caching, request parameter conversion and keeping concurrent requests in check.
- The bans plugin can now use this to check for family sharing status on connecting players, and kick them out of they have the game shared to them by a banned account.
- The shuffling plugin can now display the standard deviation of player "skill" level on the scoreboard.
- The adverts plugin can now display messages in a random order rather than in sequence.