### PR TITLE
Fix minor translation issues

### DIFF
--- a/locale/shine/extensions/basecommands/enGB.json
+++ b/locale/shine/extensions/basecommands/enGB.json
@@ -64,5 +64,7 @@
 	"ERROR_NOT_GAGGED": "{TargetName} is not gagged.",
 	"ERROR_INTERP_CONSTRAINT": "Interp is constrained by send rate to be {Rate:Format:%.2f}ms minimum.",
 	"ERROR_TICKRATE_CONSTRAINT": "Tick rate cannot be greater than move rate ({Rate}).",
-	"ERROR_SENDRATE_CONSTRAINT": "Send rate cannot be greater than tick rate ({Rate})."
+	"ERROR_SENDRATE_CONSTRAINT": "Send rate cannot be greater than tick rate ({Rate}).",
+	"MAPS": "Maps",
+	"PLUGINS": "Plugins"
 }

--- a/lua/shine/extensions/basecommands/shared.lua
+++ b/lua/shine/extensions/basecommands/shared.lua
@@ -239,7 +239,7 @@ function Plugin:SetupAdminMenuCommands()
 		local Time = GagTimes[ i ]
 		local TimeString = StringTimeToString( Time )
 
-		GagLabels[ i * 2 - 1 ] = TimeToString
+		GagLabels[ i * 2 - 1 ] = TimeString
 		GagLabels[ i * 2 ] = tostring( Time )
 	end
 
@@ -265,7 +265,7 @@ function Plugin:SetupAdminMenuCommands()
 	self:AddAdminMenuCommand( Category, self:GetPhrase( "SET_TEAM" ), "sh_setteam", true, Teams,
 		self:GetPhrase( "SET_TEAM_TIP" ) )
 
-	self:AddAdminMenuTab( "Maps", {
+	self:AddAdminMenuTab( self:GetPhrase( "MAPS" ), {
 		OnInit = function( Panel, Data )
 			local List = SGUI:Create( "List", Panel )
 			List:SetAnchor( GUIItem.Left, GUIItem.Top )
@@ -327,7 +327,7 @@ function Plugin:SetupAdminMenuCommands()
 		end
 	} )
 
-	self:AddAdminMenuTab( "Plugins", {
+	self:AddAdminMenuTab( self:GetPhrase( "PLUGINS" ), {
 		OnInit = function( Panel, Data )
 			local List = SGUI:Create( "List", Panel )
 			List:SetAnchor( GUIItem.Left, GUIItem.Top )

--- a/lua/shine/extensions/mapvote/shared.lua
+++ b/lua/shine/extensions/mapvote/shared.lua
@@ -97,7 +97,8 @@ function Plugin:SetupDataTable()
 		},
 		[ MessageTypes.MapName ] = {
 			"MapCycling", "WINNER_NEXT_MAP", "WINNER_CYCLING",
-			"CHOOSING_RANDOM_MAP", "NextMapCommand"
+			"CHOOSING_RANDOM_MAP", "NextMapCommand",
+			"MAP_CYCLING"
 		},
 		[ MessageTypes.MapVotes ] = {
 			"WINNER_VOTES"

--- a/lua/shine/extensions/tournamentmode/server.lua
+++ b/lua/shine/extensions/tournamentmode/server.lua
@@ -445,6 +445,7 @@ function Plugin:CreateCommands()
 	end
 	local UnReadyCommand = self:BindCommand( "sh_unready", { "unrdy", "unready" }, Unready, true )
 	UnReadyCommand:Help( "Makes your team not ready to start the game." )
+	UnReadyCommand:SetAlwaysMatchChat( true )
 
 	local function ReadyUp( Client )
 		if self.GameStarted then return end
@@ -508,6 +509,7 @@ function Plugin:CreateCommands()
 	end
 	local ReadyCommand = self:BindCommand( "sh_ready", { "rdy", "ready" }, ReadyUp, true )
 	ReadyCommand:Help( "Makes your team ready to start the game." )
+	ReadyCommand:SetAlwaysMatchChat( true )
 
 	local function SetTeamNames( Client, Marine, Alien )
 		self.TeamNames[ 1 ] = Marine

--- a/lua/shine/lib/debug.lua
+++ b/lua/shine/lib/debug.lua
@@ -252,15 +252,34 @@ function Shine.Assert( Assertion, Error, ... )
 	end
 end
 
---[[
-	Checks a value's type, and throws an error if it doesn't match.
-]]
-function Shine.TypeCheck( Arg, Type, ArgNumber, FuncName, Level )
-	local ArgType = type( Arg )
+do
+	local TableConcat = table.concat
 
-	if ArgType ~= Type then
-		error( StringFormat( "Bad argument #%i to '%s' (%s expected, got %s)",
-			ArgNumber, FuncName, Type, ArgType ), Level or 2 )
+	--[[
+		Checks a value's type, and throws an error if it doesn't match.
+	]]
+	function Shine.TypeCheck( Arg, Type, ArgNumber, FuncName, Level )
+		local ArgType = type( Arg )
+		local MatchesType = false
+		local ExpectedType = Type
+
+		if type( Type ) == "table" then
+			for i = 1, #Type do
+				if ArgType == Type[ i ] then
+					MatchesType = true
+					break
+				end
+			end
+
+			ExpectedType = TableConcat( Type, " or " )
+		else
+			MatchesType = ArgType == Type
+		end
+
+		if not MatchesType then
+			error( StringFormat( "Bad argument #%i to '%s' (%s expected, got %s)",
+				ArgNumber, FuncName, ExpectedType, ArgType ), Level or 3 )
+		end
 	end
 end
 

--- a/test/lib/debug.lua
+++ b/test/lib/debug.lua
@@ -37,4 +37,11 @@ UnitTest:Test( "TypeCheck", function( Assert )
 
 	Success, Err = pcall( Shine.TypeCheck, Value, "number", 1, "Test", 0 )
 	Assert:True( Success )
+
+	Success, Err = pcall( Shine.TypeCheck, Value, { "number", "string" }, 1, "Test", 0 )
+	Assert:True( Success )
+
+	Success, Err = pcall( Shine.TypeCheck, Value, { "string", "table" }, 1, "Test", 0 )
+	Assert:False( Success )
+	Assert:Equals( "Bad argument #1 to 'Test' (string or table expected, got number)", Err )
 end )


### PR DESCRIPTION
- Fixed a script error in the map vote plugin when a vote for the next map failed.
- Fixed a script error when clicking the gag button in the admin menu.
- Fixed the "Plugins" and "Maps" tab names not being translatable strings.
- The tournament mode ready and unready commands no longer require a ! or /.