### PR TITLE
Fix plugins trying to send unregistered network messages

### DIFF
--- a/lua/shine/core/shared/base_plugin.lua
+++ b/lua/shine/core/shared/base_plugin.lua
@@ -178,6 +178,10 @@ if Server then
 	]]
 	function PluginMeta:SendNetworkMessage( Target, Name, Data, Reliable )
 		local MessageName = self.__NetworkMessages[ Name ]
+		if not MessageName then
+			error( StringFormat( "Attempted to send unregistered network message '%s' for plugin '%s'.",
+				Name, self.__Name ), 2 )
+		end
 
 		Shine:ApplyNetworkMessage( Target, MessageName, Data, Reliable )
 	end

--- a/lua/shine/core/shared/base_plugin.lua
+++ b/lua/shine/core/shared/base_plugin.lua
@@ -207,6 +207,10 @@ if Server then
 elseif Client then
 	function PluginMeta:SendNetworkMessage( Name, Data, Reliable )
 		local MessageName = self.__NetworkMessages[ Name ]
+		if not MessageName then
+			error( StringFormat( "Attempted to send unregistered network message '%s' for plugin '%s'.",
+				Name, self.__Name ), 2 )
+		end
 
 		Shine.SendNetworkMessage( MessageName, Data, Reliable )
 	end

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -1184,18 +1184,21 @@ function Plugin:AddVote( Client )
 
 	if not Client then Client = "Console" end
 
-	local Allow, Error, TranslationKey, Args = Shine.Hook.Call( "OnVoteStart", "random" )
-	if Allow == false then
-		return false, TranslationKey, Args
+	do
+		local Allow, Error, TranslationKey, Args = Shine.Hook.Call( "OnVoteStart", "random" )
+		if Allow == false then
+			return false, TranslationKey, Args
+		end
 	end
 
-	local Success, Err, Args = self:CanStartVote()
-	if not Success then
-		return false, Err, Args
+	do
+		local Success, Err, Args = self:CanStartVote()
+		if not Success then
+			return false, Err, Args
+		end
 	end
 
-	Success = self.Vote:AddVote( Client )
-	if not Success then
+	if not self.Vote:AddVote( Client ) then
 		return false, "ERROR_ALREADY_VOTED", { ShuffleType = ModeStrings.ModeLower[ self.Config.BalanceMode ] }
 	end
 


### PR DESCRIPTION
It now throws an error indicating the attempted name, and the plugin responsible.