### PR TITLE
Small bug fixes for the chatbox, local stats and translations

### DIFF
--- a/lua/shine/extensions/chatbox/client.lua
+++ b/lua/shine/extensions/chatbox/client.lua
@@ -930,10 +930,17 @@ function Plugin:AddMessage( PlayerColour, PlayerName, MessageColour, MessageName
 	ChatLine:SetLineSpacing( LineMargin )
 
 	self.ChatBox.Layout:AddElement( ChatLine )
+	self:RefreshLayout()
+end
+
+function Plugin:RefreshLayout()
+	if #self.Messages == 0 then return end
+
 	-- Force layout refresh now so we can update the scrollbar.
 	self.ChatBox:InvalidateLayout( true )
 
 	if SGUI.IsValid( self.ChatBox.Scrollbar ) then
+		local ChatLine = self.Messages[ #self.Messages ]
 		local NewMaxHeight = ChatLine:GetPos().y + ChatLine:GetSize().y + self.ChatBox.BufferAmount
 		if NewMaxHeight < self.ChatBox:GetMaxHeight() then
 			self.ChatBox:SetMaxHeight( NewMaxHeight )
@@ -1132,6 +1139,8 @@ function Plugin:StartChat( Team )
 
 	self.MainPanel:SetIsVisible( true )
 	self.GUIChat:SetIsVisible( false )
+
+	self:RefreshLayout()
 
 	--Get our text entry accepting input.
 	self.TextEntry:RequestFocus()

--- a/lua/shine/extensions/mapvote/voting.lua
+++ b/lua/shine/extensions/mapvote/voting.lua
@@ -77,16 +77,20 @@ function Plugin:SendVoteData( Client )
 end
 
 function Plugin:OnVoteStart( ID )
+	if ID == "random" then
+		local VoteRandom = Shine.Plugins.voterandom
+
+		if self:IsEndVote() or self.CyclingMap then
+			return false, "You cannot start a vote at the end of the map.",
+				VoteRandom:GetStartFailureMessage()
+		end
+
+		return
+	end
+
 	if self.CyclingMap then
 		return false, "The map is now changing, unable to start a vote.",
 			"VOTE_FAIL_MAP_CHANGE", {}
-	end
-
-	if ID == "random" and self:IsEndVote() then
-		local VoteRandom = Shine.Plugins.voterandom
-
-		return false, "You cannot start a vote while the map vote is running.",
-			VoteRandom:GetStartFailureMessage()
 	end
 end
 

--- a/lua/shine/extensions/voterandom/local_stats.lua
+++ b/lua/shine/extensions/voterandom/local_stats.lua
@@ -190,7 +190,7 @@ function StatsModule:ClientDisconnect( Client )
 	if not self.StatsStorage:IsInTransaction() then return end
 
 	local Player = Client:GetControllingPlayer()
-	if not Player or not Player.GetPlayTime then return end
+	if not Player or not Player.GetPlayTime or not Player:GetPlayTime() then return end
 
 	-- Store the client's playtime when they disconnect.
 	self:IncrementStatValue( GetClientUID( Client ), Player, "PlayTime", Player:GetPlayTime() )

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -227,6 +227,7 @@ function ControlMeta:SetIsVisible( Bool )
 	if self.Background.GetIsVisible and self.Background:GetIsVisible() == Bool then return end
 
 	self.Background:SetIsVisible( Bool )
+	self:InvalidateLayout()
 
 	if self.IsAWindow then
 		if Bool then --Take focus on show.
@@ -252,6 +253,22 @@ function ControlMeta:SetIsVisible( Bool )
 			end
 		end
 	end
+end
+
+--[[
+	Computes the actual visibility state of the object, based on
+	whether it is set to be invisible, or otherwise if it has a parent
+	that is not visible.
+]]
+function ControlMeta:ComputeVisibility()
+	local OurVis = self:GetIsVisible()
+	if not OurVis then return false end
+
+	if SGUI.IsValid( self.Parent ) then
+		return self.Parent:ComputeVisibility()
+	end
+
+	return OurVis
 end
 
 --[[

--- a/lua/shine/lib/gui/objects/panel.lua
+++ b/lua/shine/lib/gui/objects/panel.lua
@@ -212,7 +212,6 @@ function Panel:SetIsVisible( Visible )
 	self.BaseClass.SetIsVisible( self, Visible )
 
 	local Children = self.Children
-
 	if not Children then return end
 
 	for Child in Children:Iterate() do
@@ -354,7 +353,7 @@ function Panel:SetMaxHeight( Height )
 	self.Scrollbar:SetScrollSize( NewScrollSize )
 
 	if self.StickyScroll and OldPos >= OldSize then
-		local ShouldSmooth = NewScrollSize < OldScrollSize and self:GetIsVisible()
+		local ShouldSmooth = NewScrollSize < OldScrollSize and self:ComputeVisibility()
 		self.Scrollbar:ScrollToBottom( ShouldSmooth )
 	end
 end


### PR DESCRIPTION
- Fixed the chatbox layout breaking when opening without a new message.
- Fixed a script error when attempting to vote for shuffled teams when the map is cycling.
- Fixed a script error in the local stats functionality of the shuffle plugin when a player disconnected before they had any playtime set.