### PR TITLE
Make sure that TeamSkills reflects the correct values

### DIFF
--- a/lua/shine/extensions/voterandom/team_balance.lua
+++ b/lua/shine/extensions/voterandom/team_balance.lua
@@ -233,6 +233,11 @@ function BalanceModule:SortPlayersByRank( TeamMembers, SortTable, Count, NumTarg
 		return Sorted
 	end
 
+	-- Update the team skill values in case the team members table was modified by the event.
+	for i = 1, 2 do
+		TeamSkills[ i ] = GetAverageSkillFunc( TeamMembers[ i ], RankFunc )
+	end
+
 	self:OptimiseTeams( TeamMembers, RankFunc, TeamSkills )
 
 	return Sorted


### PR DESCRIPTION
If a call to the event changed the TeamMembers table, these values need re-computing.