### PR TITLE
Changed the default moverate to 26 as done in build 295

### DIFF
--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -37,7 +37,7 @@ Plugin.DefaultConfig = {
 	EjectVotesNeeded = 0.5,
 	DisableLuaRun = false,
 	Interp = 100,
-	MoveRate = 30,
+	MoveRate = 26,
 	TickRate = 30,
 	SendRate = 20,
 	BWLimit = Shine.IsNS2Combat and 35 or 50,
@@ -128,7 +128,7 @@ do
 
 	local Rates = {
 		{
-			Key = "MoveRate", Default = 30, Command = "mr %s"
+			Key = "MoveRate", Default = 26, Command = "mr %s"
 		},
 		{
 			Key = "TickRate", Default = function() return Server.GetTickrate() end, Command = "tickrate %s"


### PR DESCRIPTION
The move rate has been decreased to 26 with build 295 to decrease the overall load of the servers.