### PR TITLE
[Surrender] Play new concede in-game sequence

### DIFF
--- a/lua/shine/extensions/votesurrender/server.lua
+++ b/lua/shine/extensions/votesurrender/server.lua
@@ -24,7 +24,8 @@ Plugin.DefaultConfig = {
 	VoteDelay = 10, --Time after round start before surrender vote is available
 	MinPlayers = 6, --Min players needed for voting to be enabled.
 	VoteTimeout = 120, --How long after no votes before the vote should reset?
-	AllowVoteWithMultipleBases = true --Is a team allowed to surrender with multiple bases
+	AllowVoteWithMultipleBases = true, --Is a team allowed to surrender with multiple bases
+	SkipSequence = false --Skip the in-game surrender sequence?
 }
 
 Plugin.CheckConfig = true
@@ -161,7 +162,15 @@ function Plugin:Surrender( Team )
 
 	Shine.SendNetworkMessage( "TeamConceded", { teamNumber = Team } )
 
-	Gamerules:EndGame( Team == 1 and Gamerules.team2 or Gamerules.team1 )
+
+	local SurrenderingTeam = Team == 1 and Gamerules.team2 or Gamerules.team1
+
+	--For the surrender sequence we have to set this flag
+	if not self.Config.SkipSequence then
+		SurrenderingTeam.conceded = true
+	end
+
+	Gamerules:EndGame( SurrenderingTeam )
 
 	self.Surrendered = true
 


### PR DESCRIPTION
Build 298 added a new animation sequence that shows how the surrender teams bases blow up. 

Ns2 detects if a team conceded or not via a flag that get set by the concede votes success function. The surrender extension however never set given flag and therefor the sequence gets always skipped. I fixed that.

I also added a configuration setting for those server operators who want to skip the sequence just in case.


