### PR TITLE
AFK notification and movement delay, bug fixes, 298 update fix for concede

### DIFF
--- a/lua/shine/core/shared/extensions.lua
+++ b/lua/shine/core/shared/extensions.lua
@@ -141,12 +141,14 @@ function Shine:LoadExtension( Name, DontEnable )
 
 		if PluginFiles[ ClientFile ] then
 			include( ClientFile )
+		elseif not self.Plugins[ Name ] then
+			-- No client file, and no shared file, or shared did not register.
+			return false, "plugin did not register itself"
 		end
 
 		Plugin = OldValue --Just in case someone else uses Plugin as a global...
 
 		local Plugin = self.Plugins[ Name ]
-
 		if Plugin and self.IsNS2Combat and Plugin.NS2Only then
 			self.Plugins[ Name ] = nil
 			return false, "plugin not compatible with NS2:Combat"

--- a/lua/shine/extensions/afkkick/server.lua
+++ b/lua/shine/extensions/afkkick/server.lua
@@ -40,28 +40,6 @@ Plugin.DefaultConfig = {
 Plugin.CheckConfig = true
 Plugin.CheckConfigTypes = true
 
-function Plugin:OnFirstThink()
-	local Call = Shine.Hook.Call
-	local GetEntity = Shared.GetEntity
-
-	Shine.Hook.SetupClassHook( "PlayerInfoEntity", "UpdateScore", "OnPlayerInfoUpdate",
-	function( OldFunc, self )
-		local Player = GetEntity( self.playerId )
-
-		if not Player then return OldFunc( self ) end
-
-		Call( "PrePlayerInfoUpdate", self, Player )
-
-		local Ret = OldFunc( self )
-
-		Call( "PostPlayerInfoUpdate", self, Player )
-
-		return Ret
-	end )
-
-	Shine.Hook.SetupClassHook( "Commander", "OrderEntities", "OnCommanderOrderEntities", "PassivePost" )
-end
-
 do
 	local Validator = Shine.Validator()
 	Validator:AddRule( {
@@ -477,6 +455,28 @@ function Plugin:ClientDisconnect( Client )
 end
 
 function Plugin:OnFirstThink()
+	do
+		local Call = Shine.Hook.Call
+		local GetEntity = Shared.GetEntity
+
+		Shine.Hook.SetupClassHook( "PlayerInfoEntity", "UpdateScore", "OnPlayerInfoUpdate",
+		function( OldFunc, self )
+			local Player = GetEntity( self.playerId )
+
+			if not Player then return OldFunc( self ) end
+
+			Call( "PrePlayerInfoUpdate", self, Player )
+
+			local Ret = OldFunc( self )
+
+			Call( "PostPlayerInfoUpdate", self, Player )
+
+			return Ret
+		end )
+	end
+
+	Shine.Hook.SetupClassHook( "Commander", "OrderEntities", "OnCommanderOrderEntities", "PassivePost" )
+
 	do
 		local function CheckPlayerIsAFK( Player )
 			if not Player then return end

--- a/lua/shine/extensions/afkkick/server.lua
+++ b/lua/shine/extensions/afkkick/server.lua
@@ -476,7 +476,7 @@ function Plugin:ClientDisconnect( Client )
 	self.Users[ Client ] = nil
 end
 
-Shine.Hook.Add( "OnFirstThink", "AFKKick_OverrideVote", function()
+function Plugin:OnFirstThink()
 	do
 		local function CheckPlayerIsAFK( Player )
 			if not Player then return end
@@ -484,7 +484,7 @@ Shine.Hook.Add( "OnFirstThink", "AFKKick_OverrideVote", function()
 			local Client = GetOwner( Player )
 			if not Client then return end
 
-			if not Plugin:IsAFKFor( Client, 60 ) then
+			if not self:IsAFKFor( Client, 60 ) then
 				JoinRandomTeam( Player )
 				return
 			end
@@ -500,8 +500,7 @@ Shine.Hook.Add( "OnFirstThink", "AFKKick_OverrideVote", function()
 		-- Override the built in randomise ready room vote to not move AFK players.
 		SetVoteSuccessfulCallback( "VoteRandomizeRR", 2, function( Data )
 			local ReadyRoomPlayers = GetGamerules():GetTeam( kTeamReadyRoom ):GetPlayers()
-			local Enabled = Shine:IsExtensionEnabled( "afkkick" )
-			local Action = Enabled and CheckPlayerIsAFK or JoinRandomTeam
+			local Action = self.Enabled and CheckPlayerIsAFK or JoinRandomTeam
 
 			Shine.Stream( ReadyRoomPlayers ):ForEach( Action )
 		end )
@@ -513,7 +512,7 @@ Shine.Hook.Add( "OnFirstThink", "AFKKick_OverrideVote", function()
 		local ShouldKeep = true
 		local Client = GetOwner( Player )
 
-		if not Client or Plugin:IsAFKFor( Client, 60 ) then
+		if not Client or self:IsAFKFor( Client, 60 ) then
 			ShouldKeep = false
 
 			if Client and Shine.IsPlayingTeam( Player:GetTeamNumber() ) then
@@ -528,15 +527,12 @@ Shine.Hook.Add( "OnFirstThink", "AFKKick_OverrideVote", function()
 
 	local OldGetPlayers = ForceEvenTeams_GetPlayers
 	function ForceEvenTeams_GetPlayers()
-		local Enabled = Shine:IsExtensionEnabled( "afkkick" )
-		if not Enabled then
+		if not self.Enabled then
 			return OldGetPlayers()
 		end
 
-		local Players = OldGetPlayers()
-
-		Shine.Stream( Players ):Filter( FilterPlayers )
-
-		return Players
+		return Shine.Stream( OldGetPlayers() )
+			:Filter( FilterPlayers )
+			:AsTable()
 	end
-end )
+end

--- a/lua/shine/extensions/afkkick/server.lua
+++ b/lua/shine/extensions/afkkick/server.lua
@@ -364,13 +364,14 @@ function Plugin:OnProcessMove( Player, Input )
 				if not Shine:IsValidClient( Client ) then return end
 				if not DataTable.IsAFK then return end
 
+				local CurrentPlayer = Client:GetControllingPlayer()
+				local CurrentTeam = CurrentPlayer:GetTeamNumber()
+
 				-- Sometimes this event receives one of the weird "ghost" players that can't switch teams.
-				if self.Config.MoveToReadyRoomOnWarn and Team ~= kTeamReadyRoom then
-					Player = Client:GetControllingPlayer()
-					pcall( Gamerules.JoinTeam, Gamerules, Player, kTeamReadyRoom, nil, true )
-				elseif self.Config.MoveToSpectateOnWarn and Team ~= kSpectatorIndex then
-					Player = Client:GetControllingPlayer()
-					pcall( Gamerules.JoinTeam, Gamerules, Player, kSpectatorIndex, nil, true )
+				if self.Config.MoveToReadyRoomOnWarn and CurrentTeam ~= kTeamReadyRoom then
+					pcall( Gamerules.JoinTeam, Gamerules, CurrentPlayer, kTeamReadyRoom, nil, true )
+				elseif self.Config.MoveToSpectateOnWarn and CurrentTeam ~= kSpectatorIndex then
+					pcall( Gamerules.JoinTeam, Gamerules, CurrentPlayer, kSpectatorIndex, nil, true )
 				end
 			end
 

--- a/lua/shine/extensions/afkkick/server.lua
+++ b/lua/shine/extensions/afkkick/server.lua
@@ -123,7 +123,7 @@ do
 		OldFunc = Player.GetName
 
 		local Client = GetOwner( Player )
-		local Data = Plugin.Users[ Client ]
+		local Data = self.Users[ Client ]
 		if not Data or not Data.IsAFK then return end
 
 		Player.GetName = GetName

--- a/lua/shine/extensions/afkkick/shared.lua
+++ b/lua/shine/extensions/afkkick/shared.lua
@@ -1,0 +1,20 @@
+--[[
+	AFK plugin shared.
+]]
+
+local Plugin = {}
+
+function Plugin:SetupDataTable()
+	self:AddNetworkMessage( "AFKNotify", {}, "Client" )
+end
+
+Shine:RegisterExtension( "afkkick", Plugin )
+
+if Server then return end
+
+Plugin.NotifySoundEffect = "sound/NS2.fev/common/tooltip_on"
+function Plugin:ReceiveAFKNotify( Data )
+	-- Flash the taskbar icon and play a sound. Can't say we didn't warn you.
+	Client.WindowNeedsAttention()
+	StartSoundEffect( self.NotifySoundEffect )
+end

--- a/lua/shine/extensions/chatbox/chatline.lua
+++ b/lua/shine/extensions/chatbox/chatline.lua
@@ -158,7 +158,7 @@ function ChatLine:PerformLayout()
 end
 
 function ChatLine:SetSize( Size )
-	if self.MaxWidth == Size.x then return end
+	if self.MaxWidth == Size.x and self.ComputedWrapping then return end
 
 	self.MaxWidth = Size.x
 	self.ComputedWrapping = false
@@ -202,7 +202,7 @@ do
 		end
 
 		local WrappedLabel = self:GetWrappedLabel()
-		WrappedLabel:SetText( Remaining )
+		WordWrap( WrappedLabel, Remaining, 0, MaxWidth )
 		self.WrappedLabel = WrappedLabel
 	end
 end

--- a/lua/shine/extensions/votesurrender/server.lua
+++ b/lua/shine/extensions/votesurrender/server.lua
@@ -20,12 +20,12 @@ Plugin.HasConfig = true
 Plugin.ConfigName = "VoteSurrender.json"
 
 Plugin.DefaultConfig = {
-	PercentNeeded = 0.75, --Percentage of the team needing to vote in order to surrender.
-	VoteDelay = 10, --Time after round start before surrender vote is available
-	MinPlayers = 6, --Min players needed for voting to be enabled.
-	VoteTimeout = 120, --How long after no votes before the vote should reset?
-	AllowVoteWithMultipleBases = true, --Is a team allowed to surrender with multiple bases
-	SkipSequence = false --Skip the in-game surrender sequence?
+	PercentNeeded = 0.75, -- Percentage of the team needing to vote in order to surrender.
+	VoteDelay = 10, -- Time after round start before surrender vote is available
+	MinPlayers = 6, -- Min players needed for voting to be enabled.
+	VoteTimeout = 120, -- How long after no votes before the vote should reset?
+	AllowVoteWithMultipleBases = true, -- Is a team allowed to surrender with multiple bases
+	SkipSequence = false -- Skip the in-game surrender sequence?
 }
 
 Plugin.CheckConfig = true
@@ -48,7 +48,6 @@ function Plugin:Initialise()
 	}
 
 	self.NextVote = 0
-
 	self.dt.ConcedeTime = self.Config.VoteDelay
 
 	self:CreateCommands()
@@ -107,7 +106,7 @@ end
 function Plugin:AddVote( Client, Team )
 	if not Client then return end
 
-	--Would be a fun bug...
+	-- Would be a fun bug...
 	if Team ~= 1 and Team ~= 2 then return false, "spectators can't surrender!" end
 
 	if not self:CanStartVote( Team ) then return false, "can't start" end
@@ -157,15 +156,13 @@ end
 ]]
 function Plugin:Surrender( Team )
 	local Gamerules = GetGamerules()
-
 	if not Gamerules then return end
 
 	Shine.SendNetworkMessage( "TeamConceded", { teamNumber = Team } )
 
-
 	local SurrenderingTeam = Team == 1 and Gamerules.team2 or Gamerules.team1
 
-	--For the surrender sequence we have to set this flag
+	-- For the surrender sequence we have to set this flag
 	if not self.Config.SkipSequence then
 		SurrenderingTeam.conceded = true
 	end
@@ -173,7 +170,6 @@ function Plugin:Surrender( Team )
 	Gamerules:EndGame( SurrenderingTeam )
 
 	self.Surrendered = true
-
 	self:SimpleTimer( 0, function()
 		self.Surrendered = false
 	end )
@@ -195,9 +191,9 @@ function Plugin:CastVoteByPlayer( Gamerules, ID, Player )
 	local Votes = self.Votes[ Team ]:GetVotes()
 	local Success, Err = self:AddVote( Client, Team )
 
-	--We failed to add the vote, but we should still stop it going through NS2's system...
+	-- We failed to add the vote, but we should still stop it going through NS2's system...
 	if not Success then return true end
-	--We've surrendered, no need to say another player's voted.
+	-- We've surrendered, no need to say another player's voted.
 	if self.Surrendered then return true end
 
 	local VotesNeeded = self.Votes[ Team ]:GetVotesNeeded()
@@ -219,7 +215,7 @@ function Plugin:AnnounceVote( Player, Team, VotesNeeded )
 		local Ply = Players[ i ]
 
 		if Ply then
-			--Use NS2's built in concede, it's localised.
+			-- Use NS2's built in concede, it's localised.
 			Shine.SendNetworkMessage( Ply, "VoteConcedeCast", NWMessage, true )
 		end
 	end

--- a/lua/shine/extensions/votesurrender/server.lua
+++ b/lua/shine/extensions/votesurrender/server.lua
@@ -160,14 +160,15 @@ function Plugin:Surrender( Team )
 
 	Shine.SendNetworkMessage( "TeamConceded", { teamNumber = Team } )
 
-	local SurrenderingTeam = Team == 1 and Gamerules.team2 or Gamerules.team1
+	local WinningTeam = Gamerules:GetTeam( Team == 1 and 2 or 1 )
+	local SurrenderingTeam = Gamerules:GetTeam( Team )
 
 	-- For the surrender sequence we have to set this flag
 	if not self.Config.SkipSequence then
 		SurrenderingTeam.conceded = true
 	end
 
-	Gamerules:EndGame( SurrenderingTeam )
+	Gamerules:EndGame( WinningTeam )
 
 	self.Surrendered = true
 	self:SimpleTimer( 0, function()

--- a/lua/shine/extensions/votesurrender/server.lua
+++ b/lua/shine/extensions/votesurrender/server.lua
@@ -24,7 +24,8 @@ Plugin.DefaultConfig = {
 	VoteDelay = 10, --Time after round start before surrender vote is available
 	MinPlayers = 6, --Min players needed for voting to be enabled.
 	VoteTimeout = 120, --How long after no votes before the vote should reset?
-	AllowVoteWithMultipleBases = true --Is a team allowed to surrender with multiple bases
+	AllowVoteWithMultipleBases = true, --Is a team allowed to surrender with multiple bases
+	SkipSequence = false --Skip the in-game surrender sequence?
 }
 
 Plugin.CheckConfig = true
@@ -161,7 +162,15 @@ function Plugin:Surrender( Team )
 
 	Shine.SendNetworkMessage( "TeamConceded", { teamNumber = Team } )
 
-	Gamerules:EndGame( Team == 1 and Gamerules.team2 or Gamerules.team1 )
+
+	local SurrenderingTeam = Team == 1 and Gamerules.team2 or Gamerules.team1
+
+	--For the surrender sequence we have to set this flag
+	if not self.Config.SkipSequence then
+		SurrenderingTeam.conceded = true
+	end
+
+	Gamerules:EndGame( SurrenderingTeam )
 
 	self.Surrendered = true
 


### PR DESCRIPTION
- Added `NotifyOnWarn` option to the AFK kick plugin. Sets whether players should have their taskbar icon for NS2 flashed, and a sound played when they are warned for being AFK.
- Added `MovementDelaySeconds` option to the AFK kick plugin. Sets the number of seconds to wait after warning a player before performing a move action.
- Fixed some issues in the AFK plugin that made it less friendly to inheritance than intended.
- Fixed surrender votes not triggering the concede sequence (thanks Ghoul, even though your fix used the wrong team!).
- Fixed the chatbox not properly word wrapping messages that go beyond 2 lines, or that are added while it is closed.