### PR TITLE
Allow everyone to use sh_listplugins

### DIFF
--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -682,7 +682,7 @@ function Plugin:CreateInfoCommands()
 			end
 		end
 	end
-	local ListPluginsCommand = self:BindCommand( "sh_listplugins", nil, ListPlugins )
+	local ListPluginsCommand = self:BindCommand( "sh_listplugins", nil, ListPlugins, true )
 	ListPluginsCommand:Help( "Lists all loaded plugins." )
 end
 


### PR DESCRIPTION
I would like to make the listplugins public for two reasons:
- It potentially allows me as developer to reproduce issues with my extensions / the game without contacting given server operator.
- It creates a certain degree of transparency for the users as they can now check what's running at the server. _In the past there have been server extensions granting operators in-game advantages which were directly uploaded to the server._
