### PR TITLE
WarmUp game state of Build 302

### DIFF
--- a/lua/shine/extensions/basecommands/shared.lua
+++ b/lua/shine/extensions/basecommands/shared.lua
@@ -97,12 +97,12 @@ function Plugin:NetworkUpdate( Key, Old, New )
 	if Server then return end
 
 	if Key == "Gamestate" then
-		if Old == 2 and New == 1 then
+		if Old == kGameState.PreGame and New == kGameState.NotStarted then
 			--The game state changes back to 1, then to 3 to start. This is VERY annoying...
 			self:SimpleTimer( 1, function()
 				if not self.Enabled then return end
 
-				if self.dt.Gamestate == 1 then
+				if self.dt.Gamestate == kGameState.NotStarted then
 					self:UpdateAllTalk( self.dt.Gamestate )
 				end
 			end )
@@ -154,9 +154,9 @@ local StringFormat = string.format
 local StringTimeToString = string.TimeToString
 local TableEmpty = table.Empty
 
-local NOT_STARTED = 1
-local PREGAME = 2
-local COUNTDOWN = 3
+local NOT_STARTED = kGameState and kGameState.WarmUp or 2
+local PREGAME = kGameState and kGameState.PreGame or 3
+local COUNTDOWN = kGameState and kGameState.Countdown or 4
 
 function Plugin:Initialise()
 	if self.dt.AllTalk then

--- a/lua/shine/extensions/pregame/server.lua
+++ b/lua/shine/extensions/pregame/server.lua
@@ -595,7 +595,7 @@ end
 function Plugin:CheckGameStart( Gamerules )
 	local State = Gamerules:GetGameState()
 
-	if State ~= kGameState.NotStarted and State ~= kGameState.PreGame then return end
+	if State > kGameState.PreGame then return end
 
 	--Do not allow starting too soon.
 	local StartDelay = self.Config.StartDelay

--- a/lua/shine/extensions/tournamentmode/server.lua
+++ b/lua/shine/extensions/tournamentmode/server.lua
@@ -123,7 +123,7 @@ local NextStartNag = 0
 function Plugin:CheckGameStart( Gamerules )
 	local State = Gamerules:GetGameState()
 
-	if State == kGameState.PreGame or State == kGameState.NotStarted then
+	if State <= kGameState.PreGame then
 		self.GameStarted = false
 
 		self:CheckCommanders( Gamerules )

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -490,7 +490,7 @@ function Plugin:JoinTeam( Gamerules, Player, NewTeam, Force, ShineForce )
 	local Gamestate = Gamerules:GetGameState()
 
 	--We'll do a mass balance, don't worry about them yet.
-	if self.Config.AlwaysEnabled and Gamestate == kGameState.NotStarted then return end
+	if self.Config.AlwaysEnabled and Gamestate < kGameState.Pregame then return end
 
 	--Don't block them from going back to the ready room at the end of the round.
 	if Gamestate == kGameState.Team1Won or Gamestate == kGameState.Team2Won


### PR DESCRIPTION
Build 302 adds a new `WarmUp` gamestate to the ns2 gamerules. The gamerules will switch into the `WarmUp` gamemode from `NotStarted` if the sum of players in the marine and alien team is below 12.
It will switch from `WarmUp` to `NotStarted if the same sum of players is equal or greater 12.

I adjusted all game state checks of shine to cover up for this change and also replaced all static numeric values for game states with reference to the `kGameState` table to make Shine compatible to future changes and mods that may define own game states as well (haven't seen one doing that yet though).