### PR TITLE
Various fixes to account for bots + new pregame mode

### DIFF
--- a/locale/shine/extensions/pregame/enGB.json
+++ b/locale/shine/extensions/pregame/enGB.json
@@ -4,6 +4,7 @@
 	"WAITING_FOR_ALIENS": "Waiting on Aliens to choose a commander",
 	"WAITING_FOR_MARINES": "Waiting on Marines to choose a commander",
 	"WAITING_FOR_BOTH": "Waiting on both teams to choose a commander",
+	"WAITING_FOR_PLAYER_COUNT": "Waiting for at least {MinPlayers} {MinPlayers:Pluralise:player|players} to join teams",
 	"ABORT_MARINES_EMPTY": "Game start aborted, marine team is empty.",
 	"ABORT_ALIENS_EMPTY": "Game start aborted, alien team is empty.",
 	"ABORT_COMMANDER_DROP": "Game start aborted, a commander dropped out.",

--- a/lua/shine/core/shared/base_plugin/config.lua
+++ b/lua/shine/core/shared/base_plugin/config.lua
@@ -109,6 +109,11 @@ function ConfigModule:LoadConfig()
 	local Validator = Shine.Validator()
 	Validator:AddRule( {
 		Matches = function( _, Config )
+			return self.PreValidateConfig and self:PreValidateConfig( Config )
+		end
+	} )
+	Validator:AddRule( {
+		Matches = function( _, Config )
 			return self.CheckConfig and Shine.CheckConfig( Config, self.DefaultConfig )
 		end
 	} )

--- a/lua/shine/extensions/pregame/server.lua
+++ b/lua/shine/extensions/pregame/server.lua
@@ -542,15 +542,15 @@ Plugin.UpdateFuncs = {
 		local Team1Com = Team1:GetCommander()
 		local Team2Com = Team2:GetCommander()
 
-		local Team1Count = Team1:GetNumPlayers()
-		local Team2Count = Team2:GetNumPlayers()
+		local Team1Count, Team1Rookies, Team1Bots = Team1:GetNumPlayers()
+		local Team2Count, Team2Rookies, Team2Bots = Team2:GetNumPlayers()
 
 		if self.GameStarting then
 			self:CheckTeamCounts( Gamerules, Team1Com, Team2Com, Team1Count, Team2Count )
 			return
 		end
 
-		local PlayerCount = Shine.GetHumanPlayerCount()
+		local PlayerCount = Team1Count + Team2Count - Team1Bots - Team2Bots
 		if PlayerCount < self.Config.MinPlayers then return end
 
 		if Team1Com and Team2Com then

--- a/lua/shine/extensions/pregame/server.lua
+++ b/lua/shine/extensions/pregame/server.lua
@@ -555,6 +555,16 @@ Plugin.UpdateFuncs = {
 
 		if Team1Com and Team2Com then
 			self:QueueGameStart( Gamerules )
+			return
+		end
+
+		if not self:CanRunAction( "StartNag", SharedTime(), self.StartNagInterval ) then return end
+
+		if Team1Com or Team2Com then
+			local WaitingForTeam = Team1Com and 2 or 1
+			self:NagForTeam( WaitingForTeam )
+		else
+			self:NagForBoth()
 		end
 	end
 }

--- a/lua/shine/extensions/pregame/server.lua
+++ b/lua/shine/extensions/pregame/server.lua
@@ -7,6 +7,7 @@ local Shine = Shine
 local Ceil = math.ceil
 local Clamp = math.Clamp
 local Floor = math.floor
+local Max = math.max
 local SharedTime = Shared.GetTime
 local StringFormat = string.format
 
@@ -68,6 +69,7 @@ function Plugin:Initialise()
 	end
 
 	self.Config.Mode = Clamp( Floor( self.Config.Mode ), 1, #self.Modes )
+	self.Config.MinPlayers = Max( Floor( self.Config.MinPlayers ), 0 )
 
 	self.CountStart = nil
 	self.CountEnd = nil
@@ -551,7 +553,15 @@ Plugin.UpdateFuncs = {
 		end
 
 		local PlayerCount = Team1Count + Team2Count - Team1Bots - Team2Bots
-		if PlayerCount < self.Config.MinPlayers then return end
+		if PlayerCount < self.Config.MinPlayers then
+			if self:CanRunAction( "StartNag", SharedTime(), self.StartNagInterval ) then
+				self:SendTranslatedNotify( nil, "WaitingForMinPlayers", {
+					MinPlayers = self.Config.MinPlayers
+				} )
+			end
+
+			return
+		end
 
 		if Team1Com and Team2Com then
 			self:QueueGameStart( Gamerules )

--- a/lua/shine/extensions/pregame/shared.lua
+++ b/lua/shine/extensions/pregame/shared.lua
@@ -23,6 +23,9 @@ function Plugin:SetupDataTable()
 		},
 		Duration = {
 			Duration = "integer"
+		},
+		MinPlayers = {
+			MinPlayers = "integer"
 		}
 	}
 
@@ -38,6 +41,9 @@ function Plugin:SetupDataTable()
 		},
 		[ MessageTypes.CommanderAdd ] = {
 			"TeamHasCommander"
+		},
+		[ MessageTypes.MinPlayers ] = {
+			"WaitingForMinPlayers"
 		}
 	} )
 end
@@ -59,6 +65,10 @@ function Plugin:ReceiveWaitingForTeam( Data )
 		"WAITING_FOR_ALIENS"
 	}
 	self:SetTeamMessage( self:GetPhrase( TeamKeys[ Data.Team ] ) )
+end
+
+function Plugin:ReceiveWaitingForMinPlayers( Data )
+	self:SetTeamMessage( self:GetInterpolatedPhrase( "WAITING_FOR_PLAYER_COUNT", Data ) )
 end
 
 function Plugin:ReceiveEmptyTeamAbort( Data )

--- a/lua/shine/extensions/voterandom/team_balance.lua
+++ b/lua/shine/extensions/voterandom/team_balance.lua
@@ -18,6 +18,8 @@ local TableSort = table.sort
 
 local EvenlySpreadTeams = Shine.EvenlySpreadTeams
 
+Shine.Hook.SetupClassHook( "BotTeamController", "UpdateBots", "UpdateBots", "ActivePre" )
+
 local function GetAverageSkillFunc( Players, Func, TeamNumber )
 	local PlayerCount = #Players
 	if PlayerCount == 0 then
@@ -195,6 +197,10 @@ function BalanceModule:AssignPlayers( TeamMembers, SortTable, Count, NumTargets,
 	end
 
 	return Sorted
+end
+
+function BalanceModule:UpdateBots()
+	if self.OptimisingTeams then return false end
 end
 
 function BalanceModule:OptimiseTeams( TeamMembers, RankFunc, TeamSkills )

--- a/lua/shine/extensions/votesurrender/server.lua
+++ b/lua/shine/extensions/votesurrender/server.lua
@@ -69,12 +69,10 @@ end
 
 function Plugin:GetTeamPlayerCount( Team )
 	local Gamerules = GetGamerules()
+	local TeamData = Gamerules[ Team == 1 and "team1" or "team2" ]
+	local NumPlayers, NumRookies, NumBots = TeamData:GetNumPlayers()
 
-	if Team == 1 then
-		return Gamerules.team1:GetNumPlayers()
-	else
-		return Gamerules.team2:GetNumPlayers()
-	end
+	return NumPlayers - NumBots
 end
 
 function Plugin:GetVotesNeeded( Team )
@@ -94,7 +92,7 @@ function Plugin:CanStartVote( Team )
 
 	local State = Gamerules:GetGameState()
 	local PlayingTeam = Gamerules:GetTeam( Team )
-	local TeamCount = PlayingTeam:GetNumPlayers()
+	local TeamCount = self:GetTeamPlayerCount( Team )
 
 	local AllowWithNumBases = self.Config.AllowVoteWithMultipleBases or
 			PlayingTeam:GetNumCapturedTechPoints() == 1

--- a/lua/shine/extensions/welcomemessages/server.lua
+++ b/lua/shine/extensions/welcomemessages/server.lua
@@ -22,7 +22,8 @@ Plugin.DefaultConfig = {
 			Leave = "Bob is off to fight more important battles."
 		}
 	},
-	ShowGeneric = false
+	ShowGeneric = false,
+	ShowForBots = false
 }
 
 Plugin.CheckConfig = true
@@ -36,9 +37,14 @@ function Plugin:Initialise()
 	return true
 end
 
+function Plugin:ShouldShowMessage( Client )
+	return Shine:IsValidClient( Client ) and ( self.Config.ShowForBots
+		or not Client:GetIsVirtual() )
+end
+
 function Plugin:ClientConnect( Client )
 	self:SimpleTimer( self.Config.MessageDelay, function()
-		if not Shine:IsValidClient( Client ) then return end
+		if not self:ShouldShowMessage( Client ) then return end
 
 		local ID = Client:GetUserId()
 		local MessageTable = self.Config.Users[ tostring( ID ) ]
@@ -151,8 +157,6 @@ end
 function Plugin:Cleanup()
 	self.Welcomed = nil
 	self.BaseClass.Cleanup( self )
-
-	self.Enabled = false
 end
 
 Shine.Hook.SetupGlobalHook( "Server.DisconnectClient", "OnScriptDisconnect", "PassivePre" )

--- a/lua/shine/lib/table.lua
+++ b/lua/shine/lib/table.lua
@@ -91,19 +91,27 @@ function table.AsSet( Table )
 	return Ret
 end
 
---[[
-	Returns a table that contains the given table's values as keys,
-	as well as the original table values.
-]]
-function table.AsEnum( Table )
-	local Ret = {}
-
-	for i = 1, #Table do
-		Ret[ i ] = Table[ i ]
-		Ret[ Table[ i ] ] = Table[ i ]
+do
+	local function DefaultTransformer( Index, Value )
+		return Value
 	end
 
-	return Ret
+	--[[
+		Returns a table that contains the given table's values as keys,
+		as well as the original table values.
+	]]
+	function table.AsEnum( Table, KeyTransformer )
+		KeyTransformer = KeyTransformer or DefaultTransformer
+
+		local Ret = {}
+
+		for i = 1, #Table do
+			Ret[ i ] = Table[ i ]
+			Ret[ Table[ i ] ] = KeyTransformer( i, Table[ i ] )
+		end
+
+		return Ret
+	end
 end
 
 do

--- a/test/lib/table.lua
+++ b/test/lib/table.lua
@@ -194,3 +194,14 @@ UnitTest:Test( "AsEnum", function( Assert )
 		Assert:Equals( Values[ i ], Enum[ Values[ i ] ] )
 	end
 end )
+
+UnitTest:Test( "AsEnum with transformer", function( Assert )
+	local Values = {
+		"This", "Is", "An", "Enum"
+	}
+	local Enum = table.AsEnum( Values, function( Index ) return Index end )
+	Assert:ArrayEquals( Values, Enum )
+	for i = 1, #Values do
+		Assert:Equals( i, Enum[ Values[ i ] ] )
+	end
+end )


### PR DESCRIPTION
- Fixed bots being counted towards votes in the vote surrender plugin.
- Defaulted showing connection messages for bots to disabled.
- Added a 4th mode to the pregame plugin, which waits for a minimum team player count before allowing the game to start with 2 commanders.
- Renamed the mode option in the pregame plugin from `RequireComs` to `Mode`, and made the scale from 1 - 4 for each mode described on the wiki page. This will be automatically changed for you.
- Prevented the warmup bots from interfering with team shuffling. Use the new `ApplyToBots` setting to allow them to be shuffled (defaults to false, which removes them on a shuffle).
