### PR TITLE
Add option to limit nominations per player, small hotfix

### DIFF
--- a/locale/shine/extensions/mapvote/enGB.json
+++ b/locale/shine/extensions/mapvote/enGB.json
@@ -38,6 +38,7 @@
 	"NEXT_MAP_STARTED": "Voting for the next map has started.",
 	"MAP_NOT_ON_LIST": "{MapName} is not on the map list.",
 	"NOMINATE_FAIL": "You cannot nominate the current map.",
+	"NOMINATE_DENIED": "You have reached the limit of nominations permitted.",
 	"ALREADY_NOMINATED": "{MapName} has already been nominated.",
 	"RECENTLY_PLAYED": "{MapName} was recently played and cannot be voted for yet.",
 	"NOMINATIONS_FULL": "Nominations are full.",

--- a/lua/shine/extensions/mapvote/voting.lua
+++ b/lua/shine/extensions/mapvote/voting.lua
@@ -545,6 +545,7 @@ function Plugin:StartVote( NextMap, Force )
 
 	self.Vote.TotalVotes = 0
 	self.Vote.Voted = {}
+	self.Vote.NominationTracker = {}
 
 	--First we compile the list of maps that are going to be available to vote for.
 	local MaxOptions = self.Config.MaxOptions

--- a/lua/shine/extensions/pregame/server.lua
+++ b/lua/shine/extensions/pregame/server.lua
@@ -205,6 +205,8 @@ function Plugin:QueueGameStart( Gamerules )
 	end
 
 	self:CreateTimer( self.FiveSecTimer, CountdownTime - 5, 1, function()
+		local Team1 = Gamerules.team1
+		local Team2 = Gamerules.team2
 		local Team1Com = Team1:GetCommander()
 		local Team2Com = Team2:GetCommander()
 
@@ -225,6 +227,8 @@ function Plugin:QueueGameStart( Gamerules )
 	end )
 
 	self:CreateTimer( self.CountdownTimer, CountdownTime, 1, function()
+		local Team1 = Gamerules.team1
+		local Team2 = Gamerules.team2
 		local Team1Com = Team1:GetCommander()
 		local Team2Com = Team2:GetCommander()
 


### PR DESCRIPTION
* Added `MaxNominationsPerPlayer` option to the mapvote plugin. Sets the maximum number of nominations a single player is allowed to make per vote.
* Added a hotfix to fix the commander bot code breaking team swapping.