### PR TITLE
Fix small issues in the shuffle plugin

### DIFF
--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -283,7 +283,7 @@ function Plugin:GetTargetsForSorting( ResetScores )
 		local Commander = Player:isa( "Commander" ) and self.Config.IgnoreCommanders
 
 		if AFKEnabled then -- Ignore AFK players in sorting.
-			if not AFKKick:IsAFKFor( Client, 60 ) then
+			if Commander or not AFKKick:IsAFKFor( Client, 60 ) then
 				SortPlayer( Player, Client, Commander, Pass )
 			elseif Pass == 1 then -- Chuck AFK players into the ready room.
 				local Team = Player:GetTeamNumber()


### PR DESCRIPTION
- No longer move commanders to the ready room if they are AFK and `IgnoreCommanders` is true.
- Fix standard deviation not being correct on the scoreboard due to a logic flaw.