### PR TITLE
Small bug fixes and minor feature changes

### DIFF
--- a/lua/shine/extensions/basecommands/shared.lua
+++ b/lua/shine/extensions/basecommands/shared.lua
@@ -54,7 +54,8 @@ function Plugin:SetupDataTable()
 			"RESET_GAME", "HIVE_TEAMS", "FORCE_START", "VOTE_STOPPED"
 		},
 		[ MessageTypes.Enabled ] = {
-			"CHEATS_TOGGLED", "ALLTALK_TOGGLED", "ALLTALK_PREGAME_TOGGLED"
+			"CHEATS_TOGGLED", "ALLTALK_TOGGLED", "ALLTALK_PREGAME_TOGGLED",
+			"ALLTALK_LOCAL_TOGGLED"
 		},
 		[ MessageTypes.Kick ] = {
 			"ClientKicked"

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -509,7 +509,7 @@ function Plugin:JoinTeam( Gamerules, Player, NewTeam, Force, ShineForce )
 	local Gamestate = Gamerules:GetGameState()
 
 	--We'll do a mass balance, don't worry about them yet.
-	if self.Config.AlwaysEnabled and Gamestate < kGameState.Pregame then return end
+	if self.Config.AlwaysEnabled and Gamestate < kGameState.PreGame then return end
 
 	--Don't block them from going back to the ready room at the end of the round.
 	if Gamestate == kGameState.Team1Won or Gamestate == kGameState.Team2Won

--- a/lua/shine/lib/gui/objects/webpage.lua
+++ b/lua/shine/lib/gui/objects/webpage.lua
@@ -41,6 +41,10 @@ function Webpage:LoadURL( URL, W, H )
 
 		self.Background:SetSize( Vector( W, H, 0 ) )
 		self.Background:SetTexture( TextureName )
+
+		self.WebView:HookJSAlert( function( ... )
+			self:OnJSAlert( ... )
+		end )
 	end
 
 	self.WebView:LoadUrl( URL )
@@ -50,6 +54,18 @@ function Webpage:GetHasLoaded()
 	if not self.WebView then return false end
 
 	return self.WebView:GetUrlLoaded()
+end
+
+function Webpage:OnJSAlert( ... )
+	-- Override to see JavaScript alerts...
+end
+
+function Webpage:ExecuteJS( JavaScript )
+	if not self.WebView or not self:GetHasLoaded() then
+		error( "Attempted to execute JavaScript before loading a page!", 2 )
+	end
+
+	self.WebView:ExecuteJS( JavaScript )
 end
 
 function Webpage:PlayerKeyPress( Key, Down )

--- a/lua/shine/lib/table.lua
+++ b/lua/shine/lib/table.lua
@@ -181,11 +181,7 @@ end
 --[[
 	Clears a table.
 ]]
-function table.Empty( Table )
-	for Key in pairs( Table ) do
-		Table[ Key ] = nil
-	end
-end
+table.Empty = require "table.clear"
 
 --[[
 	Fixes an array with holes in it.


### PR DESCRIPTION
- Fixed players being blocked from entering spectate when team enforcing is enabled after a shuffle vote.
- Fixed a script error in the shuffle plugin when "AlwaysEnabled" mode is true.
- Fixed a script error in the base commands plugin when toggling local all-talk.
- Web components can now run Javascript and watch for Javascript alerts.
- Changed `table.Empty` to just be an alias to LuaJIT 2.1's `table.clear`.