### PR TITLE
UI improvements, AFK lenient mode, gamemode detection for plugins

### DIFF
--- a/locale/shine/extensions/basecommands/enGB.json
+++ b/locale/shine/extensions/basecommands/enGB.json
@@ -8,6 +8,8 @@
 	"KICK_TROLLING": "Trolling",
 	"KICK_LANGUAGE": "Offensive language",
 	"KICK_MIC_SPAM": "Mic spamming",
+	"KICK_AFK": "AFK",
+	"KICK_CUSTOM": "Enter a custom reason...",
 	"GAG": "Gag",
 	"GAG_TIP": "Stops the player from using text and voice chat.",
 	"GAG_UNTIL_MAP_CHANGE": "Until map change",

--- a/lua/shine/core/client/adminmenu.lua
+++ b/lua/shine/core/client/adminmenu.lua
@@ -48,19 +48,22 @@ function AdminMenu:Create()
 
 	Window:AddCloseButton()
 	Window.OnClose = function()
-		self:SetIsVisible( false )
-
-		if self.ToDestroyOnClose then
-			for Panel in pairs( self.ToDestroyOnClose ) do
-				if Panel:IsValid() then
-					Panel:Destroy()
-				end
-
-				self.ToDestroyOnClose[ Panel ] = nil
-			end
-		end
-
+		self:Close()
 		return true
+	end
+end
+
+function AdminMenu:Close()
+	self:SetIsVisible( false )
+
+	if self.ToDestroyOnClose then
+		for Panel in pairs( self.ToDestroyOnClose ) do
+			if Panel:IsValid() then
+				Panel:Destroy()
+			end
+
+			self.ToDestroyOnClose[ Panel ] = nil
+		end
 	end
 end
 
@@ -120,7 +123,7 @@ function AdminMenu:PlayerKeyPress( Key, Down )
 	if not self.Visible then return end
 
 	if Key == InputKey.Escape and Down then
-		self:SetIsVisible( false )
+		self:Close()
 
 		return true
 	end

--- a/lua/shine/core/client/adminmenu.lua
+++ b/lua/shine/core/client/adminmenu.lua
@@ -515,7 +515,7 @@ do
 
 				local Args = GetArgsFromRows( Rows, MultiPlayer )
 
-				Menu = Button:AddMenu( Vector( 128, 32, 0 ) )
+				Menu = Button:AddMenu( Vector( Data.Width or 144, Data.ButtonHeight or 32, 0 ) )
 				Menu:CallOnRemove( function()
 					Menu = nil
 				end )
@@ -540,6 +540,8 @@ do
 							Arg()
 							CleanupMenu()
 						end )
+					elseif IsType( Arg, "table" ) and Arg.Setup then
+						Arg.Setup( Menu, Command, Args, CleanupMenu )
 					end
 				end
 			end

--- a/lua/shine/extensions/afkkick/server.lua
+++ b/lua/shine/extensions/afkkick/server.lua
@@ -35,7 +35,8 @@ Plugin.DefaultConfig = {
 	OnlyCheckOnStarted = false,
 	KickOnConnect = false,
 	KickTimeIsAFKThreshold = 0.25,
-	MarkPlayersAFK = true
+	MarkPlayersAFK = true,
+	LenientModeForSpectators = false
 }
 
 Plugin.CheckConfig = true
@@ -278,14 +279,19 @@ function Plugin:OnProcessMove( Player, Input )
 	if not ( MovementIsEmpty and AnglesMatch ) then
 		DataTable.LastMove = Time
 
-		-- Spectator movement is weighted higher because it will occur less frequently.
-		local Multiplier = IsSpectator and SPECTATOR_MOVEMENT_MULTIPLIER or MOVEMENT_MULTIPLIER
+		if IsSpectator and self.Config.LenientModeForSpectators then
+			-- Lenient mode means reset AFK time on any movement for a spectator.
+			DataTable.AFKAmount = 0
+		else
+			-- Spectator movement is weighted higher because it will occur less frequently.
+			local Multiplier = IsSpectator and SPECTATOR_MOVEMENT_MULTIPLIER or MOVEMENT_MULTIPLIER
 
-		-- Subtract the measurement time from their AFK time, so they have to stay
-		-- active for a while to get it back to 0 time.
-		-- We use a multiplier as we want activity to count for more than inactivity to avoid
-		-- overzealous kicks.
-		DataTable.AFKAmount = Max( DataTable.AFKAmount - DeltaTime * Multiplier, 0 )
+			-- Subtract the measurement time from their AFK time, so they have to stay
+			-- active for a while to get it back to 0 time.
+			-- We use a multiplier as we want activity to count for more than inactivity to avoid
+			-- overzealous kicks.
+			DataTable.AFKAmount = Max( DataTable.AFKAmount - DeltaTime * Multiplier, 0 )
+		end
 	else
 		DataTable.AFKAmount = Max( DataTable.AFKAmount + DeltaTime, 0 )
 	end

--- a/lua/shine/extensions/basecommands/shared.lua
+++ b/lua/shine/extensions/basecommands/shared.lua
@@ -220,7 +220,33 @@ function Plugin:SetupAdminMenuCommands()
 		self:GetPhrase( "KICK_NO_REASON" ), "",
 		self:GetPhrase( "KICK_TROLLING" ), "Trolling.",
 		self:GetPhrase( "KICK_LANGUAGE" ), "Offensive language.",
-		self:GetPhrase( "KICK_MIC_SPAM" ), "Mic spamming."
+		self:GetPhrase( "KICK_MIC_SPAM" ), "Mic spamming.",
+		self:GetPhrase( "KICK_AFK" ), "AFK.",
+		"Custom", {
+			Setup = function( Menu, Command, Player, CleanupMenu )
+				local Panel = SGUI:Create( "Panel", Menu )
+				local TextEntry = SGUI:Create( "TextEntry", Panel )
+				TextEntry:SetFill( true )
+				TextEntry:SetPlaceholderText( self:GetPhrase( "KICK_CUSTOM" ) )
+				TextEntry:SetFontScale( Fonts.kAgencyFB_Small, Vector2( 0.9, 0.9 ) )
+				function TextEntry:OnEnter()
+					local Text = self:GetText()
+					if #Text == 0 then return end
+
+					Shine.AdminMenu:RunCommand( Command, StringFormat( "%s %s", Player, Text ) )
+					CleanupMenu()
+				end
+
+				local Layout = SGUI.Layout:CreateLayout( "Horizontal", {
+					Padding = SGUI.Layout.Units.Spacing( 2, 2, 2, 2 )
+				} )
+				Layout:AddElement( TextEntry )
+				Panel:SetLayout( Layout )
+
+				Menu:AddPanel( Panel )
+			end
+		},
+		Width = 192
 	}, self:GetPhrase( "KICK_TIP" ) )
 
 	local GagTimes = {

--- a/lua/shine/extensions/chatbox/client.lua
+++ b/lua/shine/extensions/chatbox/client.lua
@@ -212,7 +212,8 @@ local Skin = {
 			FocusColour = Colours.Dark,
 			DarkColour = Colours.Dark,
 			BorderColour = Colour( 0, 0, 0, 0 ),
-			TextColour = Colour( 1, 1, 1, 1 )
+			TextColour = Colour( 1, 1, 1, 1 ),
+			PlaceholderTextColour = Colour( 0.8, 0.8, 0.8, 0.5 )
 		}
 	},
 

--- a/lua/shine/extensions/pregame/server.lua
+++ b/lua/shine/extensions/pregame/server.lua
@@ -47,6 +47,11 @@ Plugin.CountdownTimer = "PreGameCountdown"
 
 Plugin.StartNagInterval = 30
 
+Plugin.EnabledGamemodes = {
+	[ "ns2" ] = true,
+	[ "mvm" ] = true
+}
+
 function Plugin:OnFirstThink()
 	Shine.Hook.SetupClassHook( "Player", "GetCanAttack",
 		"CheckPlayerCanAttack", "ActivePre" )
@@ -62,12 +67,6 @@ function Plugin:PreValidateConfig( Config )
 end
 
 function Plugin:Initialise()
-	local Gamemode = Shine.GetGamemode()
-
-	if Gamemode ~= "ns2" and Gamemode ~= "mvm" then
-		return false, StringFormat( "The pregame plugin does not work with %s.", Gamemode )
-	end
-
 	self.Config.Mode = Clamp( Floor( self.Config.Mode ), 1, #self.Modes )
 	self.Config.MinPlayers = Max( Floor( self.Config.MinPlayers ), 0 )
 

--- a/lua/shine/extensions/tournamentmode/server.lua
+++ b/lua/shine/extensions/tournamentmode/server.lua
@@ -35,6 +35,10 @@ Plugin.Conflicts = {
 Plugin.CountdownTimer = "Countdown"
 Plugin.FiveSecondTimer = "5SecondCount"
 
+Plugin.EnabledGamemodes = {
+	[ "ns2" ] = true
+}
+
 function Plugin:StoreConfigSettings()
 	self.OriginalServerConfig = {
 		AutoBalance = Server.GetConfigSetting( "auto_team_balance" ),
@@ -52,13 +56,6 @@ function Plugin:RestoreConfigSettings()
 end
 
 function Plugin:Initialise()
-	local Gamemode = Shine.GetGamemode()
-
-	if Gamemode ~= "ns2" then
-		return false, StringFormat( "The tournamentmode plugin does not work with %s.",
-			Gamemode )
-	end
-
 	self.TeamMembers = {}
 	self.ReadyStates = { false, false }
 	self.TeamNames = {}

--- a/lua/shine/extensions/voterandom/local_stats.lua
+++ b/lua/shine/extensions/voterandom/local_stats.lua
@@ -201,7 +201,7 @@ function StatsModule:StoreRoundEndData( ClientID, Player, WinningTeamNumber, Rou
 	local Team = Player:GetTeamNumber()
 
 	-- Only add win/loss if the player was on the team for more than the minimum time.
-	local TimeOnTeam = Team == 1 and Player:GetMarinePlayTime() or Player:GetAlienPlayTime()
+	local TimeOnTeam = Team == 1 and Player:GetMarinePlayTime() or Player:GetAlienPlayTime() or 0
 	if TimeOnTeam >= MinTimeOnTeam then
 		local Stat = Team == WinningTeamNumber and "Wins" or "Losses"
 		self:IncrementStatValue( ClientID, Player, Stat, 1 )

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -29,6 +29,11 @@ Plugin.ConfigName = "VoteRandom.json"
 
 Plugin.RandomEndTimer = "VoteRandomTimer"
 
+Plugin.EnabledGamemodes = {
+	[ "ns2" ] = true,
+	[ "mvm" ] = true
+}
+
 Plugin.MODE_RANDOM = 1
 Plugin.MODE_SCORE = 2
 Plugin.MODE_ELO = 3

--- a/lua/shine/extensions/votesurrender/server.lua
+++ b/lua/shine/extensions/votesurrender/server.lua
@@ -31,6 +31,11 @@ Plugin.DefaultConfig = {
 Plugin.CheckConfig = true
 Plugin.CheckConfigTypes = true
 
+Plugin.EnabledGamemodes = {
+	[ "ns2" ] = true,
+	[ "mvm" ] = true
+}
+
 function Plugin:Initialise()
 	local function VoteTimeout( Vote )
 		local LastVoted = Vote.LastVoted

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -75,6 +75,21 @@ function ControlMeta:CallOnRemove( Func )
 	Table[ #Table + 1 ] = Func
 end
 
+--[[
+	Sets a new styling state, which will potentially apply different styling
+	values to the control.
+
+	This can be used to easily define focus/hover behaviour.
+]]
+function ControlMeta:SetStylingState( Name )
+	self.StylingState = Name
+	SGUI.SkinManager:ApplySkin( self )
+end
+
+function ControlMeta:GetStylingState()
+	return self.StylingState
+end
+
 function ControlMeta:SetStyleName( Name )
 	self.StyleName = Name
 	SGUI.SkinManager:ApplySkin( self )

--- a/lua/shine/lib/gui/objects/menu.lua
+++ b/lua/shine/lib/gui/objects/menu.lua
@@ -74,7 +74,7 @@ function Menu:AddPanel( Panel )
 	Panel:SetSize( self.ButtonSize )
 
 	self.ButtonCount = self.ButtonCount + 1
-	self.Buttons[ self.ButtonCount ] = Button
+	self.Buttons[ self.ButtonCount ] = Panel
 
 	self:Resize()
 

--- a/lua/shine/lib/gui/objects/menu.lua
+++ b/lua/shine/lib/gui/objects/menu.lua
@@ -61,12 +61,31 @@ function Menu:AddButton( Text, DoClick, Tooltip )
 	self.ButtonCount = self.ButtonCount + 1
 	self.Buttons[ self.ButtonCount ] = Button
 
+	self:Resize()
+
+	return Button
+end
+
+function Menu:AddPanel( Panel )
+	Panel:SetParent( self )
+	Panel:SetStyleName( "MenuPanel" )
+	Panel:SetAnchor( GUIItem.Left, GUIItem.Top )
+	Panel:SetPos( self.ButtonSpacing + self.ButtonCount * self.ButtonOffset )
+	Panel:SetSize( self.ButtonSize )
+
+	self.ButtonCount = self.ButtonCount + 1
+	self.Buttons[ self.ButtonCount ] = Button
+
+	self:Resize()
+
+	return Panel
+end
+
+function Menu:Resize()
 	if not ( self.MaxVisibleButtons and self.ButtonCount > self.MaxVisibleButtons ) then
 		self:SetSize( self.ButtonSpacing * 2 + self.ButtonSize
 			+ ( self.ButtonCount - 1 ) * self.ButtonOffset )
 	end
-
-	return Button
 end
 
 ------------------- Event calling -------------------

--- a/lua/shine/lib/gui/objects/textentry.lua
+++ b/lua/shine/lib/gui/objects/textentry.lua
@@ -251,6 +251,9 @@ end
 
 function TextEntry:SetTextScale( Scale )
 	self.TextObj:SetScale( Scale )
+	if self.PlaceholderText then
+		self.PlaceholderText:SetScale( Scale )
+	end
 
 	self.WidthScale = Scale.x
 	self.HeightScale = Scale.y
@@ -949,6 +952,7 @@ function TextEntry:OnFocusChange( NewFocus, ClickingOtherElement )
 			self.Enabled = false
 			self.Highlighted = false
 			self:FadeTo( self.InnerBox, self.FocusColour, self.DarkCol, 0, 0.1 )
+			self:SetStylingState( nil )
 		end
 
 		self.Caret:SetColor( Clear )
@@ -957,6 +961,7 @@ function TextEntry:OnFocusChange( NewFocus, ClickingOtherElement )
 		return
 	end
 
+	self:SetStylingState( "Focus" )
 	self:StopFade( self.InnerBox )
 	self.InnerBox:SetColor( self.FocusColour )
 

--- a/lua/shine/lib/gui/skin_manager.lua
+++ b/lua/shine/lib/gui/skin_manager.lua
@@ -73,6 +73,12 @@ function SkinManager:ApplySkin( Element )
 	local StyleDef = self:GetStyleForElement( Element )
 	if not StyleDef then return end
 
+	-- States can apply different scheme values, e.g. focus/hover etc.
+	local State = Element:GetStylingState()
+	if State and StyleDef.States then
+		StyleDef = StyleDef.States[ State ] or StyleDef
+	end
+
 	local StyleCopy = {}
 	for Key, Value in pairs( StyleDef ) do
 		if SGUI.IsColour( Value ) then

--- a/lua/shine/lib/gui/skins/default.lua
+++ b/lua/shine/lib/gui/skins/default.lua
@@ -96,6 +96,9 @@ local Skin = {
 		},
 		TitleBar = {
 			Colour = Colour( 0.25, 0.25, 0.25, 1 )
+		},
+		MenuPanel = {
+			Colour = Colour( 0.25, 0.25, 0.25, 1 )
 		}
 	},
 	ProgressBar = {
@@ -135,11 +138,17 @@ local Skin = {
 	},
 	TextEntry = {
 		Default = {
-			FocusColour = Colour( 0.6, 0.6, 0.6, 1 ),
+			FocusColour = Colour( 0.35, 0.35, 0.35, 1 ),
 			DarkColour = Colour( 0.4, 0.4, 0.4, 1 ),
-			HighlightColour = Colour( 1, 0.6, 0, 0.5 ),
-			PlaceholderTextColour = Colour( 0.8, 0.8, 0.8, 0.5 ),
-			BorderColour = Colour( 0, 0, 0, 1 )
+			HighlightColour = Colour( 1, 0.4, 0, 0.5 ),
+			PlaceholderTextColour = Colour( 0.9, 0.9, 0.9, 1 ),
+			BorderColour = Colour( 0.1, 0.1, 0.1, 1 ),
+			BorderSize = Vector2( 1, 1 ),
+			States = {
+				Focus = {
+					BorderColour = Colour( 1, 0.3, 0, 1 )
+				}
+			}
 		}
 	},
 	Tooltip = {


### PR DESCRIPTION
* Fixed a script error when `Player:GetMarinePlayTime()` or `Player:GetAlienPlayTime()` return `nil`.
* Fixed escape not closing command menus in the admin menu.
* Added a text entry for a custom kick reason to the kick command's menu.
* SGUI components now have the concept of styling states, allowing skins to define different properties for different states. Currently on `TextEntry` controls use this, and they have a single non-standard state called `Focus`.
* Made move detection more forgiving for spectators, and added the `LenientModeForSpectators` option to make AFK time reset to 0 when spectators move.
* Plugins can now define either a whitelist (`EnabledGamemodes`) or blacklist (`DisabledGamemodes`) of gamemodes and they will be automatically disabled when the current gamemode does not match the filters.
* Vote shuffle and vote surrender are now only enabled for `ns2` and `mvm` gamemodes.