### PR TITLE
Small script error fixes for badges and local stats

### DIFF
--- a/lua/shine/extensions/badges.lua
+++ b/lua/shine/extensions/badges.lua
@@ -3,6 +3,7 @@
 ]]
 
 local pairs = pairs
+local pcall = pcall
 local tonumber = tonumber
 local tostring = tostring
 local IsType = Shine.IsType
@@ -26,6 +27,15 @@ local DefaultRow = 5
 local MaxBadgeRows = 10
 Plugin.DefaultRow = DefaultRow
 
+local function AssignBadge( ID, Name, Row )
+	-- Catch error from badge enum missing values.
+	local Success, BadgeAssigned = pcall( GiveBadge, ID, Name, Row )
+	if not Success then
+		BadgeAssigned = false
+	end
+	return BadgeAssigned
+end
+
 function Plugin:AssignGroupBadge( ID, GroupName, Group, AssignedGroups, MasterBadgeTable )
 	if not Group then return end
 
@@ -42,7 +52,7 @@ function Plugin:AssignGroupBadge( ID, GroupName, Group, AssignedGroups, MasterBa
 		local GroupBadgeName = GroupName:lower()
 		local Rows = MasterBadgeTable and MasterBadgeTable:Get( GroupBadgeName ) or { DefaultRow }
 		for i = 1, #Rows do
-			GiveBadge( ID, GroupBadgeName, Rows[ i ] )
+			AssignBadge( ID, GroupBadgeName, Rows[ i ] )
 		end
 	end
 
@@ -112,7 +122,6 @@ end
 	have a single value under "Badge" or a an array under "Badges".
 ]]
 function Plugin:AssignBadgesToID( ID, Entry, MasterBadgeTable, OwnerName )
-	local AssignBadge = GiveBadge
 	local SingleBadge = Entry.Badge or Entry.badge
 	local BadgeList = Entry.Badges or Entry.badges
 

--- a/lua/shine/extensions/voterandom/local_stats.lua
+++ b/lua/shine/extensions/voterandom/local_stats.lua
@@ -200,11 +200,13 @@ function StatsModule:StoreRoundEndData( ClientID, Player, WinningTeamNumber, Rou
 	local MinTimeOnTeam = Min( self.Config.StatsRecording.MinMinutesOnTeam * 60, RoundLength * 0.95 )
 	local Team = Player:GetTeamNumber()
 
-	-- Only add win/loss if the player was on the team for more than the minimum time.
-	local TimeOnTeam = Team == 1 and Player:GetMarinePlayTime() or Player:GetAlienPlayTime() or 0
-	if TimeOnTeam >= MinTimeOnTeam then
-		local Stat = Team == WinningTeamNumber and "Wins" or "Losses"
-		self:IncrementStatValue( ClientID, Player, Stat, 1 )
+	if WinningTeamNumber then
+		-- Only add win/loss if the player was on the team for more than the minimum time.
+		local TimeOnTeam = Team == 1 and Player:GetMarinePlayTime() or Player:GetAlienPlayTime() or 0
+		if TimeOnTeam >= MinTimeOnTeam then
+			local Stat = Team == WinningTeamNumber and "Wins" or "Losses"
+			self:IncrementStatValue( ClientID, Player, Stat, 1 )
+		end
 	end
 
 	-- Re-evaluate whether the player is still a rookie based upon the recorded data.
@@ -215,7 +217,7 @@ end
 function StatsModule:EndGame( Gamerules, WinningTeam, Players )
 	if not self.Config.UseLocalFileStats then return end
 
-	local WinningTeamNumber = WinningTeam:GetTeamNumber()
+	local WinningTeamNumber = WinningTeam and WinningTeam:GetTeamNumber()
 	local RoundLength = Shared.GetTime() - Gamerules.gameStartTime
 
 	for i = 1, #Players do


### PR DESCRIPTION
* Fixed script error due to badge functionality throwing an error when a badge is missing.
* Fixed a script error in vote shuffle's local stats recording when the game ends in a draw.