### PR TITLE
Check for Steam overlay in AFK kick, and fix kicking bots

### DIFF
--- a/lua/shine/extensions/afkkick/shared.lua
+++ b/lua/shine/extensions/afkkick/shared.lua
@@ -6,6 +6,7 @@ local Plugin = {}
 
 function Plugin:SetupDataTable()
 	self:AddNetworkMessage( "AFKNotify", {}, "Client" )
+	self:AddNetworkMessage( "SteamOverlay", { Open = "boolean" }, "Server" )
 end
 
 Shine:RegisterExtension( "afkkick", Plugin )
@@ -17,4 +18,21 @@ function Plugin:ReceiveAFKNotify( Data )
 	-- Flash the taskbar icon and play a sound. Can't say we didn't warn you.
 	Client.WindowNeedsAttention()
 	StartSoundEffect( self.NotifySoundEffect )
+end
+
+local GetIsSteamOverlayActive
+function Plugin:OnFirstThink()
+	GetIsSteamOverlayActive = Client.GetIsSteamOverlayActive
+end
+
+local SteamOverlayIsOpen = false
+function Plugin:Think()
+	local CurrentOverlayState = GetIsSteamOverlayActive()
+
+	-- Watch the Steam overlay. If it's opened, then the server should ignore all input
+	-- from the player until it closes, thus treating them as AFK.
+	if CurrentOverlayState ~= SteamOverlayIsOpen then
+		SteamOverlayIsOpen = CurrentOverlayState
+		self:SendNetworkMessage( "SteamOverlay", { Open = SteamOverlayIsOpen }, true )
+	end
 end

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -262,6 +262,26 @@ function Plugin:GetTargetsForSorting( ResetScores )
 		end
 	end
 
+	local function DisconnectBot( Client )
+		local Bots = gServerBots
+		local Found = false
+
+		if Bots then
+			-- No reference back to the bot, so have to search the table...
+			for i = 1, #Bots do
+				if Bots[ i ] and Bots[ i ].client == Client then
+					Found = true
+					Bots[ i ]:Disconnect()
+					break
+				end
+			end
+		end
+
+		if not Found then
+			Server.DisconnectClient( Client )
+		end
+	end
+
 	local function AddPlayer( Player, Pass )
 		if not Player then return end
 
@@ -275,11 +295,7 @@ function Plugin:GetTargetsForSorting( ResetScores )
 		-- Bot and we don't want to deal with them, so kick them out.
 		if Client:GetIsVirtual() and not self.Config.ApplyToBots then
 			if Pass == 1 then
-				if Player.Disconnect then
-					Player:Disconnect()
-				else
-					Server.DisconnectClient( Client )
-				end
+				DisconnectBot( Client )
 			end
 
 			return


### PR DESCRIPTION
- Clients in the Steam overlay are now always considered AFK.
- Fixed shuffling teams not kicking bots correctly.