### PR TITLE
Improve mapvote's previous map exclusions

### DIFF
--- a/lua/shine/core/shared/config.lua
+++ b/lua/shine/core/shared/config.lua
@@ -8,6 +8,9 @@ local pairs = pairs
 local StringFormat = string.format
 local type = type
 
+-- Make JSON encoding always have consistent order.
+Shine.SetUpValue( Encode, "pairs", SortedPairs, true )
+
 local JSONSettings = { indent = true, level = 1 }
 
 local IsType = Shine.IsType
@@ -96,7 +99,7 @@ function Shine.RecursiveCheckConfig( Config, DefaultConfig, DontRemove )
 end
 
 --Checks a config for missing entries without checking sub-tables.
-function Shine.CheckConfig( Config, DefaultConfig, DontRemove )
+function Shine.CheckConfig( Config, DefaultConfig, DontRemove, ReservedKeys )
 	local Updated
 
 	--Add new keys.
@@ -112,7 +115,8 @@ function Shine.CheckConfig( Config, DefaultConfig, DontRemove )
 
 	--Remove old keys.
 	for Option, Value in pairs( Config ) do
-		if DefaultConfig[ Option ] == nil then
+		if DefaultConfig[ Option ] == nil
+		and not ( ReservedKeys and ReservedKeys[ Option ] ) then
 			Config[ Option ] = nil
 
 			Updated = true

--- a/lua/shine/extensions/mapvote/cycle.lua
+++ b/lua/shine/extensions/mapvote/cycle.lua
@@ -251,7 +251,6 @@ function Plugin:LoadLastMaps()
 end
 
 function Plugin:SaveLastMaps()
-	local Max = self.Config.ExcludeLastMaps
 	local Data = self.LastMapData
 
 	if not Data then
@@ -259,11 +258,14 @@ function Plugin:SaveLastMaps()
 		Data = self.LastMapData
 	end
 
-	Data[ #Data + 1 ] = Shared.GetMapName()
-
-	while #Data > Max do
-		TableRemove( Data, 1 )
+	-- Store the last played maps in an ever repeating cycle.
+	local CurrentMap = Shared.GetMapName()
+	for i = #Data, 1, -1 do
+		if Data[ i ] == CurrentMap then
+			TableRemove( Data, i )
+		end
 	end
+	Data[ #Data + 1 ] = CurrentMap
 
 	local Success, Err = Shine.SaveJSONFile( Data, LastMapsFile )
 
@@ -307,7 +309,7 @@ end
 	Also, advance the current map group if we have one.
 ]]
 function Plugin:MapChange()
-	if self.Config.ExcludeLastMaps > 0 and not self.StoredCurrentMap then
+	if not self.StoredCurrentMap then
 		self.StoredCurrentMap = true
 		self:SaveLastMaps()
 	end

--- a/lua/shine/extensions/namefilter.lua
+++ b/lua/shine/extensions/namefilter.lua
@@ -21,6 +21,7 @@ local tostring = tostring
 local Plugin = {}
 
 Plugin.PrintName = "Name Filter"
+Plugin.Version = "1.0"
 
 Plugin.ConfigName = "NameFilter.json"
 Plugin.HasConfig = true

--- a/lua/shine/lib/objects/set.lua
+++ b/lua/shine/lib/objects/set.lua
@@ -1,0 +1,114 @@
+--[[
+	Defines a simple set.
+]]
+
+local getmetatable = getmetatable
+local TableGetKeys = table.GetKeys
+local TableQuickCopy = table.QuickCopy
+local TableShallowCopy = table.ShallowCopy
+
+local Set = Shine.TypeDef()
+function Set:Init( Lookup )
+	if getmetatable( Lookup ) == Set then
+		self.List = TableQuickCopy( Lookup.List )
+		self.Lookup = TableShallowCopy( Lookup.Lookup )
+	else
+		self.List = Lookup and TableGetKeys( Lookup ) or {}
+		self.Lookup = Lookup and TableShallowCopy( Lookup ) or {}
+	end
+
+	self.Stream = Shine.Stream( self.List )
+
+	return self
+end
+
+do
+	local function Iterate( Context )
+		Context.Index = Context.Index + 1
+		return Context.List[ Context.Index ]
+	end
+
+	function Set:Iterate()
+		return Iterate, { List = self.List, Index = 0 }
+	end
+end
+
+function Set:ForEach( Consumer )
+	return self.Stream:ForEach( Consumer )
+end
+
+--[[
+	Removes all elements not contained in the given lookup set.
+
+	This can either be a set instance, or a normal Lua table whose keys are the
+	values to be kept.
+]]
+function Set:Intersection( Lookup )
+	if getmetatable( Lookup ) == Set then
+		Lookup = Lookup.Lookup
+	end
+
+	return self:Filter( Predicates.Has( Lookup ) )
+end
+
+--[[
+	Adds all elements from the given set to this one.
+]]
+function Set:Union( OtherSet )
+	for Value in OtherSet:Iterate() do
+		self:Add( Value )
+	end
+
+	return self
+end
+
+function Set:Filter( Predicate )
+	self.Stream:Filter( function( Value )
+		local IsAllowed = Predicate( Value )
+		if not IsAllowed then
+			self.Lookup[ Value ] = nil
+		end
+		return IsAllowed
+	end )
+	return self
+end
+
+function Set:Add( Value )
+	if not self.Lookup[ Value ] then
+		self.Lookup[ Value ] = true
+		self.List[ #self.List + 1 ] = Value
+	end
+
+	return self
+end
+
+function Set:Contains( Value )
+	return self.Lookup[ Value ] or false
+end
+
+function Set:Remove( Value )
+	return self:Filter( Predicates.Not( Predicates.Equals( Value ) ) )
+end
+
+function Set:GetCount()
+	return #self.List
+end
+
+function Set:AsList()
+	return self.List
+end
+
+function Set:__eq( OtherSet )
+	if OtherSet:GetCount() ~= self:GetCount() then return false end
+
+	-- We don't care about order, just that they're all present.
+	for i = 1, #self.List do
+		if not OtherSet:Contains( self.List[ i ] ) then
+			return false
+		end
+	end
+
+	return true
+end
+
+Shine.Set = Set

--- a/lua/shine/lib/objects/stream.lua
+++ b/lua/shine/lib/objects/stream.lua
@@ -12,6 +12,25 @@ local TableSort = table.sort
 
 local Stream = Shine.TypeDef()
 
+-- Expose some useful predicate functions.
+Predicates = {
+	Equals = function( Value )
+		return function( Entry )
+			return Entry == Value
+		end
+	end,
+	Has = function( Set )
+		return function( Entry )
+			return Set[ Entry ]
+		end
+	end,
+	Not = function( Predicate )
+		return function( Entry )
+			return not Predicate( Entry )
+		end
+	end
+}
+
 function Stream:Init( Table )
 	self.Data = Table
 

--- a/lua/shine/lib/objects/version.lua
+++ b/lua/shine/lib/objects/version.lua
@@ -1,0 +1,63 @@
+--[[
+	Version object, allowing comparison of version numbers.
+]]
+
+local StringExplode = string.Explode
+
+local Version = Shine.TypeDef()
+
+local function ToNumberOrZero( Value ) return tonumber( Value ) or 0 end
+
+function Version:Init( Specifier )
+	self.Components = Shine.Stream( StringExplode( Specifier, "%." ) ):Map( ToNumberOrZero ):AsTable()
+	while #self.Components < 3 do
+		self.Components[ #self.Components + 1 ] = 0
+	end
+
+	return self
+end
+
+function Version:LessThan( OtherVersion )
+	for i = 1, 3 do
+		local OurComponent = self.Components[ i ]
+		local TheirComponent = OtherVersion.Components[ i ]
+
+		-- If our major > their major, we're newer, and so on.
+		if OurComponent > TheirComponent then return false end
+		-- If our major < their major, we're older, and so on.
+		if OurComponent < TheirComponent then return true end
+	end
+
+	-- No conclusion.
+	return nil
+end
+
+function Version:__lt( OtherVersion )
+	return self:LessThan( OtherVersion ) or false
+end
+
+function Version:__le( OtherVersion )
+	-- Either less than explicitly...
+	local IsLessThan = self:LessThan( OtherVersion )
+	if IsLessThan ~= nil then return IsLessThan end
+
+	-- Or exactly equal.
+	return true
+end
+
+function Version:__eq( OtherVersion )
+	-- Equal if first 3 version components are equal.
+	for i = 1, 3 do
+		if self.Components[ i ] ~= OtherVersion.Components[ i ] then
+			return false
+		end
+	end
+
+	return true
+end
+
+function Version:__tostring()
+	return Shine.Stream( self.Components ):Concat( ".", tostring )
+end
+
+Shine.VersionHolder = Version

--- a/lua/shine/lib/table.lua
+++ b/lua/shine/lib/table.lua
@@ -487,6 +487,24 @@ do
 		return KeyValueIterator( Keys, Table )
 	end
 
+	local IsType = Shine.IsType
+	local tostring = tostring
+
+	local function NaturalOrder( A, B )
+		if IsType( A, "number" ) and IsType( B, "number" ) then
+			return A < B
+		end
+
+		return tostring( A ) < tostring( B )
+	end
+	local function ReverseNaturalOrder( A, B )
+		if IsType( A, "number" ) and IsType( B, "number" ) then
+			return A > B
+		end
+
+		return tostring( A ) > tostring( B )
+	end
+
 	--[[
 		Iterates the given table's key-value pairs in the order the table's
 		keys are naturally sorted.
@@ -494,11 +512,9 @@ do
 	function SortedPairs( Table, Desc )
 		local Keys = GetKeys( Table )
 		if Desc then
-			TableSort( Keys, function( A, B )
-				return A > B
-			end )
+			TableSort( Keys, ReverseNaturalOrder )
 		else
-			TableSort( Keys )
+			TableSort( Keys, NaturalOrder )
 		end
 
 		return KeyValueIterator( Keys, Table )

--- a/lua/shine/lib/table.lua
+++ b/lua/shine/lib/table.lua
@@ -436,6 +436,19 @@ function table.QuickCopy( Table )
 	return Copy
 end
 
+--[[
+	Copies an arbitrary table structure without deep-copying values.
+]]
+function table.ShallowCopy( Table )
+	local Copy = {}
+
+	for Key, Value in pairs( Table ) do
+		Copy[ Key ] = Value
+	end
+
+	return Copy
+end
+
 do
 	--[[
 		Returns an array of all keys in the given table in an undefined order.

--- a/test/extensions/mapvote.lua
+++ b/test/extensions/mapvote.lua
@@ -59,3 +59,295 @@ UnitTest:Test( "IsValidMapChoice - Player count", function( Assert )
 		Assert:False( MapVote:IsValidMapChoice( Map, i ) )
 	end
 end )
+
+local OldMaxOptions = MapVote.Config.MaxOptions
+local OldExcludeLastMaps = MapVote.Config.ExcludeLastMaps
+local OldLastMaps = MapVote.LastMapData
+
+MapVote.Config.MaxOptions = 5
+MapVote.Config.ExcludeLastMaps = {
+	Min = 0,
+	Max = 0
+}
+MapVote.LastMapData = {
+	"ns2_refinery", "ns2_veil", "ns2_summit", "ns2_kodiak"
+}
+
+UnitTest:Test( "RemoveLastMaps - Min and max == 0", function( Assert )
+	local PotentialMaps = Shine.Set( {
+		ns2_tram = true,
+		ns2_derelict = true,
+		ns2_veil = true,
+		ns2_summit = true,
+		ns2_kodiak = true,
+		ns2_refinery = true,
+		ns2_descent = true,
+		ns2_biodome = true
+	} )
+	local FinalChoices = Shine.Set()
+
+	MapVote:RemoveLastMaps( PotentialMaps, FinalChoices )
+
+	-- Should not remove anything, min and max are 0.
+	Assert:Equals( Shine.Set( {
+		ns2_tram = true,
+		ns2_derelict = true,
+		ns2_veil = true,
+		ns2_summit = true,
+		ns2_kodiak = true,
+		ns2_refinery = true,
+		ns2_descent = true,
+		ns2_biodome = true
+	} ), PotentialMaps )
+end )
+
+MapVote.Config.ExcludeLastMaps = {
+	Min = 3
+}
+
+UnitTest:Test( "RemoveLastMaps - Min == auto and no max", function( Assert )
+	local PotentialMaps = Shine.Set( {
+		ns2_tram = true,
+		ns2_derelict = true,
+		ns2_veil = true,
+		ns2_summit = true,
+		ns2_kodiak = true,
+		ns2_refinery = true,
+		ns2_descent = true,
+		ns2_biodome = true
+	} )
+	local FinalChoices = Shine.Set()
+
+	MapVote:RemoveLastMaps( PotentialMaps, FinalChoices )
+
+	-- Should remove the last 3 maps, as min is 3 and auto would be 3 to bring it down to max options.
+	Assert:Equals( Shine.Set( {
+		ns2_tram = true,
+		ns2_derelict = true,
+		ns2_refinery = true,
+		ns2_descent = true,
+		ns2_biodome = true
+	} ), PotentialMaps )
+end )
+
+UnitTest:Test( "RemoveLastMaps - Min > auto and no max", function( Assert )
+	local PotentialMaps = Shine.Set( {
+		ns2_tram = true,
+		ns2_derelict = true,
+		ns2_veil = true,
+		ns2_summit = true,
+		ns2_kodiak = true,
+		ns2_refinery = true,
+		ns2_descent = true
+	} )
+	local FinalChoices = Shine.Set()
+
+	MapVote:RemoveLastMaps( PotentialMaps, FinalChoices )
+
+	-- Should remove the last 3 maps, as min is 3, even though it's now less than max options.
+	Assert:Equals( Shine.Set( {
+		ns2_tram = true,
+		ns2_derelict = true,
+		ns2_refinery = true,
+		ns2_descent = true
+	} ), PotentialMaps )
+end )
+
+MapVote.Config.ExcludeLastMaps = {
+	Min = 2,
+	Max = 2
+}
+
+UnitTest:Test( "RemoveLastMaps - Min and max equal", function( Assert )
+	local PotentialMaps = Shine.Set( {
+		ns2_tram = true,
+		ns2_derelict = true,
+		ns2_veil = true,
+		ns2_summit = true,
+		ns2_kodiak = true,
+		ns2_refinery = true,
+		ns2_descent = true,
+		ns2_biodome = true
+	} )
+	local FinalChoices = Shine.Set()
+
+	MapVote:RemoveLastMaps( PotentialMaps, FinalChoices )
+
+	-- Should remove the last 2 maps, as min is 2 and max is 2, even though auto would be 3.
+	Assert:Equals( Shine.Set( {
+		ns2_tram = true,
+		ns2_derelict = true,
+		ns2_veil = true,
+		ns2_refinery = true,
+		ns2_descent = true,
+		ns2_biodome = true
+	} ), PotentialMaps )
+end )
+
+MapVote.Config.ExcludeLastMaps = {
+	Min = 1,
+	Max = 2
+}
+
+UnitTest:Test( "RemoveLastMaps - Min and max not equal", function( Assert )
+	local PotentialMaps = Shine.Set( {
+		ns2_tram = true,
+		ns2_derelict = true,
+		ns2_veil = true,
+		ns2_summit = true,
+		ns2_kodiak = true,
+		ns2_refinery = true,
+		ns2_descent = true,
+		ns2_biodome = true
+	} )
+	local FinalChoices = Shine.Set()
+
+	MapVote:RemoveLastMaps( PotentialMaps, FinalChoices )
+
+	-- Should remove the last 2 maps, as min is 1 and max is 2, auto would be 3.
+	Assert:Equals( Shine.Set( {
+		ns2_tram = true,
+		ns2_derelict = true,
+		ns2_veil = true,
+		ns2_refinery = true,
+		ns2_descent = true,
+		ns2_biodome = true
+	} ), PotentialMaps )
+end )
+
+MapVote.Config.ExcludeLastMaps = {
+	Min = 2,
+	Max = 4
+}
+
+UnitTest:Test( "RemoveLastMaps - Min and max not equal, max larger than auto", function( Assert )
+	local PotentialMaps = Shine.Set( {
+		ns2_tram = true,
+		ns2_derelict = true,
+		ns2_veil = true,
+		ns2_summit = true,
+		ns2_kodiak = true,
+		ns2_refinery = true,
+		ns2_descent = true,
+		ns2_biodome = true
+	} )
+	local FinalChoices = Shine.Set()
+
+	MapVote:RemoveLastMaps( PotentialMaps, FinalChoices )
+
+	-- Should remove the last 3 maps, as min is 2 and max is 4, auto would be 3.
+	Assert:Equals( Shine.Set( {
+		ns2_tram = true,
+		ns2_derelict = true,
+		ns2_refinery = true,
+		ns2_descent = true,
+		ns2_biodome = true
+	} ), PotentialMaps )
+end )
+
+local OldMaps = MapVote.Config.Maps
+local OldGetMapGroup = MapVote.GetMapGroup
+local OldIsValidMapChoice = MapVote.IsValidMapChoice
+
+MapVote.Config.Maps = {
+	ns2_tram = true,
+	ns2_derelict = true,
+	ns2_veil = true,
+	ns2_summit = true,
+	ns2_kodiak = true,
+	ns2_refinery = true,
+	ns2_descent = true,
+	ns2_biodome = true
+}
+
+function MapVote:GetMapGroup() return nil end
+function MapVote:IsValidMapChoice( Map, PlayerCount ) return true end
+
+MapVote.Vote.Nominated = {}
+
+UnitTest:Test( "BuildPotentialMapChoices - No nominations or map group", function( Assert )
+	-- Should just select all maps.
+	Assert:Equals( Shine.Set( {
+		ns2_tram = true,
+		ns2_derelict = true,
+		ns2_veil = true,
+		ns2_summit = true,
+		ns2_kodiak = true,
+		ns2_refinery = true,
+		ns2_descent = true,
+		ns2_biodome = true
+	} ), MapVote:BuildPotentialMapChoices() )
+end )
+
+function MapVote:IsValidMapChoice( Map, PlayerCount ) return Map ~= "ns2_refinery" end
+
+UnitTest:Test( "BuildPotentialMapChoices - No nominations or map group with invalid map", function( Assert )
+	-- Should select everything except refinery.
+	Assert:Equals( Shine.Set( {
+		ns2_tram = true,
+		ns2_derelict = true,
+		ns2_veil = true,
+		ns2_summit = true,
+		ns2_kodiak = true,
+		ns2_descent = true,
+		ns2_biodome = true
+	} ), MapVote:BuildPotentialMapChoices() )
+end )
+
+MapVote.Vote.Nominated = { "ns2_eclipse" }
+
+UnitTest:Test( "BuildPotentialMapChoices - Nominations", function( Assert )
+	-- Should select everything except refinery and including eclipse.
+	Assert:Equals( Shine.Set( {
+		ns2_tram = true,
+		ns2_derelict = true,
+		ns2_veil = true,
+		ns2_summit = true,
+		ns2_kodiak = true,
+		ns2_descent = true,
+		ns2_biodome = true,
+		ns2_eclipse = true
+	} ), MapVote:BuildPotentialMapChoices() )
+end )
+
+function MapVote:GetMapGroup()
+	return { maps = { "ns2_tram", "ns2_veil", "ns2_summit" } }
+end
+
+MapVote.Vote.Nominated = { "ns2_eclipse" }
+
+UnitTest:Test( "BuildPotentialMapChoices - Map group", function( Assert )
+	-- Should select everything in the map group, plus the nomination.
+	Assert:Equals( Shine.Set( {
+		ns2_tram = true,
+		ns2_veil = true,
+		ns2_summit = true,
+		ns2_eclipse = true
+	} ), MapVote:BuildPotentialMapChoices() )
+end )
+
+UnitTest:Test( "ChooseRandomMaps", function( Assert )
+	local PotentialMaps = Shine.Set( {
+		ns2_tram = true,
+		ns2_veil = true,
+		ns2_summit = true,
+		ns2_eclipse = true
+	} )
+	local FinalChoices = Shine.Set( {
+		ns2_biodome = true,
+		ns2_eclipse = true
+	} )
+
+	MapVote:ChooseRandomMaps( PotentialMaps, FinalChoices, 5 )
+
+	-- Should fill the choices up.
+	Assert:Equals( 5, FinalChoices:GetCount() )
+end )
+
+MapVote.Config.MaxOptions = OldMaxOptions
+MapVote.Config.ExcludeLastMaps = OldExcludeLastMaps
+MapVote.LastMapData = OldLastMaps
+MapVote.Config.Maps = OldMaps
+MapVote.IsValidMapChoice = OldIsValidMapChoice
+MapVote.GetMapGroup = OldGetMapGroup
+MapVote.Vote.Nominated = {}

--- a/test/lib/objects/set.lua
+++ b/test/lib/objects/set.lua
@@ -1,0 +1,92 @@
+--[[
+	Set object unit tests.
+]]
+
+local UnitTest = Shine.UnitTest
+
+UnitTest:Test( "Construction from lookup", function( Assert )
+	local Set = Shine.Set( { a = true, b = true, c = true } )
+	Assert:Equals( 3, Set:GetCount() )
+	Assert:True( Set:Contains( "a" ) )
+	Assert:True( Set:Contains( "b" ) )
+	Assert:True( Set:Contains( "c" ) )
+end )
+
+UnitTest:Test( "Intersection", function( Assert )
+	local Set = Shine.Set( { a = true, b = true, c = true } )
+	Set:Intersection( { a = true, b = true, d = true } )
+
+	Assert:Equals( 2, Set:GetCount() )
+	Assert:True( Set:Contains( "a" ) )
+	Assert:True( Set:Contains( "b" ) )
+	Assert:False( Set:Contains( "c" ) )
+end )
+
+UnitTest:Test( "Union", function( Assert )
+	local Set = Shine.Set( { a = true, b = true, c = true } )
+	Set:Union( Shine.Set( { a = true, b = true, d = true } ) )
+
+	Assert:Equals( 4, Set:GetCount() )
+	Assert:True( Set:Contains( "a" ) )
+	Assert:True( Set:Contains( "b" ) )
+	Assert:True( Set:Contains( "c" ) )
+	Assert:True( Set:Contains( "d" ) )
+end )
+
+UnitTest:Test( "Filter", function( Assert )
+	local Set = Shine.Set( { a = true, b = true, c = true } )
+	Set:Filter( function( Value ) return Value == "a" end )
+
+	Assert:Equals( 1, Set:GetCount() )
+	Assert:True( Set:Contains( "a" ) )
+	Assert:False( Set:Contains( "b" ) )
+	Assert:False( Set:Contains( "c" ) )
+end )
+
+UnitTest:Test( "Add existing element", function( Assert )
+	local Set = Shine.Set( { a = true, b = true, c = true } )
+	Assert:Equals( 3, Set:GetCount() )
+	Assert:True( Set:Contains( "a" ) )
+
+	Set:Add( "a" )
+
+	Assert:Equals( 3, Set:GetCount() )
+	Assert:True( Set:Contains( "a" ) )
+end )
+
+UnitTest:Test( "Add non-existing element", function( Assert )
+	local Set = Shine.Set( { a = true, b = true, c = true } )
+	Assert:Equals( 3, Set:GetCount() )
+
+	Set:Add( "d" )
+
+	Assert:Equals( 4, Set:GetCount() )
+	Assert:True( Set:Contains( "d" ) )
+end )
+
+UnitTest:Test( "Remove", function( Assert )
+	local Set = Shine.Set( { a = true, b = true, c = true } )
+	Assert:Equals( 3, Set:GetCount() )
+
+	Set:Remove( "a" )
+
+	Assert:Equals( 2, Set:GetCount() )
+	Assert:False( Set:Contains( "a" ) )
+end )
+
+UnitTest:Test( "Iteration", function( Assert )
+	local Set = Shine.Set( { a = true, b = true, c = true } )
+	local Seen = Shine.Set()
+
+	for Value in Set:Iterate() do
+		Seen:Add( Value )
+	end
+
+	Assert:Equals( Seen, Set )
+end )
+
+UnitTest:Test( "Equality", function( Assert )
+	Assert:Equals( Shine.Set( { a = true, b = true, c = true } ), Shine.Set( { a = true, b = true, c = true } ) )
+	Assert:NotEquals( Shine.Set( { a = true, b = true, c = true } ), Shine.Set( { a = true, c = true } ) )
+	Assert:NotEquals( Shine.Set( { a = true, b = true, c = true } ), Shine.Set( { a = true, c = true, d = true } ) )
+end )

--- a/test/lib/objects/version.lua
+++ b/test/lib/objects/version.lua
@@ -1,0 +1,30 @@
+--[[
+	Version object tests.
+]]
+
+local UnitTest = Shine.UnitTest
+
+UnitTest:Test( "Equality", function( Assert )
+	Assert:Equals( Shine.VersionHolder( "1.0.0" ), Shine.VersionHolder( "1.0.0" ) )
+end )
+
+UnitTest:Test( "Less than", function( Assert )
+	Assert:True( Shine.VersionHolder( "1.0.0" ) < Shine.VersionHolder( "1.0.1" ) )
+	Assert:True( Shine.VersionHolder( "1.0.0" ) < Shine.VersionHolder( "1.1.0" ) )
+	Assert:True( Shine.VersionHolder( "1.0.0" ) < Shine.VersionHolder( "2.0.0" ) )
+
+	Assert:False( Shine.VersionHolder( "1.0.0" ) > Shine.VersionHolder( "1.0.1" ) )
+	Assert:False( Shine.VersionHolder( "1.0.0" ) > Shine.VersionHolder( "1.1.0" ) )
+	Assert:False( Shine.VersionHolder( "1.0.0" ) > Shine.VersionHolder( "2.0.0" ) )
+end )
+
+UnitTest:Test( "Less or equal", function( Assert )
+	Assert:True( Shine.VersionHolder( "1.0.0" ) <= Shine.VersionHolder( "1.0.0" ) )
+	Assert:True( Shine.VersionHolder( "1.0.0" ) <= Shine.VersionHolder( "1.0.1" ) )
+	Assert:True( Shine.VersionHolder( "1.0.0" ) <= Shine.VersionHolder( "1.1.0" ) )
+	Assert:True( Shine.VersionHolder( "1.0.0" ) <= Shine.VersionHolder( "2.0.0" ) )
+
+	Assert:False( Shine.VersionHolder( "1.0.0" ) >= Shine.VersionHolder( "1.0.1" ) )
+	Assert:False( Shine.VersionHolder( "1.0.0" ) >= Shine.VersionHolder( "1.1.0" ) )
+	Assert:False( Shine.VersionHolder( "1.0.0" ) >= Shine.VersionHolder( "2.0.0" ) )
+end )

--- a/test/lib/table.lua
+++ b/test/lib/table.lua
@@ -128,6 +128,17 @@ UnitTest:Test( "QuickCopy", function( Assert )
 	end
 end )
 
+UnitTest:Test( "ShallowCopy", function( Assert )
+	local Table = { 1, 2, 3, Key = "Value" }
+	local Copy = table.ShallowCopy( Table )
+
+	Assert:NotEquals( Table, Copy )
+	for i = 1, #Table do
+		Assert:Equals( Table[ i ], Copy[ i ] )
+	end
+	Assert:Equals( "Value", Copy.Key )
+end )
+
 local function GetTestTable()
 	return {
 		Key1 = true,


### PR DESCRIPTION
### Map Vote
- Configuration format for `ExcludeLastMaps` is now an object with `Min` and `Max` fields. `Min` determines the absolute minimum previous maps that must be removed from the choices, `Max` is an optional upper limit on the number to remove. Without an upper limit, the maximum will be the number of maps that can be removed that still allows for`MaxOptions` number of choices available.
- Default `VoteLength` is now 1 minute.

### Other
- JSON output will now alphabetically sort its keys.
- Added `Set` and `VersionHolder` objects.
- Improved `SortedPairs` to be able to handle any key type, regardless of whether they are comparable or not.
- Added new configuration migration system.
  - Plugins can define `ConfigMigrationSteps` as a list of steps to apply to config files when their `__Version` value is less than the plugin's current `Version` field.
  - Versions are compared based on semantic versioning, thus treating a version as `Major.Minor.Bugfix`. Omitted version values default to 0.
  - Each step requires two fields:
    - `VersionTo` - the plugin version the step migrates to.
    - `Apply` - a function that takes the config and transforms it into the version expected by `VersionTo`.
