### PR TITLE
Fix nomination problems and allow excluding AFK players from votes

### DIFF
--- a/lua/shine/core/shared/extensions.lua
+++ b/lua/shine/core/shared/extensions.lua
@@ -32,6 +32,10 @@ function Shine.GetPluginFile( Plugin, Path )
 	return StringFormat( "%s%s/%s", ExtensionPath, Plugin, Path )
 end
 
+function Shine.GetModuleFile( ModuleName )
+	return StringFormat( "lua/shine/modules/%s", ModuleName )
+end
+
 --Here we collect every extension file so we can be sure it exists before attempting to load it.
 local Files = {}
 Shared.GetMatchingFileNames( ExtensionPath.."*.lua", true, Files )

--- a/lua/shine/extensions/mapvote/server.lua
+++ b/lua/shine/extensions/mapvote/server.lua
@@ -16,7 +16,7 @@ local TableHasValue = table.HasValue
 local TableCount = table.Count
 
 local Plugin = Plugin
-Plugin.Version = "1.7"
+Plugin.Version = "1.8"
 
 Plugin.HasConfig = true
 Plugin.ConfigName = "MapVote.json"

--- a/lua/shine/extensions/mapvote/voting.lua
+++ b/lua/shine/extensions/mapvote/voting.lua
@@ -610,6 +610,7 @@ function Plugin:AddNominations( PotentialMaps, FinalChoices, Nominations )
 		local Nominee = Nominations[ i ]
 		if PotentialMaps:Contains( Nominee ) then
 			FinalChoices:Add( Nominee )
+			PotentialMaps:Remove( Nominee )
 		end
 	end
 end

--- a/lua/shine/extensions/mapvote/voting.lua
+++ b/lua/shine/extensions/mapvote/voting.lua
@@ -19,6 +19,8 @@ local TableConcat = table.concat
 local Plugin = Plugin
 local IsType = Shine.IsType
 
+Script.Load( Shine.GetModuleFile( "vote.lua" ), true )
+
 function Plugin:SendVoteOptions( Client, Options, Duration, NextMap, TimeLeft, ShowTime )
 	local MessageTable = {
 		Options = Options,
@@ -107,7 +109,7 @@ end
 	Returns the number of votes needed to begin a map vote.
 ]]
 function Plugin:GetVotesNeededToStart()
-	return Ceil( GetNumPlayers() * self.Config.PercentToStart )
+	return Ceil( self:GetPlayerCountForVote() * self.Config.PercentToStart )
 end
 
 --[[
@@ -121,7 +123,7 @@ end
 	Returns whether a map vote can start.
 ]]
 function Plugin:CanStartVote()
-	local PlayerCount = GetNumPlayers()
+	local PlayerCount = self:GetPlayerCountForVote()
 
 	if PlayerCount < self.Config.MinPlayers then
 		return false, "There are not enough players to start a vote.", "VOTE_FAIL_INSUFFICIENT_PLAYERS", {}
@@ -135,8 +137,7 @@ function Plugin:CanStartVote()
 end
 
 function Plugin:GetVoteEnd()
-	local PlayerCount = GetNumPlayers()
-
+	local PlayerCount = self:GetPlayerCountForVote()
 	return Ceil( PlayerCount * self.Config.PercentToFinish )
 end
 

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -21,7 +21,7 @@ local TableConcat = table.concat
 local tostring = tostring
 
 local Plugin = Plugin
-Plugin.Version = "2.0"
+Plugin.Version = "2.1"
 Plugin.PrintName = "Shuffle"
 
 Plugin.HasConfig = true
@@ -616,8 +616,7 @@ function Plugin:ClientConnect( Client )
 end
 
 function Plugin:GetVotesNeeded()
-	local PlayerCount = GetNumPlayers()
-
+	local PlayerCount = self:GetPlayerCountForVote()
 	return Ceil( PlayerCount * self.Config.PercentNeeded )
 end
 
@@ -626,7 +625,7 @@ function Plugin:GetStartFailureMessage()
 end
 
 function Plugin:CanStartVote()
-	local PlayerCount = GetNumPlayers()
+	local PlayerCount = self:GetPlayerCountForVote()
 
 	if PlayerCount < self.Config.MinPlayers then
 		return false, "ERROR_NOT_ENOUGH_PLAYERS"
@@ -901,3 +900,4 @@ function Plugin:CreateCommands()
 end
 
 Script.Load( Shine.GetPluginFile( "voterandom", "local_stats.lua" ) )
+Script.Load( Shine.GetModuleFile( "vote.lua" ), true )

--- a/lua/shine/extensions/votesurrender/server.lua
+++ b/lua/shine/extensions/votesurrender/server.lua
@@ -14,7 +14,7 @@ local Max = math.max
 local Random = math.random
 
 local Plugin = Plugin
-Plugin.Version = "1.2"
+Plugin.Version = "1.3"
 
 Plugin.HasConfig = true
 Plugin.ConfigName = "VoteSurrender.json"
@@ -35,6 +35,8 @@ Plugin.EnabledGamemodes = {
 	[ "ns2" ] = true,
 	[ "mvm" ] = true
 }
+
+Script.Load( Shine.GetModuleFile( "vote.lua" ), true )
 
 function Plugin:Initialise()
 	local function VoteTimeout( Vote )
@@ -75,9 +77,17 @@ end
 function Plugin:GetTeamPlayerCount( Team )
 	local Gamerules = GetGamerules()
 	local TeamData = Gamerules[ Team == 1 and "team1" or "team2" ]
-	local NumPlayers, NumRookies, NumBots = TeamData:GetNumPlayers()
 
-	return NumPlayers - NumBots
+	local Count = 0
+	local function CountPlayers( Player )
+		local Client = GetOwner( Player )
+		if Client and self:IsValidVoter( Client ) then
+			Count = Count + 1
+		end
+	end
+	TeamData:ForEachPlayer( CountPlayers )
+
+	return Count
 end
 
 function Plugin:GetVotesNeeded( Team )

--- a/lua/shine/lib/objects/map.lua
+++ b/lua/shine/lib/objects/map.lua
@@ -28,6 +28,10 @@ function Map:GetCount()
 	return self.NumMembers
 end
 
+function Map:GetKeys()
+	return self.Keys
+end
+
 --[[
 	Adds a key-value pair to the map, or updates the value if it is already in it.
 

--- a/lua/shine/lib/objects/stream.lua
+++ b/lua/shine/lib/objects/stream.lua
@@ -8,6 +8,7 @@
 local setmetatable = setmetatable
 local TableConcat = table.concat
 local TableMergeSort = table.MergeSort
+local TableQuickCopy = table.QuickCopy
 local TableSort = table.sort
 
 local Stream = Shine.TypeDef()
@@ -30,6 +31,13 @@ Predicates = {
 		end
 	end
 }
+
+--[[
+	Creates a stream containing the given values, but not referencing the original table.
+]]
+function Stream.Of( Table )
+	return Stream( TableQuickCopy( Table ) )
+end
 
 function Stream:Init( Table )
 	self.Data = Table
@@ -158,6 +166,10 @@ end
 ]]
 function Stream:AsTable()
 	return self.Data
+end
+
+function Stream:GetCount()
+	return #self.Data
 end
 
 Shine.Stream = Stream

--- a/lua/shine/modules/vote.lua
+++ b/lua/shine/modules/vote.lua
@@ -7,12 +7,14 @@ local Stream = Shine.Stream
 
 local Module = {}
 
-Module.DefaultConfig = {
-	VoteSettings = {
-		ConsiderAFKPlayersInVotes = true,
-		AFKTimeInSeconds = 60
+if not Plugin.HandlesVoteConfig then
+	Module.DefaultConfig = {
+		VoteSettings = {
+			ConsiderAFKPlayersInVotes = true,
+			AFKTimeInSeconds = 60
+		}
 	}
-}
+end
 
 local function IsNotBot( Client )
 	return Client.GetIsVirtual and not Client:GetIsVirtual()
@@ -26,13 +28,16 @@ function Module:GetPlayerCountForVote()
 		return GetHumanPlayerCount()
 	end
 
+	return self:GetNumNonAFKHumans( self.Config.VoteSettings.AFKTimeInSeconds )
+end
+
+function Module:GetNumNonAFKHumans( AFKTime )
 	local AFKEnabled, AFKKick = Shine:IsExtensionEnabled( "afkkick" )
 	if not AFKEnabled then
 		return GetHumanPlayerCount()
 	end
 
 	local Clients = Shine.GameIDs:GetKeys()
-	local AFKTime = self.Config.VoteSettings.AFKTimeInSeconds
 	return Stream.Of( Clients ):Filter( IsNotBot ):Filter( function( Client )
 		return not AFKKick:IsAFKFor( Client, AFKTime )
 	end ):GetCount()

--- a/lua/shine/modules/vote.lua
+++ b/lua/shine/modules/vote.lua
@@ -1,0 +1,59 @@
+--[[
+	Provides a way to control who is considered in votes.
+]]
+
+local GetHumanPlayerCount = Shine.GetHumanPlayerCount
+local Stream = Shine.Stream
+
+local Module = {}
+
+Module.DefaultConfig = {
+	VoteSettings = {
+		ConsiderAFKPlayersInVotes = true,
+		AFKTimeInSeconds = 60
+	}
+}
+
+local function IsNotBot( Client )
+	return Client.GetIsVirtual and not Client:GetIsVirtual()
+end
+
+--[[
+	Returns the number of humans players, minus any that are AFK for the configured time.
+]]
+function Module:GetPlayerCountForVote()
+	if self.Config.VoteSettings.ConsiderAFKPlayersInVotes then
+		return GetHumanPlayerCount()
+	end
+
+	local AFKEnabled, AFKKick = Shine:IsExtensionEnabled( "afkkick" )
+	if not AFKEnabled then
+		return GetHumanPlayerCount()
+	end
+
+	local Clients = Shine.GameIDs:GetKeys()
+	local AFKTime = self.Config.VoteSettings.AFKTimeInSeconds
+	return Stream.Of( Clients ):Filter( IsNotBot ):Filter( function( Client )
+		return not AFKKick:IsAFKFor( Client, AFKTime )
+	end ):GetCount()
+end
+
+--[[
+	Returns whether the given client is valid to be counted in a vote.
+]]
+function Module:IsValidVoter( Client )
+	if Client:GetIsVirtual() then return false end
+
+	if self.Config.VoteSettings.ConsiderAFKPlayersInVotes then
+		return true
+	end
+
+	local AFKEnabled, AFKKick = Shine:IsExtensionEnabled( "afkkick" )
+	if not AFKEnabled then
+		return true
+	end
+
+	return not AFKKick:IsAFKFor( Client, self.Config.VoteSettings.AFKTimeInSeconds )
+end
+
+Plugin:AddModule( Module )

--- a/test/extensions/mapvote.lua
+++ b/test/extensions/mapvote.lua
@@ -344,6 +344,34 @@ UnitTest:Test( "ChooseRandomMaps", function( Assert )
 	Assert:Equals( 5, FinalChoices:GetCount() )
 end )
 
+function MapVote:GetMapGroup() return nil end
+function MapVote:IsValidMapChoice( Map, PlayerCount ) return true end
+
+MapVote.Vote.Nominated = { "ns2_tram", "ns2_summit", "ns2_veil", "ns2_biodome", "ns2_eclipse" }
+MapVote.Config.ExcludeLastMaps = {
+	Min = 0,
+	Max = 0
+}
+
+local OldForcedMaps = MapVote.Config.ForcedMaps
+MapVote.Config.ForcedMaps = {}
+
+UnitTest:Test( "BuildMapChoices - Respect nominations", function( Assert )
+	-- Nominated 5 maps, with 5 max options, so all nominations should be the choices.
+	Assert:ArrayEquals( MapVote.Vote.Nominated, MapVote:BuildMapChoices() )
+end )
+
+function MapVote:IsValidMapChoice( Map, PlayerCount ) return Map ~= "ns2_eclipse" end
+
+UnitTest:Test( "BuildMapChoices - Deny nominations", function( Assert )
+	-- Should use all nominations except the denied one.
+	local Choices = MapVote:BuildMapChoices()
+	for i = 1, 4 do
+		Assert:Equals( MapVote.Vote.Nominated[ i ], Choices[ i ] )
+	end
+	Assert:NotEquals( "ns2_eclipse", Choices[ 5 ] )
+end )
+
 MapVote.Config.MaxOptions = OldMaxOptions
 MapVote.Config.ExcludeLastMaps = OldExcludeLastMaps
 MapVote.LastMapData = OldLastMaps
@@ -351,3 +379,4 @@ MapVote.Config.Maps = OldMaps
 MapVote.IsValidMapChoice = OldIsValidMapChoice
 MapVote.GetMapGroup = OldGetMapGroup
 MapVote.Vote.Nominated = {}
+MapVote.Config.ForcedMaps = OldForcedMaps


### PR DESCRIPTION
- Fixed nominations not always being added to the final vote list.
- AFK players can now be excluded from all votes, both Shine's and the vanilla votes.