### PR TITLE
Fix map options not being respected, and fix AFK warning with KickOnConnect

### DIFF
--- a/locale/shine/extensions/afkkick/enGB.json
+++ b/locale/shine/extensions/afkkick/enGB.json
@@ -1,0 +1,4 @@
+{
+	"NOTIFY_PREFIX": "[AFKKick]",
+	"WARN_KICK_ON_CONNECT": "You have been AFK for over {AFKTime:Duration}. You may be kicked when new players attempt to connect."
+}

--- a/lua/shine/extensions/afkkick/server.lua
+++ b/lua/shine/extensions/afkkick/server.lua
@@ -4,6 +4,7 @@
 
 local Shine = Shine
 
+local Floor = math.floor
 local GetHumanPlayerCount = Shine.GetHumanPlayerCount
 local GetMaxPlayers = Server.GetMaxPlayers
 local GetNumPlayersTotal = Server.GetNumPlayersTotal
@@ -346,12 +347,18 @@ function Plugin:OnProcessMove( Player, Input )
 		elseif not DataTable.Warn and TimeSinceLastMove >= WarnTime then
 			DataTable.Warn = true
 
-			local AFKTime = Time - DataTable.LastMove
-
-			Shine.SendNetworkMessage( Client, "AFKWarning", {
-				timeAFK = AFKTime,
-				maxAFKTime = KickTime
-			}, true )
+			if not self.Config.KickOnConnect then
+				local AFKTime = Time - DataTable.LastMove
+				Shine.SendNetworkMessage( Client, "AFKWarning", {
+					timeAFK = AFKTime,
+					maxAFKTime = KickTime
+				}, true )
+			elseif Players >= self.Config.MinPlayers then
+				-- Only warn players if there's actually a possibity they'll be kicked.
+				self:SendTranslatedNotify( Client, "WARN_KICK_ON_CONNECT", {
+					AFKTime = Floor( WarnTime )
+				} )
+			end
 
 			if self.Config.NotifyOnWarn then
 				self:SendNetworkMessage( Client, "AFKNotify", {}, true )

--- a/lua/shine/extensions/afkkick/shared.lua
+++ b/lua/shine/extensions/afkkick/shared.lua
@@ -3,10 +3,14 @@
 ]]
 
 local Plugin = {}
+Plugin.NotifyPrefixColour = { 255, 50, 0 }
 
 function Plugin:SetupDataTable()
 	self:AddNetworkMessage( "AFKNotify", {}, "Client" )
 	self:AddNetworkMessage( "SteamOverlay", { Open = "boolean" }, "Server" )
+	self:AddTranslatedNotify( "WARN_KICK_ON_CONNECT", {
+		AFKTime = "integer"
+	} )
 end
 
 Shine:RegisterExtension( "afkkick", Plugin )

--- a/lua/shine/extensions/mapvote/cycle.lua
+++ b/lua/shine/extensions/mapvote/cycle.lua
@@ -33,6 +33,8 @@ local function SetupFromTable( self, Map )
 	if IsType( Map.percent or Map.Percent, "number" ) then
 		self.TrackMapStats = true
 	end
+
+	self.MapOptions[ Map.map ] = Map
 end
 
 function Plugin:AddMapFromCycle( ConfigMaps, Map )
@@ -50,6 +52,7 @@ end
 function Plugin:SetupMaps( Cycle )
 	self.MapProbabilities = {}
 	self.MapChoices = {}
+	self.MapOptions = {}
 
 	if self.Config.GetMapsFromMapCycle then
 		local Maps = Cycle and Cycle.maps
@@ -64,7 +67,6 @@ function Plugin:SetupMaps( Cycle )
 
 			for i = 1, #Maps do
 				local Map = Maps[ i ]
-
 				self:AddMapFromCycle( ConfigMaps, Map )
 			end
 		end

--- a/lua/shine/extensions/mapvote/voting.lua
+++ b/lua/shine/extensions/mapvote/voting.lua
@@ -589,7 +589,7 @@ function Plugin:BuildPotentialMapChoices()
 	end
 
 	-- Now filter out any maps that are invalid.
-	PotentialMaps:Filter( function( Map ) return self:IsValidMapChoice( Map, PlayerCount ) end )
+	PotentialMaps:Filter( function( Map ) return self:IsValidMapChoice( self.MapOptions[ Map ] or Map, PlayerCount ) end )
 
 	return PotentialMaps
 end


### PR DESCRIPTION
- Fixed maps not respecting min/max/percent values.
- Changed the AFK warning when "KickOnConnect" is enabled to indicate that the player may be kicked when a new player joins.