### PR TITLE
Update to account for NS2 build 314

### DIFF
--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -569,6 +569,7 @@ Add( "Think", "ReplaceMethods", function()
 	SetupClassHook( "ConstructMixin", "OnInitialized", "OnConstructInit", "PassivePre" )
 
 	SetupClassHook( Gamerules, "UpdatePregame", "UpdatePregame", "Halt" )
+	SetupClassHook( Gamerules, "UpdateWarmUp", "UpdateWarmUp", "Halt" )
 	SetupClassHook( Gamerules, "CheckGameStart", "CheckGameStart", "Halt" )
 	SetupClassHook( Gamerules, "CastVoteByPlayer", "CastVoteByPlayer", "Halt" )
 	SetupClassHook( Gamerules, "SetGameState", "SetGameState", function( OldFunc, self, State )

--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -1276,7 +1276,8 @@ function Plugin:CreateMessageCommands()
 			R = Colour[ 1 ], G = Colour[ 2 ], B = Colour[ 3 ],
 			Alignment = 1,
 			Size = 2,
-			FadeIn = 1
+			FadeIn = 1,
+			IgnoreFormat = true
 		} )
 		Shine:AdminPrint( nil, "CSay from %s: %s", true, Shine.GetClientInfo( Client ), Message )
 	end

--- a/lua/shine/extensions/basecommands/shared.lua
+++ b/lua/shine/extensions/basecommands/shared.lua
@@ -98,11 +98,9 @@ function Plugin:NetworkUpdate( Key, Old, New )
 	if Server then return end
 
 	if Key == "Gamestate" then
-		if Old == kGameState.PreGame and New == kGameState.NotStarted then
-			--The game state changes back to 1, then to 3 to start. This is VERY annoying...
+		if ( Old == kGameState.PreGame or Old == kGameState.WarmUp ) and New == kGameState.NotStarted then
+			-- The game state changes back to NotStarted, then to Countdown to start. This is VERY annoying...
 			self:SimpleTimer( 1, function()
-				if not self.Enabled then return end
-
 				if self.dt.Gamestate == kGameState.NotStarted then
 					self:UpdateAllTalk( self.dt.Gamestate )
 				end
@@ -154,9 +152,6 @@ local SGUI = Shine.GUI
 local StringFormat = string.format
 local StringTimeToString = string.TimeToString
 local TableEmpty = table.Empty
-
-local NOT_STARTED = kGameState and kGameState.WarmUp or 2
-local COUNTDOWN = kGameState and kGameState.Countdown or 4
 
 function Plugin:Initialise()
 	if self.dt.AllTalk then
@@ -553,14 +548,14 @@ function Plugin:ReceivePluginData( Data )
 	end
 end
 
+local NOT_STARTED = kGameState and kGameState.WarmUp or 2
+local COUNTDOWN = kGameState and kGameState.Countdown or 4
+
 function Plugin:UpdateAllTalk( State )
 	if not self.dt.AllTalk then return end
 
 	if State >= COUNTDOWN then
-		if not self.TextObj then return end
-
 		self:RemoveAllTalkText()
-
 		return
 	end
 
@@ -583,6 +578,7 @@ function Plugin:UpdateAllTalk( State )
 	end
 
 	self.TextObj.Text = Phrase
+	self.TextObj:UpdateText()
 
 	local Col = State > NOT_STARTED and Color( 255, 0, 0 ) or Color( 255, 255, 255 )
 

--- a/lua/shine/extensions/pregame/server.lua
+++ b/lua/shine/extensions/pregame/server.lua
@@ -588,9 +588,27 @@ function Plugin:UpdatePregame( Gamerules )
 	end
 end
 
+function Plugin:GetNumPlayersFromGamerules( Gamerules )
+	local Team1Players, _, Team1Bots = Gamerules.team1:GetNumPlayers()
+	local Team2Players, _, Team2Bots = Gamerules.team2:GetNumPlayers()
+
+	return Team1Players + Team2Players - Team1Bots - Team2Bots
+end
+
+function Plugin:UpdateWarmUp( Gamerules )
+	local State = Gamerules:GetGameState()
+	if State ~= kGameState.WarmUp then return end
+
+	local NumPlayers = self:GetNumPlayersFromGamerules( Gamerules )
+	if NumPlayers >= Gamerules:GetWarmUpPlayerLimit() then
+		-- Restore old behaviour, go to NotStarted when players exceed warm up total.
+		Gamerules:SetGameState( kGameState.NotStarted )
+		return false
+	end
+end
+
 function Plugin:CheckGameStart( Gamerules )
 	local State = Gamerules:GetGameState()
-
 	if State > kGameState.PreGame then return end
 
 	--Do not allow starting too soon.

--- a/lua/shine/lib/datatables.lua
+++ b/lua/shine/lib/datatables.lua
@@ -172,7 +172,7 @@ if Server then
 		return setmetatable( DT, DataTableMeta )
 	end
 
-	--Obey permissions...
+	-- Obey permissions...
 	Shine.Hook.Add( "ClientConfirmConnect", "DataTablesUpdate", function( Client )
 		for Table, Data in pairs( RealData ) do
 			if not Table.__Access then
@@ -193,24 +193,25 @@ if Server then
 	return
 end
 
---Refuse creation/editing keys on the client.
+-- Refuse creation/editing keys on the client.
 function DataTableMeta:__newindex( Key, Value )
 
 end
 
---Process a complete network message.
+-- Process a complete network message.
 function DataTableMeta:ProcessComplete( Data )
 	for Key, Value in pairs( Data ) do
 		RealData[ self ][ Key ] = Value
 	end
 end
 
---Processes a partial network message.
+-- Processes a partial network message.
 function DataTableMeta:ProcessPartial( Key, Data )
+	local Old = RealData[ self ][ Key ]
 	RealData[ self ][ Key ] = Data[ Key ]
 
 	if self.__OnChange then
-		self.__OnChange( self.__Host, Key, RealData[ self ][ Key ], Data[ Key ] )
+		self.__OnChange( self.__Host, Key, Old, Data[ Key ] )
 	end
 end
 

--- a/lua/shine/lib/screentext/sh_screentext.lua
+++ b/lua/shine/lib/screentext/sh_screentext.lua
@@ -15,7 +15,8 @@ Shared.RegisterNetworkMessage( "Shine_ScreenText", {
 	ID = "integer (0 to 100)",
 	Alignment = "integer (0 to 2)",
 	Size = "integer (1 to 3)",
-	FadeIn = "float (0 to 2 by 0.05)"
+	FadeIn = "float (0 to 2 by 0.05)",
+	IgnoreFormat = "boolean"
 } )
 Shared.RegisterNetworkMessage( "Shine_ScreenTextUpdate", {
 	ID = "integer (0 to 100)",

--- a/lua/shine/lib/screentext/sv_screentext.lua
+++ b/lua/shine/lib/screentext/sv_screentext.lua
@@ -6,6 +6,7 @@ local Shine = Shine
 
 function Shine.ScreenText.Add( ID, Params, Player )
 	Params.ID = ID
+	Params.IgnoreFormat = Params.IgnoreFormat or false
 
 	Shine:ApplyNetworkMessage( Player, "Shine_ScreenText", Params, true )
 end


### PR DESCRIPTION
- Fixed the all-talk message not behaving quite correctly in some cases.
- Fixed being able to use string formatting in csay messages.
- Replaced behaviour added in build 314 to fix all talk being disabled when the warm up mode ends (but only when using the `pregame` plugin).
- Fixed datatable change listeners not receiving the old value.