### PR TITLE
Add extra logging for shuffles, and fix chatbox wrapping

### DIFF
--- a/lua/shine/extensions/chatbox/chatline.lua
+++ b/lua/shine/extensions/chatbox/chatline.lua
@@ -190,7 +190,7 @@ do
 		if not Text:find( "[^%s]" ) then return end
 
 		local Width = MessageLabel:GetTextWidth()
-		if Width <= MaxWidth then
+		if XPos + Width <= MaxWidth then
 			self:RemoveWrappedLine()
 			return
 		end

--- a/lua/shine/extensions/voterandom/team_balance.lua
+++ b/lua/shine/extensions/voterandom/team_balance.lua
@@ -203,6 +203,15 @@ function BalanceModule:UpdateBots()
 	if self.OptimisingTeams then return false end
 end
 
+local function DebugLogTeamMembers( Logger, self, TeamMembers )
+	local TeamMemberOutput = {
+		self:AsLogOutput( TeamMembers[ 1 ] ),
+		self:AsLogOutput( TeamMembers[ 2 ] )
+	}
+
+	Logger:Debug( "Assigned team members:\n%s", table.ToString( TeamMemberOutput ) )
+end
+
 function BalanceModule:OptimiseTeams( TeamMembers, RankFunc, TeamSkills )
 	-- Sanity check, make sure both team tables have even counts.
 	Shine.EqualiseTeamCounts( TeamMembers )
@@ -224,6 +233,9 @@ function BalanceModule:OptimiseTeams( TeamMembers, RankFunc, TeamSkills )
 	} )
 
 	Optimiser:Optimise()
+
+	self.Logger:Debug( "After optimisation:" )
+	self.Logger:IfDebugEnabled( DebugLogTeamMembers, self, TeamMembers )
 end
 
 function BalanceModule:SortPlayersByRank( TeamMembers, SortTable, Count, NumTargets, RankFunc, NoSecondPass )
@@ -343,6 +355,9 @@ function BalanceModule:SortByScore( Gamerules, Targets, TeamMembers, Silent, Ran
 		self:AddPlayersRandomly( RandomTable, RandomTableCount, TeamMembers )
 	end
 
+	self.Logger:Debug( "After SortByScore:" )
+	self.Logger:IfDebugEnabled( DebugLogTeamMembers, self, TeamMembers )
+
 	EvenlySpreadTeams( Gamerules, TeamMembers )
 end
 
@@ -350,6 +365,10 @@ BalanceModule.ShufflingModes = {
 	--Random only.
 	function( self, Gamerules, Targets, TeamMembers, Silent )
 		self:AddPlayersRandomly( Targets, #Targets, TeamMembers )
+
+		self.Logger:Debug( "After AddPlayersRandomly:" )
+		self.Logger:IfDebugEnabled( DebugLogTeamMembers, self, TeamMembers )
+
 		EvenlySpreadTeams( Gamerules, TeamMembers )
 
 		if not Silent then

--- a/lua/shine/lib/objects.lua
+++ b/lua/shine/lib/objects.lua
@@ -16,4 +16,6 @@ function Shine.TypeDef( Parent )
 	} )
 end
 
+Shine.Objects = {}
+
 Shine.LoadScriptsByPath( "lua/shine/lib/objects" )

--- a/lua/shine/lib/objects/logger.lua
+++ b/lua/shine/lib/objects/logger.lua
@@ -1,0 +1,65 @@
+--[[
+	Logger object.
+
+	Allows setting various levels of logging, and only writing messages at or below the set level.
+]]
+
+local select = select
+local StringFormat = string.format
+
+local Logger = Shine.TypeDef()
+
+Logger.LogLevel = table.AsEnum( {
+	"ERROR",
+	"WARN",
+	"INFO",
+	"DEBUG",
+	"TRACE"
+}, function( Index ) return Index end )
+
+function Logger:Init( Level, Writer )
+	Shine.TypeCheck( Level, { "number", "string" }, 1, "Logger" )
+	Shine.TypeCheck( Writer, "function", 2, "Logger" )
+
+	self.Writer = Writer
+
+	return self:SetLevel( Level )
+end
+
+function Logger:SetLevel( Level )
+	if Shine.IsType( Level, "string" ) then
+		Level = Logger.LogLevel[ Level ]
+	end
+
+	Shine.Assert( Logger.LogLevel[ Level ], "Unrecognised log level" )
+
+	self.Level = Level
+
+	return self
+end
+
+for i = 1, #Logger.LogLevel do
+	local LevelName = Logger.LogLevel[ i ]
+	local NiceLevelName = LevelName:sub( 1, 1 )..LevelName:sub( 2 ):lower()
+
+	local function IsLevelEnabled( self )
+		return self.Level >= i
+	end
+
+	Logger[ NiceLevelName ] = function( self, Message, ... )
+		if not IsLevelEnabled( self ) then return end
+
+		local Text = select( "#", ... ) > 0 and StringFormat( Message, ... ) or Message
+		self.Writer( StringFormat( "[%s] %s", NiceLevelName, Text ) )
+	end
+
+	Logger[ "Is"..NiceLevelName.."Enabled" ] = IsLevelEnabled
+
+	Logger[ "If"..NiceLevelName.."Enabled" ] = function( self, Action, ... )
+		if not IsLevelEnabled( self ) then return end
+
+		return Action( self, ... )
+	end
+end
+
+Shine.Objects.Logger = Logger

--- a/lua/shine/modules/logger.lua
+++ b/lua/shine/modules/logger.lua
@@ -1,0 +1,55 @@
+--[[
+	Provides a configurable logger for a plugin.
+]]
+
+local StringUpper = string.upper
+local TableConcat = table.concat
+
+local Module = {}
+
+Module.DefaultConfig = {
+	LogLevel = "Info"
+}
+
+function Module:Initialise()
+	self.Logger = Shine.Objects.Logger( StringUpper( self.Config.LogLevel ), function( Text )
+		return self:Print( Text )
+	end )
+end
+
+Shine:RegisterCommand( "sh_setloglevel", nil, function( Client, PluginName, LogLevel )
+	local Plugin = Shine.Plugins[ PluginName ]
+	if not Plugin then
+		Shine:NotifyCommandError( Client, "No plugin named '%s' exists.", true, PluginName )
+		return
+	end
+
+	if not Plugin.Logger then
+		Shine:NotifyCommandError( Client, "Plugin '%s' has no logger to configure.", true, PluginName )
+		return
+	end
+
+	local ValidLevels = Shine.Objects.Logger.LogLevel
+	LogLevel = StringUpper( LogLevel )
+
+	if not ValidLevels[ LogLevel ] then
+		Shine:NotifyCommandError( Client, "Invalid log level: '%s'. Expected one of %s.", true,
+			LogLevel, TableConcat( ValidLevels, ", " ) )
+		return
+	end
+
+	Plugin.Logger:SetLevel( LogLevel )
+	Plugin.Config.LogLevel = LogLevel
+	Plugin:SaveConfig()
+
+	Shine:AdminPrint( Client, "Log level of plugin '%s' set to '%s'.", true, PluginName, LogLevel )
+end )
+:Help( "Sets the log level for the given plugin." )
+:AddParam( {
+	Type = "string", Help = "Plugin Name"
+} )
+:AddParam( {
+	Type = "string", Help = "Log Level"
+} )
+
+Plugin:AddModule( Module )

--- a/test/extensions/voterandom/voterandom.lua
+++ b/test/extensions/voterandom/voterandom.lua
@@ -297,3 +297,59 @@ UnitTest:Test( "OptimiseTeams with preference", function( Assert )
 	Assert:ArrayEquals( { 1, 6, 3 }, TeamMembers[ 1 ] )
 	Assert:ArrayEquals( { 4, 5, 2 }, TeamMembers[ 2 ] )
 end, nil, 5 )
+
+VoteShuffle.Config.IgnoreCommanders = true
+
+UnitTest:Test( "OptimiseTeams with commanders", function( Assert )
+	local Index = 0
+	local Players = {}
+	local function Player( Skill, Commander )
+		Index = Index + 1
+		Players[ Index ] = {
+			Index = Index,
+			Skill = Skill,
+			isa = function() return Commander end,
+			Commander = Commander
+		}
+		return Players[ Index ]
+	end
+
+	local Marines = {
+		Player( 2000, true ), Player( 2000 ), Player( 1000 )
+	}
+	local Aliens = {
+		Player( 1000, true ), Player( 1000 ), Player( 1000 )
+	}
+
+	local function RankFunc( Player )
+		return Player.Skill
+	end
+
+	local TeamMembers = {
+		Marines,
+		Aliens,
+		TeamPreferences = {
+			[ Marines[ 1 ] ] = true,
+			[ Aliens[ 1 ] ] = true
+		}
+	}
+
+	local TeamSkills = {
+		{
+			Average = 5000 / 3,
+			Total = 5000,
+			Count = 3
+		},
+		{
+			Average = 1000,
+			Total = 3000,
+			Count = 3
+		}
+	}
+
+	VoteShuffle:OptimiseTeams( TeamMembers, RankFunc, TeamSkills )
+
+	-- It should never swap the commanders.
+	Assert:ArrayEquals( { Players[ 1 ], Players[ 6 ], Players[ 3 ] }, TeamMembers[ 1 ] )
+	Assert:ArrayEquals( { Players[ 4 ], Players[ 5 ], Players[ 2 ] }, TeamMembers[ 2 ] )
+end, nil, 5 )

--- a/test/lib/objects/logger.lua
+++ b/test/lib/objects/logger.lua
@@ -1,0 +1,61 @@
+--[[
+	Logger object tests.
+]]
+
+local UnitTest = Shine.UnitTest
+
+local Logger = Shine.Objects.Logger
+local LogLevel = Logger.LogLevel
+
+UnitTest:Test( "Construct with string level", function( Assert )
+	local Instance = Logger( "DEBUG", LuaPrint )
+	Assert:Equals( LogLevel.DEBUG, Instance.Level )
+	Assert:Equals( LuaPrint, Instance.Writer )
+end )
+
+UnitTest:Test( "Construct with number level", function( Assert )
+	local Instance = Logger( LogLevel.DEBUG, LuaPrint )
+	Assert:Equals( LogLevel.DEBUG, Instance.Level )
+	Assert:Equals( LuaPrint, Instance.Writer )
+end )
+
+UnitTest:Test( "Message is logged when level is higher", function( Assert )
+	local Text = {}
+	local function Writer( Message )
+		Text[ #Text + 1 ] = Message
+	end
+
+	local Instance = Logger( LogLevel.INFO, Writer )
+	Instance:Error( "Error" )
+	Instance:Warn( "Warn" )
+	Instance:Info( "Info" )
+	Instance:Debug( "Debug" )
+	Instance:Trace( "Trace" )
+
+	Assert:ArrayEquals( { "[Error] Error", "[Warn] Warn", "[Info] Info" }, Text )
+end )
+
+UnitTest:Test( "Is<X>Enabled", function( Assert )
+	local Instance = Logger( LogLevel.INFO, LuaPrint )
+	Assert:True( Instance:IsErrorEnabled() )
+	Assert:True( Instance:IsWarnEnabled() )
+	Assert:True( Instance:IsInfoEnabled() )
+	Assert:False( Instance:IsDebugEnabled() )
+	Assert:False( Instance:IsTraceEnabled() )
+end )
+
+UnitTest:Test( "If<X>Enabled", function( Assert )
+	local Instance = Logger( LogLevel.INFO, LuaPrint )
+
+	local Called = false
+	Instance:IfDebugEnabled( function()
+		Called = true
+	end )
+	Assert:False( Called )
+
+	Instance:IfInfoEnabled( function( self )
+		Assert:Equals( Instance, self )
+		Called = true
+	end )
+	Assert:True( Called )
+end )


### PR DESCRIPTION
- Added new, more fine grained logging for plugins. Any plugin can add this functionality by including the `logger` module.
- The shuffle plugin uses this logging functionality to log shuffle information before and after at the debug level.
- Fixed the chatbox not considering the position of the message label when word wrapping.