### PR TITLE
Fix not always swapping the right players

### DIFF
--- a/lua/shine/extensions/voterandom/team_optimiser.lua
+++ b/lua/shine/extensions/voterandom/team_optimiser.lua
@@ -247,7 +247,11 @@ function TeamOptimiser:TrySwaps( PlayerIndex, Pass )
 		local OtherPlayer = TeamMembers[ self.LesserTeam ][ OtherPlayerIndex ]
 
 		if OtherPlayer and self:IsValidForSwap( OtherPlayer, Pass ) then
-			self:SimulateSwap( PlayerIndex, OtherPlayerIndex )
+			if self.LargerTeam == 1 then
+				self:SimulateSwap( PlayerIndex, OtherPlayerIndex )
+			else
+				self:SimulateSwap( OtherPlayerIndex, PlayerIndex )
+			end
 		end
 	end
 


### PR DESCRIPTION
When team counts were uneven, the swapping logic would always assume the larger team was team 1, rather than properly accounting for it, which would lead to random swaps including potentially commanders.