### PR TITLE
Improve bans and group definitions

### DIFF
--- a/test/lib/table.lua
+++ b/test/lib/table.lua
@@ -140,14 +140,12 @@ UnitTest:Test( "ShallowCopy", function( Assert )
 end )
 
 do
-	local Smaller = {}
-	local Larger = {}
 	local function LT( A, B )
-		return A == Smaller
+		return A.Index < B.Index
 	end
 	local ComparableObjects = {
-		setmetatable( Smaller, { __lt = LT } ),
-		setmetatable( Larger, { __lt = LT } )
+		setmetatable( { Index = 1 }, { __lt = LT } ),
+		setmetatable( { Index = 2 }, { __lt = LT } )
 	}
 	local function GetTestTable()
 		return {


### PR DESCRIPTION
- Added `BanSharerOnSharedBan` option to the bans plugin. When enabled, banning a player that is playing the game through family sharing will also ban the account that is sharing the game to them.
- User groups set to be whitelists can now deny commands that are allowed by default.