### PR TITLE
Added support for the new NS2 F3 Help Screen 

### DIFF
--- a/lua/shine/core/client/adminmenu.lua
+++ b/lua/shine/core/client/adminmenu.lua
@@ -111,6 +111,11 @@ function AdminMenu.AnimateVisibility( Window, Show, Visible, EasingTime, TargetP
 end
 
 function AdminMenu:SetIsVisible( Bool )
+	if self.Visible == Bool then return end
+
+	--Check if the NS2 HelpScreen is open
+	if self._Visible == Bool then return end
+
 	if not self.Created then
 		self:Create()
 	end
@@ -132,6 +137,30 @@ end
 Hook.Add( "PlayerKeyPress", "AdminMenu_KeyPress", function( Key, Down )
 	AdminMenu:PlayerKeyPress( Key, Down )
 end, 1 )
+
+function AdminMenu:OnHelpScreenDisplay()
+	if not self.Visible then return end
+
+	self._Visible = true
+	
+	self:SetIsVisible( false )
+end
+
+function AdminMenu:OnHelpScreenHide()
+	if not self._Visible then return end
+	
+	self._Visible = nil
+
+	self:SetIsVisible( true )
+end
+
+Hook.Add( "OnHelpScreenDisplay", "AdminMenu_OnHelpScreenDisplay", function()
+	AdminMenu:OnHelpScreenDisplay()
+end)
+
+Hook.Add( "OnHelpScreenHide", "AdminMenu_OnHelpScreenHide", function()
+	AdminMenu:OnHelpScreenHide()
+end)
 
 function AdminMenu:AddTab( Name, Data )
 	self.Tabs[ Name ] = Data
@@ -668,5 +697,3 @@ below. If you want to get to it outside the game, visit:]],
 		end
 	} )
 end
-
-

--- a/lua/shine/core/client/votemenu_gui.lua
+++ b/lua/shine/core/client/votemenu_gui.lua
@@ -179,6 +179,9 @@ function VoteMenu:SetIsVisible( Bool )
 	end
 
 	if Bool then
+		--Check if the NS2 HelpScreen is open
+		if self._Visible then return end
+
 		self:UpdateTeamType()
 
 		Shared.PlaySound( nil, OpenSound )
@@ -224,6 +227,30 @@ end
 Hook.Add( "PlayerKeyPress", "VoteMenuKeyPress", function( Key, Down )
 	return VoteMenu:PlayerKeyPress( Key, Down )
 end, 1 )
+
+function VoteMenu:OnHelpScreenDisplay()
+	if not self.Visible then return end
+
+	self._Visible = true
+
+	self:SetIsVisible( false )
+end
+
+function VoteMenu:OnHelpScreenHide()
+	if not self._Visible then return end
+
+	self._Visible = nil
+
+	self:SetIsVisible( true )
+end
+
+Hook.Add( "OnHelpScreenDisplay", "VoteMenu_OnHelpScreenDisplay", function()
+	VoteMenu:OnHelpScreenDisplay()
+end)
+
+Hook.Add( "OnHelpScreenHide", "VoteMenu_OnHelpScreenHide", function()
+	VoteMenu:OnHelpScreenHide()
+end)
 
 function VoteMenu:Think( DeltaTime )
 	if not self.Visible then return end

--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -437,6 +437,11 @@ if Client then
 
 		SetupGlobalHook( "ChatUI_EnterChatMessage", "StartChat", "ActivePre" )
 		SetupGlobalHook( "CommanderUI_Logout", "OnCommanderUILogout", "PassivePost" )
+
+		--HelpScreen events
+		SetupClassHook( "HelpScreen", "Display", "OnHelpScreenDisplay", "PassivePost")
+		SetupClassHook( "HelpScreen", "Hide", "OnHelpScreenHide", "PassivePost")
+
 	end, -20 )
 
 	Add( "Think", "ClientOnFirstThink", function()

--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -439,8 +439,8 @@ if Client then
 		SetupGlobalHook( "CommanderUI_Logout", "OnCommanderUILogout", "PassivePost" )
 
 		--HelpScreen events
-		SetupClassHook( "HelpScreen", "Display", "OnHelpScreenDisplay", "PassivePost")
-		SetupClassHook( "HelpScreen", "Hide", "OnHelpScreenHide", "PassivePost")
+		SetupClassHook( "HelpScreen", "Display", "OnHelpScreenDisplay", "PassivePost" )
+		SetupClassHook( "HelpScreen", "Hide", "OnHelpScreenHide", "PassivePost" )
 
 	end, -20 )
 


### PR DESCRIPTION
With build 315 a new Help Screen gets added to Natural Selection 2. 

The Help Screen can be open by the player at any point via the F3 key and explains shortly each attack/weapon the player has currently available.

Examples how it looks in-game can be found at the given trello card: https://trello.com/c/AhJO6ECB/331-h-info-help-screen

To not obscure the Help Screen HUD elements should hide when it opens and restore their visibility state after the help screen has been closed.

I added two hooks to support that behavior for the Shine HUD elements (Vote Menu, Admin Menu and Client Config Menu) called `OnHelpScreenDisplay` and `OnHelpScreenHide` .

The change can be tested with the `Beta` Steam branch and the relevant code of the HelpScreen can be found at https://github.com/GhoulofGSG9/ns2-game/tree/feature/h-screen/ns2/lua/Hud/HelpScreen .

You may want to rename the `_Visible` variable. I wasn't entirely sure how to name it.