### PR TITLE
Add persistent gagging/renames, more configuration options

### DIFF
--- a/locale/shine/extensions/workshopupdater/zhCN.json
+++ b/locale/shine/extensions/workshopupdater/zhCN.json
@@ -1,6 +1,6 @@
 {
 	"MOD_CHANGED": "MOD“{ModName}”已经在创意工坊里更新了。",
-	"MAY_BE_UNABLE_TO_CONNECT": "在换图之前，玩家们可以能无法连接进入服务器。",
+	"MAY_BE_UNABLE_TO_CONNECT": "在换图之前，玩家们可能无法连接进入服务器。",
 	"MAP_CYCLE": "地图将会更换{TimeLeft:NonZero:于}{TimeLeft:Duration:现在}。",
 	"NOTIFY_PREFIX": "[创意工坊]"
 }

--- a/lua/shine/core/client/adminmenu.lua
+++ b/lua/shine/core/client/adminmenu.lua
@@ -447,11 +447,12 @@ do
 		end
 	} )
 
-	function AdminMenu:RunCommand( Command, Args )
-		if not Args then
+	local TableConcat = table.concat
+	function AdminMenu:RunCommand( Command, ... )
+		if not ... then
 			Shared.ConsoleCommand( Command )
 		else
-			Shared.ConsoleCommand( StringFormat( "%s %s", Command, Args ) )
+			Shared.ConsoleCommand( StringFormat( "%s %s", Command, TableConcat( { ... }, " " ) ) )
 		end
 	end
 
@@ -559,7 +560,7 @@ do
 						end )
 					elseif IsType( Arg, "function" ) then
 						Menu:AddButton( Option, function()
-							Arg()
+							Arg( Args )
 							CleanupMenu()
 						end )
 					elseif IsType( Arg, "table" ) and Arg.Setup then

--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -35,6 +35,7 @@ Plugin.DefaultConfig = {
 	AllTalkSpectator = false,
 	AllTalkLocal = false,
 	EjectVotesNeeded = 0.5,
+	CommanderBotVoteDelayInSeconds = 300,
 	DisableLuaRun = false,
 	Interp = 100,
 	MoveRate = 26,
@@ -359,10 +360,9 @@ end
 function Plugin:Think()
 	self.dt.AllTalk = self.Config.AllTalkPreGame
 
-	if self.SetEjectVotes then return end
+	if self.ConfiguredGamerulesSettings then return end
 
 	local Gamerules = GetGamerules()
-
 	if not Gamerules then return end
 
 	if not Gamerules.team1 or not Gamerules.team2 then return end
@@ -370,8 +370,9 @@ function Plugin:Think()
 
 	Gamerules.team1.ejectCommVoteManager:SetTeamPercentNeeded( self.Config.EjectVotesNeeded )
 	Gamerules.team2.ejectCommVoteManager:SetTeamPercentNeeded( self.Config.EjectVotesNeeded )
+	Gamerules.kStartGameVoteDelay = self.Config.CommanderBotVoteDelayInSeconds
 
-	self.SetEjectVotes = true
+	self.ConfiguredGamerulesSettings = true
 end
 
 function Plugin:SetGameState( Gamerules, NewState, OldState )

--- a/lua/shine/extensions/basecommands/shared.lua
+++ b/lua/shine/extensions/basecommands/shared.lua
@@ -258,6 +258,10 @@ function Plugin:SetupAdminMenuCommands()
 
 	GagLabels[ #GagLabels + 1 ] = self:GetPhrase( "GAG_UNTIL_MAP_CHANGE" )
 	GagLabels[ #GagLabels + 1 ] = ""
+	GagLabels[ #GagLabels + 1 ] = self:GetPhrase( "PERMANENTLY" )
+	GagLabels[ #GagLabels + 1 ] = function( Args )
+		Shine.AdminMenu:RunCommand( "sh_gagid", Args )
+	end
 
 	self:AddAdminMenuCommand( Category, self:GetPhrase( "GAG" ), "sh_gag", false, GagLabels,
 		self:GetPhrase( "GAG_TIP" ) )

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -345,7 +345,7 @@ do
 			local Commander = Player:isa( "Commander" ) and self.Config.IgnoreCommanders
 
 			if AFKEnabled then -- Ignore AFK players in sorting.
-				if Commander or not AFKKick:IsAFKFor( Client, 60 ) then
+				if Commander or not AFKKick:IsAFKFor( Client, self.Config.VoteSettings.AFKTimeInSeconds ) then
 					SortPlayer( Player, Client, Commander, Pass )
 				elseif Pass == 1 then -- Chuck AFK players into the ready room.
 					local Team = Player:GetTeamNumber()

--- a/lua/shine/extensions/votesurrender/server.lua
+++ b/lua/shine/extensions/votesurrender/server.lua
@@ -9,6 +9,7 @@ local SharedTime = Shared.GetTime
 local StringFormat = string.format
 
 local Ceil = math.ceil
+local Clamp = math.Clamp
 local Floor = math.floor
 local Max = math.max
 local Random = math.random
@@ -49,6 +50,13 @@ Plugin.EnabledGamemodes = {
 Script.Load( Shine.GetModuleFile( "vote.lua" ), true )
 
 function Plugin:Initialise()
+	local function ClampConfigOption( Option, Min, Max )
+		self.Config[ Option ] = Clamp( self.Config[ Option ], Min, Max )
+	end
+	ClampConfigOption( "PercentNeeded", 0, 1 )
+	ClampConfigOption( "PercentNeededInEarlyGame", 0, 1 )
+	ClampConfigOption( "LastCommandStructureMinHealthPercent", 0, 1 )
+
 	local function VoteTimeout( Vote )
 		local LastVoted = Vote.LastVoted
 		if LastVoted and SharedTime() - LastVoted > self.Config.VoteTimeout then

--- a/test/extensions/votesurrender.lua
+++ b/test/extensions/votesurrender.lua
@@ -1,0 +1,68 @@
+--[[
+	Vote surrender plugin unit tests.
+]]
+
+local UnitTest = Shine.UnitTest
+
+local VoteSurrender = UnitTest:LoadExtension( "votesurrender" )
+if not VoteSurrender then return end
+
+local OldConfig = VoteSurrender.Config
+VoteSurrender.Config = table.Copy( OldConfig )
+
+UnitTest:Test( "GetVotesNeeded in early game uses PercentNeededInEarlyGame", function( Assert )
+	VoteSurrender.NextVote = Shared.GetTime() + 1
+	VoteSurrender.Config.PercentNeededInEarlyGame = 0.9
+	VoteSurrender.GetTeamPlayerCount = function() return 10 end
+
+	-- Next vote is in the future, so should use PercentNeededInEarlyGame
+	Assert:Equals( 9, VoteSurrender:GetVotesNeeded( 1 ) )
+end )
+
+UnitTest:Test( "GetVotesNeeded in later game uses PercentNeeded", function( Assert )
+	VoteSurrender.NextVote = Shared.GetTime() - 1
+	VoteSurrender.Config.PercentNeeded = 0.5
+	VoteSurrender.GetTeamPlayerCount = function() return 10 end
+
+	-- Next vote is in the past, so should use PercentNeeded.
+	Assert:Equals( 5, VoteSurrender:GetVotesNeeded( 1 ) )
+end )
+
+UnitTest:Test( "HasTooManyTechPoints denies with too many tech points", function( Assert )
+	VoteSurrender.Config.AllowVoteWithMultipleBases = true
+
+	local Gamerules = {
+		GetTeam = function( self, Team )
+			return {
+				GetNumCapturedTechPoints = function() return Team == 1 and 2 or 1 end
+			}
+		end
+	}
+
+	-- Both permitted, config allows multiple bases.
+	Assert:False( VoteSurrender:HasTooManyTechPoints( Gamerules, 1 ) )
+	Assert:False( VoteSurrender:HasTooManyTechPoints( Gamerules, 2 ) )
+
+	VoteSurrender.Config.AllowVoteWithMultipleBases = false
+	-- Team 1 has 2 tech points so should be denied, team 2 has only 1 so should be allowed.
+	Assert:True( VoteSurrender:HasTooManyTechPoints( Gamerules, 1 ) )
+	Assert:False( VoteSurrender:HasTooManyTechPoints( Gamerules, 2 ) )
+end )
+
+local OldGetEntitiesForTeam = GetEntitiesForTeam
+function GetEntitiesForTeam( Type, Team )
+	return { { GetHealthFraction = function() return Team == 1 and 0.5 or 1 end } }
+end
+
+UnitTest:Test( "HasCommandStructureAtTooLowHP denies when HP too low", function( Assert )
+	VoteSurrender.Config.LastCommandStructureMinHealthPercent = 0.75
+
+	-- Team 1 has 1 command structure at too low health
+	Assert:True( VoteSurrender:HasCommandStructureAtTooLowHP( 1 ) )
+	-- Team 2 has 1 command stucture at higher health.
+	Assert:False( VoteSurrender:HasCommandStructureAtTooLowHP( 2 ) )
+end )
+
+GetEntitiesForTeam = OldGetEntitiesForTeam
+
+VoteSurrender.Config = OldConfig


### PR DESCRIPTION
- The amount of time before a player is considered AFK when shuffling is now controlled by the `VoteSettings.AFKTimeInSeconds` option.
- Players can now be persistently gagged using `sh_gagid`/`sh_ungagid`.
- Players can now be persistently renamed with the name filter plugin using `sh_renameid`/`sh_unrenameid`.
- New options for surrender votes:
  - `PercentNeededInEarlyGame` - When non-zero, sets the percentage of votes needed to surrender during the `VoteDelay` duration after a round start.
  - `LastCommandStructureMinHealthPercent` - When non-zero, sets the percentage of health required on the last command structure to allow a surrender vote.
- Small Chinese translation fix (thanks axamdy).