### PR TITLE
Fix bot behaviour in shuffle votes, other minor improvements

### DIFF
--- a/locale/shine/extensions/afkkick/fiFI.json
+++ b/locale/shine/extensions/afkkick/fiFI.json
@@ -1,0 +1,4 @@
+{
+	"NOTIFY_PREFIX": "[AFKKick]",
+	"WARN_KICK_ON_CONNECT": "Olet ollut poissa kauemmin kuin {AFKTime:Duration}. Sinut voidaan potkia, kun uusi pelaaja yrittää liittyä peliin."
+}

--- a/lua/shine/extensions/commbans/server.lua
+++ b/lua/shine/extensions/commbans/server.lua
@@ -20,6 +20,7 @@ Plugin.DefaultConfig = {
 	Banned = {},
 	BansSubmitURL = "",
 	BansSubmitArguments = {},
+	LogLevel = "Info",
 	MaxSubmitRetries = 3,
 	SubmitTimeout = 5,
 	DefaultBanTime = 60
@@ -29,6 +30,7 @@ Plugin.CheckConfig = true
 Plugin.ListPermission = "sh_uncommban"
 
 function Plugin:Initialise()
+	self:BroadcastModuleEvent( "Initialise" )
 	self:GenerateNetworkData()
 
 	self:VerifyConfig()

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -186,9 +186,12 @@ function Plugin:Initialise()
 		self.dt.RequiredShuffleVotes = 0
 	end
 
-	self.ForceRandomEnd = 0 --Time based.
-	self.RandomOnNextRound = false --Round based.
+	-- Time based.
+	self.ForceRandomEnd = 0
+	-- Round based.
+	self.RandomOnNextRound = false
 	self.ForceRandom = self.Config.AlwaysEnabled
+	self.HasShuffledThisRound = false
 
 	self.dt.HighlightTeamSwaps = self.Config.HighlightTeamSwaps
 	self.dt.DisplayStandardDeviations = self.Config.DisplayStandardDeviations
@@ -398,6 +401,7 @@ function Plugin:ShuffleTeams( ResetScores, ForceMode )
 	self.ShufflingModes[ Mode ]( self, Gamerules, Targets, TeamMembers )
 
 	self.OptimisingTeams = false
+	self.HasShuffledThisRound = true
 
 	-- Remember who was on what team at the point of shuffling, so we can work out
 	-- how close to the shuffled teams we are later.
@@ -507,6 +511,7 @@ end
 
 function Plugin:EndGame( Gamerules, WinningTeam )
 	self.DoneStartShuffle = false
+	self.HasShuffledThisRound = false
 	self.VoteBlockTime = nil
 
 	local Players, Count = GetAllPlayers()

--- a/lua/shine/extensions/voterandom/team_balance.lua
+++ b/lua/shine/extensions/voterandom/team_balance.lua
@@ -201,6 +201,7 @@ end
 
 function BalanceModule:UpdateBots()
 	if self.OptimisingTeams then return false end
+	if self.HasShuffledThisRound and not self.Config.ApplyToBots then return false end
 end
 
 local function DebugLogTeamMembers( Logger, self, TeamMembers )

--- a/lua/shine/lib/query.lua
+++ b/lua/shine/lib/query.lua
@@ -151,8 +151,6 @@ end
 	number of max attempts.
 ]]
 function Shine.HTTPRequestWithRetry( URL, Protocol, Params, Callbacks, MaxAttempts, Timeout )
-	MaxAttempts = MaxAttempts or 3
-
 	local NeedParams = true
 	if Protocol ~= "POST" and not IsType( Callbacks, "table" ) then
 		Timeout = MaxAttempts
@@ -160,6 +158,8 @@ function Shine.HTTPRequestWithRetry( URL, Protocol, Params, Callbacks, MaxAttemp
 		Callbacks = Params
 		NeedParams = false
 	end
+
+	MaxAttempts = MaxAttempts or 3
 
 	local Attempts = 0
 	local Submit


### PR DESCRIPTION
- Bots are now prevented from re-joining until the end of a round after a shuffle vote has passed and `ApplyToBots` is set to false.
- Added Finnish translations for the afkkick plugin (thanks MisterOizo!)
- Improved logging behaviour in the bans plugin.
- Fixed the default value for `MaxAttempts` not applying correctly in `Shine.HTTPRequestWithRetry` when performing a `GET` request.