### PR TITLE
Make shuffle account for team preferences better, improve AFK tracking

### DIFF
--- a/locale/shine/extensions/voterandom/enGB.json
+++ b/locale/shine/extensions/voterandom/enGB.json
@@ -84,5 +84,9 @@
 	"TEAM_SWITCH_DENIED_HIVE_BASED": "You cannot switch teams. Hive skill based teams are enabled.",
 	"TEAM_SWITCH_DENIED_KDR_BASED": "You cannot switch teams. KDR based teams are enabled.",
 	"TEAM_SWITCH_DENIED_RANDOM_BASED": "You cannot switch teams. Random teams are enabled.",
-	"TEAM_SWITCH_DENIED_SCORE_BASED": "You cannot switch teams. Score based teams are enabled."
+	"TEAM_SWITCH_DENIED_SCORE_BASED": "You cannot switch teams. Score based teams are enabled.",
+	"TEAM_PREFERENCE": "Shuffle Team Preference:",
+	"MARINE": "Marines",
+	"ALIEN": "Aliens",
+	"NONE": "No Preference"
 }

--- a/lua/shine/core/server/commands.lua
+++ b/lua/shine/core/server/commands.lua
@@ -529,45 +529,6 @@ do
 	}
 end
 
-do
-	local TeamMatches = {
-		{ "ready", 0 },
-		{ "marine", 1 },
-		{ "alien", 2 },
-		{ "spectat", 3 },
-		{ "blu", 1 },
-		{ "orang", 2 },
-		{ "gold", 2 },
-		{ "^rr", 0 }
-	}
-
-	local StringLower = string.lower
-
-	-- Team takes either 0 - 3 directly or takes a string matching a team name
-	-- and turns it into the team number.
-	ParamTypes.team = {
-		Parse = function( Client, String, Table )
-			if not String then
-				return GetDefault( Table )
-			end
-
-			local TeamNumber = tonumber( String )
-			if TeamNumber then return MathClamp( Round( TeamNumber ), 0, 3 ) end
-
-			String = StringLower( String )
-
-			for i = 1, #TeamMatches do
-				if StringFind( String, TeamMatches[ i ][ 1 ] ) then
-					return TeamMatches[ i ][ 2 ]
-				end
-			end
-
-			return nil
-		end,
-		Help = "team"
-	}
-end
-
 ParamTypes.steamid = {
 	Parse = function( Client, String, Table )
 		local NS2ID = tonumber( String )

--- a/lua/shine/core/shared/base_plugin.lua
+++ b/lua/shine/core/shared/base_plugin.lua
@@ -41,6 +41,12 @@ function PluginMeta:AddModule( Module )
 	if Module.DefaultConfig and self.DefaultConfig ~= Module.DefaultConfig then
 		TableShallowMerge( Module.DefaultConfig, self.DefaultConfig )
 	end
+
+	-- Merge any configuration validation rules.
+	if Module.ConfigValidator and self.ConfigValidator
+	and self.ConfigValidator ~= Module.ConfigValidator then
+		self.ConfigValidator:Add( Module.ConfigValidator )
+	end
 end
 
 --[[

--- a/lua/shine/core/shared/commands.lua
+++ b/lua/shine/core/shared/commands.lua
@@ -165,6 +165,46 @@ Shine.CommandUtil.ParamTypes = {
 		Help = "boolean"
 	}
 }
+
+do
+	local TeamMatches = {
+		{ "ready", 0 },
+		{ "marine", 1 },
+		{ "alien", 2 },
+		{ "spectat", 3 },
+		{ "blu", 1 },
+		{ "orang", 2 },
+		{ "gold", 2 },
+		{ "^rr", 0 }
+	}
+
+	local StringFind = string.find
+	local StringLower = string.lower
+
+	-- Team takes either 0 - 3 directly or takes a string matching a team name
+	-- and turns it into the team number.
+	Shine.CommandUtil.ParamTypes.team = {
+		Parse = function( Client, String, Table )
+			if not String then
+				return GetDefault( Table )
+			end
+
+			local TeamNumber = tonumber( String )
+			if TeamNumber then return MathClamp( Round( TeamNumber ), 0, 3 ) end
+
+			String = StringLower( String )
+
+			for i = 1, #TeamMatches do
+				if StringFind( String, TeamMatches[ i ][ 1 ] ) then
+					return TeamMatches[ i ][ 2 ]
+				end
+			end
+
+			return nil
+		end,
+		Help = "team"
+	}
+end
 local ParamTypes = Shine.CommandUtil.ParamTypes
 
 local function ParseByType( Client, String, Table, Type )

--- a/lua/shine/core/shared/config.lua
+++ b/lua/shine/core/shared/config.lua
@@ -233,7 +233,10 @@ do
 		return function( Value )
 			return not IsType( Value, Type )
 		end,
-		Validator.Constant( DefaultValue )
+		Validator.Constant( DefaultValue ),
+		function()
+			return StringFormat( "%%s must be a %s", Type )
+		end
 	end
 
 	function Validator:AddRule( Rule )

--- a/lua/shine/extensions/afkkick/server.lua
+++ b/lua/shine/extensions/afkkick/server.lua
@@ -214,7 +214,11 @@ do
 			self.Users = Shine.Map()
 		end
 
-		self:CreateTimer( "AFKCheck", 1, -1, function() self:EvaluatePlayers() end )
+		if self.Config.Warn or not self.Config.KickOnConnect then
+			-- Need to periodically evaluate players if they need to be warned or if
+			-- kicking is not performed at connection time.
+			self:CreateTimer( "AFKCheck", 1, -1, function() self:EvaluatePlayers() end )
+		end
 
 		self.Enabled = true
 

--- a/lua/shine/extensions/chatbox/chatline.lua
+++ b/lua/shine/extensions/chatbox/chatline.lua
@@ -27,7 +27,7 @@ end
 
 function ChatLine:SetParent( Parent )
 	self.BaseClass.SetParent( self, Parent )
-	self:ForEachLabel( "SetParent", Parent, Parent.ScrollParent )
+	self:ForEachLabel( "SetParent", Parent, Parent and Parent.ScrollParent )
 end
 
 do

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -180,10 +180,10 @@ Plugin.ConfigMigrationSteps = {
 
 do
 	local Validator = Shine.Validator()
-	Validator:AddFieldRule( "VotePassActions.PreGame", Validator.IsType( "table" ),
-		Validator.Constant( Plugin.DefaultConfig.PreGame ) )
-	Validator:AddFieldRule( "VotePassActions.InGame", Validator.IsType( "table" ),
-		Validator.Constant( Plugin.DefaultConfig.InGame ) )
+	Validator:AddFieldRule( "VotePassActions.PreGame", Validator.IsType( "table",
+		Plugin.DefaultConfig.PreGame ) )
+	Validator:AddFieldRule( "VotePassActions.InGame", Validator.IsType( "table",
+		Plugin.DefaultConfig.InGame ) )
 	Validator:AddFieldRules( {
 		"VotePassActions.PreGame.ShufflePolicy",
 		"VotePassActions.InGame.ShufflePolicy"

--- a/lua/shine/extensions/voterandom/shared.lua
+++ b/lua/shine/extensions/voterandom/shared.lua
@@ -121,6 +121,15 @@ function Plugin:SetupClientConfig()
 
 		Print( "Team preference saved as: %s.%s", self.Config.PreferredTeam, ResetHint )
 	end ):AddParam{ Type = "team", Optional = true, Default = 3 }
+
+	Shine:RegisterClientSetting( {
+		Type = "Radio",
+		Command = "sh_shuffle_teampref",
+		ConfigOption = function() return self.Config.PreferredTeam end,
+		Options = self.TeamType,
+		Description = "TEAM_PREFERENCE",
+		TranslationSource = self.__Name
+	} )
 end
 
 function Plugin:UpdateShuffleButton()

--- a/lua/shine/extensions/voterandom/team_balance.lua
+++ b/lua/shine/extensions/voterandom/team_balance.lua
@@ -150,6 +150,7 @@ BalanceModule.SkillGetters = {
 
 BalanceModule.HappinessHistoryFile = "config://shine/temp/shuffle_happiness.json"
 BalanceModule.MaxHappinessHistoryRounds = 5
+BalanceModule.MinRoundLengthToRecord = 5 * 60
 
 function BalanceModule:Initialise()
 	self.HappinessHistory = self:LoadHappinessHistory()
@@ -169,6 +170,10 @@ function BalanceModule:EndGame( Gamerules, WinningTeam, Players )
 	local LastTeamLookup = self.LastShuffleTeamLookup
 	local LastPreferences = self.LastShufflePreferences
 	if not LastPreferences then return end
+
+	if not Gamerules.gameStartTime or ( Shared.GetTime() - Gamerules.gameStartTime ) < self.MinRoundLengthToRecord then
+		return
+	end
 
 	local RoundData = {}
 

--- a/lua/shine/lib/gui/objects/checkbox.lua
+++ b/lua/shine/lib/gui/objects/checkbox.lua
@@ -72,6 +72,8 @@ function CheckBox:GetChecked()
 end
 
 function CheckBox:SetChecked( Value, DontFade )
+	if Value == self.Checked then return end
+
 	if Value then
 		self.Checked = true
 
@@ -118,7 +120,7 @@ function CheckBox:OnMouseUp( Key )
 
 	if not self.Checked then
 		self:SetChecked( true )
-	else
+	elseif not self.Radio then
 		self:SetChecked( false )
 	end
 
@@ -169,6 +171,7 @@ function CheckBox:OnChecked( Checked )
 
 end
 
+SGUI.AddProperty( CheckBox, "Radio" )
 SGUI.AddBoundProperty( CheckBox, "Font", "Label" )
 SGUI.AddBoundProperty( CheckBox, "TextColour", "Label:SetColour" )
 SGUI.AddBoundProperty( CheckBox, "TextScale", "Label" )

--- a/lua/shine/lib/objects/map.lua
+++ b/lua/shine/lib/objects/map.lua
@@ -4,18 +4,33 @@
 ]]
 
 local Clamp = math.Clamp
+local getmetatable = getmetatable
+local IsType = Shine.IsType
+local pairs = pairs
 local TableRemove = table.remove
 
 local Map = Shine.TypeDef()
 
 Shine.Map = Map
 
-function Map:Init()
+function Map:Init( InitialValues )
 	self.Keys = {}
 	self.MemberLookup = {}
 
 	self.Position = 0
 	self.NumMembers = 0
+
+	if IsType( InitialValues, "table" ) then
+		if getmetatable( InitialValues ) == Map then
+			for Key, Value in InitialValues:Iterate() do
+				self:Add( Key, Value )
+			end
+		else
+			for Key, Value in pairs( InitialValues ) do
+				self:Add( Key, Value )
+			end
+		end
+	end
 
 	return self
 end
@@ -260,9 +275,6 @@ do
 		return GetPrevious, self
 	end
 end
-
-local getmetatable = getmetatable
-local pairs = pairs
 
 --[[
 	A multimap is a map that can map multiple values per key. It abstracts away the idiom of

--- a/test/extensions/afkkick.lua
+++ b/test/extensions/afkkick.lua
@@ -90,6 +90,7 @@ UnitTest:Test( "ValidateConfig - WarnMinPlayers <= MinPlayers", function( Assert
 	Assert:Equals( AFKKick.Config.MinPlayers, AFKKick.Config.WarnMinPlayers )
 end )
 
+local OldGetClientInfo = Shine.GetClientInfo
 AFKKick.Print = function() end
 Shine.GetClientInfo = function() return "" end
 AFKKick.CanKickForConnectingClient = function() return true end
@@ -98,7 +99,7 @@ UnitTest:Test( "KickOnConnect", function( Assert )
 	AFKKick.Config.KickOnConnect = true
 	AFKKick.Config.KickTime = 2
 
-	AFKKick.Users = {
+	AFKKick.Users = Shine.Map( {
 		[ 1 ] = {
 			AFKAmount = 2.5 * 60
 		},
@@ -108,7 +109,7 @@ UnitTest:Test( "KickOnConnect", function( Assert )
 		[ 3 ] = {
 			AFKAmount = 5 * 60
 		}
-	}
+	} )
 
 	-- Should kick client 3
 	local Kicked
@@ -129,3 +130,5 @@ UnitTest:Test( "KickOnConnect", function( Assert )
 end, function()
 	AFKKick.Config.KickOnConnect = false
 end )
+
+Shine.GetClientInfo = OldGetClientInfo

--- a/test/extensions/voterandom/voterandom.lua
+++ b/test/extensions/voterandom/voterandom.lua
@@ -121,10 +121,12 @@ end
 VoteShuffle.HappinessHistory = {}
 VoteShuffle.SaveHappinessHistory = function() end
 VoteShuffle.HasShuffledThisRound = false
+
+local FakeGamerules = {}
 local BalanceModule = VoteShuffle.Modules[ #VoteShuffle.Modules - 3 ]
 
 UnitTest:Test( "BalanceModule:EndGame - Does nothing if not shuffled", function( Assert )
-	BalanceModule.EndGame( VoteShuffle, nil, nil, { FakePlayer( 1 ) } )
+	BalanceModule.EndGame( VoteShuffle, FakeGamerules, nil, { FakePlayer( 1 ) } )
 	Assert:Equals( 0, #VoteShuffle.HappinessHistory )
 end )
 
@@ -132,9 +134,17 @@ VoteShuffle.HasShuffledThisRound = true
 VoteShuffle.LastShufflePreferences = nil
 
 UnitTest:Test( "BalanceModule:EndGame - Does nothing if no preference stored", function( Assert )
-	BalanceModule.EndGame( VoteShuffle, nil, nil, { FakePlayer( 1 ) } )
+	BalanceModule.EndGame( VoteShuffle, FakeGamerules, nil, { FakePlayer( 1 ) } )
 	Assert:Equals( 0, #VoteShuffle.HappinessHistory )
 end )
+
+FakeGamerules.gameStartTime = Shared.GetTime()
+UnitTest:Test( "BalanceModule:EndGame - Does nothing if round is too short", function( Assert )
+	BalanceModule.EndGame( VoteShuffle, FakeGamerules, nil, { FakePlayer( 1 ) } )
+	Assert:Equals( 0, #VoteShuffle.HappinessHistory )
+end )
+
+FakeGamerules.gameStartTime = -math.huge
 
 VoteShuffle.LastShufflePreferences = {
 	[ 1 ] = 1,
@@ -146,7 +156,7 @@ VoteShuffle.LastShuffleTeamLookup = {
 	[ 3 ] = 2
 }
 UnitTest:Test( "BalanceModule:EndGame - Remembers team preferences", function( Assert )
-	BalanceModule.EndGame( VoteShuffle, nil, nil, { FakePlayer( 1, 1 ), FakePlayer( 2, 1 ), FakePlayer( 3, 2 ) } )
+	BalanceModule.EndGame( VoteShuffle, FakeGamerules, nil, { FakePlayer( 1, 1 ), FakePlayer( 2, 1 ), FakePlayer( 3, 2 ) } )
 	-- Should store the round.
 	Assert:Equals( 1, #VoteShuffle.HappinessHistory )
 	-- Should remember that player 1 was on the team they wanted, while player 2 was not.

--- a/test/lib/objects/map.lua
+++ b/test/lib/objects/map.lua
@@ -149,6 +149,29 @@ UnitTest:Test( "EmptyMapIterators", function( Assert )
 	Assert.Equals( "Generic for backwards on an empty map iterated > 0 times!", 0, i )
 end )
 
+UnitTest:Test( "Construct with map", function( Assert )
+	local InitialMap = Map()
+	InitialMap:Add( "Test", "Value" )
+	InitialMap:Add( "AnotherTest", "AnotherValue" )
+
+	local Copy = Map( InitialMap )
+	Assert:Equals( 2, Copy:GetCount() )
+	Assert:Equals( "Value", Copy:Get( "Test" ) )
+	Assert:Equals( "AnotherValue", Copy:Get( "AnotherTest" ) )
+end )
+
+UnitTest:Test( "Construct with table", function( Assert )
+	local InitialValues = {
+		Test = "Value",
+		AnotherTest = "AnotherValue"
+	}
+
+	local Copy = Map( InitialValues )
+	Assert:Equals( 2, Copy:GetCount() )
+	Assert:Equals( "Value", Copy:Get( "Test" ) )
+	Assert:Equals( "AnotherValue", Copy:Get( "AnotherTest" ) )
+end )
+
 local Multimap = Shine.Multimap
 
 UnitTest:Test( "Multimap:Add()/Get()/GetCount()", function( Assert )

--- a/test/test_init.lua
+++ b/test/test_init.lua
@@ -143,6 +143,18 @@ UnitTest.Assert = {
 	Equals = function( A, B ) return A == B end,
 	NotEquals = function( A, B ) return A ~= B end,
 
+	TableEquals = function( A, B )
+		for Key, Value in pairs( A ) do
+			if Value ~= B[ Key ] then return false end
+		end
+
+		for Key, Value in pairs( B ) do
+			if Value ~= A[ Key ] then return false end
+		end
+
+		return true
+	end,
+
 	True = function( A ) return A == true end,
 	Truthy = function( A ) return A end,
 	False = function( A ) return A == false end,


### PR DESCRIPTION
### Shuffle Improvements
- Team preferences can now be explicitly specified by players.
- When shuffling, a history of previous rounds indicating which players got to play the team they prefer is used to determine an overall score for how satisfied players are with their teams. If there are more players unhappy than happy, the final teams will be swapped entirely (i.e. marine becomes alien and vice-versa).

### AFK Tracking
- Player AFK state is now always tracked, regardless of player count/round state. However, no action will be taken until the minimum player count/correct round state is reached.
- When the minimum player count/correct round state is reached, any player that has been AFK for greater than the warn/kick time will be warned/kicked immediately, rather than starting from 0 AFK time.