### PR TITLE
Improve vote menu, adverts plugin, config loading, web configs

### DIFF
--- a/lua/shine/core/client/votemenu_gui.lua
+++ b/lua/shine/core/client/votemenu_gui.lua
@@ -34,22 +34,19 @@ local FontName = Fonts.kAgencyFB_Small
 local FontScale = Vector( 1, 1, 0 )
 local TextCol = Colour( 1, 1, 1, 1 )
 
-local MenuTexture =
-{
+local MenuTexture = {
 	[ kMarineTeamType ] = "ui/marine_request_menu.dds",
 	[ kAlienTeamType ] = "ui/alien_request_menu.dds",
 	[ kNeutralTeamType ] = "ui/marine_request_menu.dds",
 }
 
-local ButtonTexture =
-{
+local ButtonTexture = {
 	[ kMarineTeamType ] = "ui/marine_request_button.dds",
 	[ kAlienTeamType ] = "ui/alien_request_button.dds",
 	[ kNeutralTeamType ] = "ui/marine_request_button.dds",
 }
 
-local ButtonHighlightTexture =
-{
+local ButtonHighlightTexture = {
 	[ kMarineTeamType ] = "ui/marine_request_button_highlighted.dds",
 	[ kAlienTeamType ] = "ui/alien_request_button_highlighted.dds",
 	[ kNeutralTeamType ] = "ui/marine_request_button_highlighted.dds",
@@ -352,9 +349,10 @@ function VoteMenu:SetPage( Name, IgnoreAnim )
 	self.ActivePage = Name
 end
 
-local function ClearButton( Button )
+local function ClearButton( self, Button )
 	if not SGUI.IsValid( Button ) then return end
 
+	self:MarkAsSelected( Button, false )
 	Button:SetIsVisible( false )
 	Button:SetTooltip( nil )
 
@@ -375,11 +373,11 @@ function VoteMenu:Clear()
 	local TopButton = Buttons.Top
 	local BottomButton = Buttons.Bottom
 
-	ClearButton( TopButton )
-	ClearButton( BottomButton )
+	ClearButton( self, TopButton )
+	ClearButton( self, BottomButton )
 
 	for i = 1, #SideButtons do
-		ClearButton( SideButtons[ i ] )
+		ClearButton( self, SideButtons[ i ] )
 	end
 
 	self.ButtonIndex = 0
@@ -544,6 +542,33 @@ function VoteMenu:AddSideButton( Text, DoClick )
 	self.ButtonIndex = Index
 
 	return Button
+end
+
+do
+	local TickTexture = PrecacheAsset( "ui/checkmark.dds" )
+
+	--[[
+		Marks or unmarks a given button as selected.
+		Selected buttons have a checkmark added to their right-hand side.
+	]]
+	function VoteMenu:MarkAsSelected( Button, Selected )
+		local HasCheckMark = SGUI.IsValid( Button.CheckMark )
+
+		if Selected and not HasCheckMark then
+			local Height = Button:GetSize().y * 0.75
+
+			local CheckMark = SGUI:Create( "Image", Button )
+			CheckMark:SetAnchor( "CentreRight" )
+			CheckMark:SetSize( Vector2( Height, Height ) )
+			CheckMark:SetPos( Vector2( -Height, -Height * 0.5 ) )
+			CheckMark:SetTexture( TickTexture )
+
+			Button.CheckMark = CheckMark
+		elseif not Selected and HasCheckMark then
+			Button.CheckMark:Destroy()
+			Button.CheckMark = nil
+		end
+	end
 end
 
 --[[

--- a/lua/shine/core/server/commands.lua
+++ b/lua/shine/core/server/commands.lua
@@ -11,6 +11,7 @@ local StringExplode = string.Explode
 local StringFind = string.find
 local StringFormat = string.format
 local StringGSub = string.gsub
+local StringPatternSafe = string.PatternSafe
 local StringStartsWith = string.StartsWith
 local StringSub = string.sub
 local TableConcat = table.concat
@@ -561,7 +562,7 @@ local function MatchStringRestriction( ParsedArg, Restriction )
 	end
 
 	-- Escape any patterns in the string.
-	Restriction = StringGSub( Restriction, "([%%%[%]%^%$%(%)%.%+%-%?])", "%%%1" )
+	Restriction = StringPatternSafe( Restriction )
 	Restriction = StringGSub( Restriction, "*", "(.-)" ).."$"
 
 	return StringFind( ParsedArg, Restriction ) ~= nil

--- a/lua/shine/core/server/config.lua
+++ b/lua/shine/core/server/config.lua
@@ -13,32 +13,32 @@ local ConfigPath = "config://shine/BaseConfig"
 local BackupPath = "config://Shine_BaseConfig"
 
 local DefaultConfig = {
-	EnableLogging = true, --Enable Shine's internal log. Note that plugins rely on this to log.
+	EnableLogging = true, -- Enable Shine's internal log. Note that plugins rely on this to log.
 	DebugLogging = false,
-	LogDir = "config://shine/logs/", --Logging directory.
-	DateFormat = "dd-mm-yyyy", --Format for logging dates.
+	LogDir = "config://shine/logs/", -- Logging directory.
+	DateFormat = "dd-mm-yyyy", -- Format for logging dates.
 
-	ExtensionDir = "config://shine/plugins/", --Plugin configs directory.
+	ExtensionDir = "config://shine/plugins/", -- Plugin configs directory.
 
-	GetUsersFromWeb = false, --Sets whether user data should be retrieved from the web.
-	GetUsersWithPOST = false, --Should we use POST to retrieve users?
-	UserRetrieveArguments = {}, --What extra arguments should be sent using POST?
-	UsersURL = "http://www.yoursite.com/users.json", --URL to get user data from if the above is true.
-	RefreshUsers = false, --Auto-refresh users every set amount of time.
-	RefreshInterval = 60, --How long in seconds between refreshes?
+	GetUsersFromWeb = false, -- Sets whether user data should be retrieved from the web.
+	GetUsersWithPOST = false, -- Should we use POST to retrieve users?
+	UserRetrieveArguments = {}, -- What extra arguments should be sent using POST?
+	UsersURL = "http://www.yoursite.com/users.json", -- URL to get user data from if the above is true.
+	RefreshUsers = false, -- Auto-refresh users every set amount of time.
+	RefreshInterval = 60, -- How long in seconds between refreshes?
 
 	WebConfigs = {
-		Enabled = false, --Should plugins get their configuration files from the web?
-		RequestURL = "", --Where should we request them from?
-		RequestArguments = {}, --What additional POST arguments should we send?
-		MaxAttempts = 3, --How many times should we attempt to get the configs before giving up?
-		UpdateMode = 1, --How should they be updated? 1 = on mapcycle, 2 = timed refresh.
-		UpdateInterval = 1, --How long in minutes between updates if set to time based?
-		IsBlacklist = false, --Is the plugins list a blacklist, or a whitelist?
-		Plugins = {} --List of plugins to get web configs for.
+		Enabled = false, -- Should plugins get their configuration files from the web?
+		RequestURL = "", -- Where should we request them from?
+		RequestArguments = {}, -- What additional POST arguments should we send?
+		MaxAttempts = 3, -- How many times should we attempt to get the configs before giving up?
+		UpdateMode = 1, -- How should they be updated? 1 = on mapcycle, 2 = timed refresh.
+		UpdateInterval = 1, -- How long in minutes between updates if set to time based?
+		IsBlacklist = false, -- Is the plugins list a blacklist, or a whitelist?
+		Plugins = {} -- List of plugins to get web configs for.
 	},
 
-	ActiveExtensions = { --Defines which plugins should be active.
+	ActiveExtensions = { -- Defines which plugins should be active.
 		adverts = false,
 		afkkick = false,
 		badges = false,
@@ -69,19 +69,19 @@ local DefaultConfig = {
 		Steam = ""
 	},
 
-	EqualsCanTarget = false, --Defines whether users with the same immunity can target each other or not.
+	EqualsCanTarget = false, -- Defines whether users with the same immunity can target each other or not.
 
-	NotifyOnCommand = false, --Should we display a notification for commands such as kick, ban etc?
-	NotifyAnonymous = true, --Should we hide who performed the operation?
-	NotifyAdminAnonymous = false, --Should we hide to players with greater-equal immunity who performed it?
-	ChatName = "Admin", --The name to use for anonymous output.
-	ConsoleName = "Admin", --The name to use for console running a command.
+	NotifyOnCommand = false, -- Should we display a notification for commands such as kick, ban etc?
+	NotifyAnonymous = true, -- Should we hide who performed the operation?
+	NotifyAdminAnonymous = false, -- Should we hide to players with greater-equal immunity who performed it?
+	ChatName = "Admin", -- The name to use for anonymous output.
+	ConsoleName = "Admin", -- The name to use for console running a command.
 
-	SilentChatCommands = true, --Defines whether to silence all chat commands, or only those starting with "/".
+	SilentChatCommands = true, -- Defines whether to silence all chat commands, or only those starting with "/".
 
-	AddTag = true, --Add 'shine' as a server tag.
+	AddTag = true, -- Add 'shine' as a server tag.
 
-	ReportErrors = true --Should errors be reported at the end of a round?
+	ReportErrors = true -- Should errors be reported at the end of a round?
 }
 
 local DefaultGamemode = Shine.BaseGamemode
@@ -159,7 +159,7 @@ do
 
 			ConfigFile, Pos, Err = self.LoadJSONFile( Path )
 
-			--Store what path we've loaded from so we update the right one!
+			-- Store what path we've loaded from so we update the right one!
 			if ConfigFile ~= false then
 				self.ConfigPath = Path
 
@@ -171,10 +171,10 @@ do
 
 		if not ConfigFile or not IsType( ConfigFile, "table" ) then
 			if IsType( Pos, "string" ) then
-				--No file exists.
+				-- No file exists.
 				self:GenerateDefaultConfig( true )
 			else
-				--Invalid JSON. Load the default config but don't save.
+				-- Invalid JSON. Load the default config but don't save.
 				self.Config = DefaultConfig
 				self.ConfigHasSyntaxError = true
 
@@ -197,7 +197,7 @@ do
 		local ConfigFile, Err = self.SaveJSONFile( self.Config,
 			self.ConfigPath or GetConfigPath( false, true ) )
 
-		if not ConfigFile then --Something's gone horribly wrong!
+		if not ConfigFile then -- Something's gone horribly wrong!
 			Shine.Error = "Error writing config file: "..Err
 
 			Notify( Shine.Error )
@@ -220,11 +220,9 @@ function Shine:GenerateDefaultConfig( Save )
 end
 
 local function ConvertToLookup( Table )
-	local Count = #Table
+	if #Table == 0 then return Table end
 
-	if Count == 0 then return Table end
-
-	--I've had the game crash before for not making a new table when doing this...
+	-- I've had the game crash before for not making a new table when doing this...
 	local NewTable = {}
 
 	for i = 1, #Table do
@@ -234,34 +232,34 @@ local function ConvertToLookup( Table )
 	return NewTable
 end
 
---Gets all plugins set to load their configs from the web.
+-- Gets all plugins set to load their configs from the web.
 local function GetWebLoadingPlugins( self )
 	local WebConfig = self.Config.WebConfigs
-
 	if not WebConfig.Enabled then
 		return {}
 	end
 
 	local ActiveExtensions = self.Config.ActiveExtensions
-	local PluginList = ConvertToLookup( WebConfig.Plugins )
+	local PluginsByName = ConvertToLookup( WebConfig.Plugins )
 
 	if WebConfig.IsBlacklist then
-		local DontLoad = {}
+		local LoadFromWeb = {}
 
 		for Plugin, Enabled in pairs( ActiveExtensions ) do
-			if not PluginList[ Plugin ] and Enabled then
-				DontLoad[ Plugin ] = true
+			if not PluginsByName[ Plugin ] and Enabled then
+				LoadFromWeb[ Plugin ] = true
 			end
 		end
 
-		return DontLoad
+		return LoadFromWeb
 	end
 
-	return PluginList
+	return PluginsByName
 end
 
 local function LoadPlugin( self, Name )
-	if self.Plugins[ Name ] then --We already loaded it, it was a shared plugin.
+	if self.Plugins[ Name ] then
+		-- We already loaded it, it was a shared plugin.
 		local Success, Err = self:EnableExtension( Name )
 		Notify( Success and StringFormat( "- Extension '%s' loaded.", Name )
 			or StringFormat( "- Error loading %s: %s", Name, Err ) )
@@ -275,7 +273,7 @@ end
 function Shine:LoadExtensionConfigs()
 	self:LoadConfig()
 
-	if self.Config.AddTag then --Would be nice to know who's running it.
+	if self.Config.AddTag then -- Would be nice to know who's running it.
 		Server.AddTag( "shine" )
 	end
 
@@ -283,14 +281,14 @@ function Shine:LoadExtensionConfigs()
 	local ActiveExtensions = self.Config.ActiveExtensions
 	local Modified = false
 
-	--Find any new plugins we don't have in our config, and add them.
+	-- Find any new plugins we don't have in our config, and add them.
 	for i = 1, #AllPlugins do
 		local Plugin = AllPlugins[ i ]
 		if ActiveExtensions[ Plugin ] == nil then
 			local PluginTable = self.Plugins[ Plugin ]
 			local DefaultState = false
 
-			--Load, but do not enable, the extension to determine its default state.
+			-- Load, but do not enable, the extension to determine its default state.
 			if not PluginTable then
 				self:LoadExtension( Plugin, true )
 
@@ -344,7 +342,7 @@ function Shine:LoadExtensionConfigs()
 end
 
 local function LoadDefaultConfigs( self, List )
-	--Just call the default enable, it'll load the HDD/default config.
+	-- Just call the default enable, it'll load the disk/default config.
 	for i = 1, #List do
 		LoadPlugin( self, List[ i ] )
 	end
@@ -360,6 +358,35 @@ local function OnFail( self, List, FailMessage, Format, ... )
 	Notify( "[Shine] Finished loading." )
 end
 
+local function ValidateAndSaveConfig( Name, PluginTable )
+	if PluginTable:ValidateConfigAfterLoad() then
+		Notify( StringFormat( "WARNING: '%s' config required changes to be valid."
+			.. " Check the local copy to see what changed.", Name ) )
+	end
+	PluginTable:SaveConfig( true )
+end
+
+local function LoadPluginWithConfig( self, Name, PluginTable, ConfigData, GamemodeName, NeedDifferentPath )
+	PluginTable.Config = ConfigData
+
+	-- Set the gamemode config path if we've been given a gamemode config.
+	if NeedDifferentPath then
+		PluginTable.__ConfigPath = StringFormat( "%s%s/%s",
+			self.Config.ExtensionDir, GamemodeName, PluginTable.ConfigName )
+	end
+
+	-- Cache to disk.
+	ValidateAndSaveConfig( Name, PluginTable )
+
+	if PluginTable.OnWebConfigLoaded then
+		PluginTable:OnWebConfigLoaded()
+	end
+
+	local Success, Err = self:EnableExtension( Name, true )
+	Notify( Success and StringFormat( "- Extension '%s' loaded.", Name )
+		or StringFormat( "- Error loading %s: %s", Name, Err ) )
+end
+
 local function OnWebPluginSuccess( self, Response, List, Reload )
 	if not Response then
 		OnFail( self, List, "[WebConfigs] Web request for plugin configs got a blank response. Loading default/cache files..." )
@@ -370,8 +397,8 @@ local function OnWebPluginSuccess( self, Response, List, Reload )
 	local Decoded, Pos, Err = Decode( Response )
 
 	if not Decoded or not IsType( Decoded, "table" ) then
-		OnFail( self, List, "[WebConfigs] Web request for plugin configs received invalid JSON. Error: %s. Loading default/cache files...",
-			true, Err )
+		OnFail( self, List, "[WebConfigs] Web request for plugin configs received invalid JSON. Error: %s.\nResponse:\n%s\nLoading default/cache files...",
+			true, Err, Response )
 
 		return
 	end
@@ -394,13 +421,25 @@ local function OnWebPluginSuccess( self, Response, List, Reload )
 		Notify( "[Shine] Parsing web config response..." )
 	end
 
-	for Name, Data in SortedPairs( PluginData ) do
+	local Loaded = {}
+	local function ProcessPlugin( Name, Data )
+		if not IsType( Name, "string" ) or not IsType( Data, "table" ) then
+			self:Print( "[WebConfigs] Server responded with invalid key/value in config table: %s/%s", true, Name, Data )
+			if not Reload and IsType( Name, "string" ) then
+				Loaded[ Name ] = true
+				LoadPlugin( self, Name )
+			end
+			return
+		end
+
+		Loaded[ Name ] = true
+
 		local Success = Data.success or Data.Success
 		local ConfigData = Data.config or Data.Config
 
-		--Is the config we're loading for a specific gamemode?
-		local GamemodeResponse = Data.Gamemode or Data.gamemode
-		local NeedDifferentPath = GamemodeResponse and GamemodeResponse ~= DefaultGamemode
+		-- Is the config we're loading for a specific gamemode?
+		local GamemodeName = Data.Gamemode or Data.gamemode
+		local NeedDifferentPath = GamemodeName and GamemodeName ~= DefaultGamemode
 
 		if not Success then
 			self:Print( "[WebConfigs] Server responded with error for plugin %s: %s.", true,
@@ -413,74 +452,46 @@ local function OnWebPluginSuccess( self, Response, List, Reload )
 			local PluginTable = self.Plugins[ Name ]
 
 			if PluginTable then
-				--Reloading means we just need to update the given config keys.
 				if Reload then
+					-- Reloading means we just need to update the given config keys.
 					for Key, Value in pairs( ConfigData ) do
 						PluginTable.Config[ Key ] = Value
 					end
 
-					PluginTable:SaveConfig( true )
+					ValidateAndSaveConfig( Name, PluginTable )
 				else
-					PluginTable.Config = ConfigData
-
-					--Check and cache new/missing entries.
-					if PluginTable.CheckConfig then
-						Shine.CheckConfig( PluginTable.Config, PluginTable.DefaultConfig )
-					end
-
-					--Set the gamemode config path if we've been given a gamemode config.
-					if NeedDifferentPath then
-						PluginTable.__ConfigPath = StringFormat( "%s%s/%s",
-							self.Config.ExtensionDir, GamemodeResponse, PluginTable.ConfigName )
-					end
-
-					--Cache to HDD.
-					PluginTable:SaveConfig( true )
-
-					if PluginTable.OnWebConfigLoaded then
-						PluginTable:OnWebConfigLoaded()
-					end
-
-					local Success, Err = self:EnableExtension( Name, true )
-
-					Notify( Success and StringFormat( "- Extension '%s' loaded.", Name )
-						or StringFormat( "- Error loading %s: %s", Name, Err ) )
+					LoadPluginWithConfig( self, Name, PluginTable, ConfigData, GamemodeName, NeedDifferentPath )
 				end
-			elseif not Reload then --We don't want to enable new extensions on reload.
+			-- We don't want to enable new extensions on reload.
+			elseif not Reload then
 				local Success, Err = self:LoadExtension( Name, true )
 
 				if not Success then
 					Notify( StringFormat( "- Error loading %s: %s", Name, Err ) )
 				else
 					PluginTable = self.Plugins[ Name ]
-
-					PluginTable.Config = ConfigData
-
-					if PluginTable.CheckConfig then
-						Shine.CheckConfig( PluginTable.Config, PluginTable.DefaultConfig )
-					end
-
-					if NeedDifferentPath then
-						PluginTable.__ConfigPath = StringFormat( "%s%s/%s",
-							self.Config.ExtensionDir, GamemodeResponse, PluginTable.ConfigName )
-					end
-
-					PluginTable:SaveConfig( true )
-
-					if PluginTable.OnWebConfigLoaded then
-						PluginTable:OnWebConfigLoaded()
-					end
-
-					Success, Err = self:EnableExtension( Name, true )
-
-					Notify( Success and StringFormat( "- Extension '%s' loaded.", Name )
-						or StringFormat( "- Error loading %s: %s", Name, Err ) )
+					LoadPluginWithConfig( self, Name, PluginTable, ConfigData, GamemodeName, NeedDifferentPath )
 				end
 			end
 		else
 			self:Print( "[WebConfigs] Server responded with success but supplied no config for plugin %s.", true, Name )
 
 			if not Reload then
+				LoadPlugin( self, Name )
+			end
+		end
+	end
+
+	for Name, Data in SortedPairs( PluginData ) do
+		ProcessPlugin( Name, Data )
+	end
+
+	if not Reload then
+		-- Make sure any entries that weren't provided in the response are still loaded.
+		for i = 1, #List do
+			local Name = List[ i ]
+			if not Loaded[ Name ] then
+				self:Print( "[WebConfigs] No data was provided for plugin %s, so it was loaded from disk.", true, Name )
 				LoadPlugin( self, Name )
 			end
 		end

--- a/lua/shine/core/server/config.lua
+++ b/lua/shine/core/server/config.lua
@@ -459,6 +459,10 @@ local function OnWebPluginSuccess( self, Response, List, Reload )
 					end
 
 					ValidateAndSaveConfig( Name, PluginTable )
+
+					if PluginTable.OnWebConfigReloaded then
+						PluginTable:OnWebConfigReloaded()
+					end
 				else
 					LoadPluginWithConfig( self, Name, PluginTable, ConfigData, GamemodeName, NeedDifferentPath )
 				end

--- a/lua/shine/core/shared/base_plugin/config.lua
+++ b/lua/shine/core/shared/base_plugin/config.lua
@@ -106,6 +106,16 @@ function ConfigModule:LoadConfig()
 
 	self.Config = PluginConfig
 
+	if self:ValidateConfigAfterLoad() then
+		self:SaveConfig()
+	end
+end
+
+--[[
+	Validates the plugin's configuration, returning true if changes
+	were made.
+]]
+function ConfigModule:ValidateConfigAfterLoad()
 	local Validator = Shine.Validator()
 	Validator:AddRule( {
 		Matches = function( _, Config )
@@ -139,9 +149,7 @@ function ConfigModule:LoadConfig()
 		Validator:Add( self.ConfigValidator )
 	end
 
-	if Validator:Validate( self.Config ) then
-		self:SaveConfig()
-	end
+	return Validator:Validate( self.Config )
 end
 
 function ConfigModule:MigrateConfig( Config )

--- a/lua/shine/core/shared/base_plugin/config.lua
+++ b/lua/shine/core/shared/base_plugin/config.lua
@@ -119,7 +119,15 @@ function ConfigModule:LoadConfig()
 	} )
 	Validator:AddRule( {
 		Matches = function( _, Config )
-			return self.CheckConfig and Shine.CheckConfig( Config, self.DefaultConfig, false, { __Version = true } )
+			if self.CheckConfig then
+				local ReservedKeys = { __Version = true }
+
+				if self.CheckConfigRecursively then
+					return Shine.VerifyConfig( Config, self.DefaultConfig, ReservedKeys )
+				end
+
+				return Shine.CheckConfig( Config, self.DefaultConfig, false, ReservedKeys )
+			end
 		end
 	} )
 	Validator:AddRule( {

--- a/lua/shine/core/shared/config.lua
+++ b/lua/shine/core/shared/config.lua
@@ -3,8 +3,10 @@
 ]]
 
 local Encode, Decode = json.encode, json.decode
+local getmetatable = getmetatable
 local Open = io.open
 local pairs = pairs
+local setmetatable = setmetatable
 local StringFormat = string.format
 local type = type
 
@@ -55,11 +57,11 @@ function Shine.SaveJSONFile( Table, Path, Settings )
 	return WriteFile( Path, Encode( Table, Settings or JSONSettings ) )
 end
 
---Checks a config for missing entries including the first level of sub-tables.
+-- Checks a config for missing entries including the first level of sub-tables.
 function Shine.RecursiveCheckConfig( Config, DefaultConfig, DontRemove )
 	local Updated
 
-	--Add new keys.
+	-- Add new keys.
 	for Option, Value in pairs( DefaultConfig ) do
 		if Config[ Option ] == nil then
 			Config[ Option ] = Value
@@ -78,7 +80,7 @@ function Shine.RecursiveCheckConfig( Config, DefaultConfig, DontRemove )
 
 	if DontRemove then return Updated end
 
-	--Remove old keys.
+	-- Remove old keys.
 	for Option, Value in pairs( Config ) do
 		if DefaultConfig[ Option ] == nil then
 			Config[ Option ] = nil
@@ -98,11 +100,74 @@ function Shine.RecursiveCheckConfig( Config, DefaultConfig, DontRemove )
 	return Updated
 end
 
---Checks a config for missing entries without checking sub-tables.
+do
+	local IgnorableValue = {}
+	--[[
+		Marks a table value as ignorable when checking configuration
+		values.
+
+		This should be used when a table does not have fixed keys. It will not change
+		the table's behaviour at all, it just adds a marker meta-table.
+	]]
+	function Shine.IgnoreWhenChecking( Value )
+		Shine.TypeCheck( Value, "table", 1, "IgnoreWhenChecking" )
+		return setmetatable( Value, IgnorableValue )
+	end
+
+	local function ShouldIgnore( DefaultValue )
+		return getmetatable( DefaultValue ) == IgnorableValue
+	end
+
+	--[[
+		For each value in the configuration recursively, ensure that any missing
+		keys in the provided config are added, and that any keys not present in the
+		default config are removed.
+
+		This ignores any key that is a number on the basis that it's likely an array
+		value and thus it is not useful to check.
+
+		Tables can also be set to be ignored manually by using Shine.IgnoreWhenChecking().
+	]]
+	function Shine.VerifyConfig( Config, DefaultConfig, ReservedKeys )
+		local Updated = false
+
+		for Option, DefaultValue in pairs( DefaultConfig ) do
+			-- Ignore any number keys, assume they are default array options which can vary.
+			if not IsType( Option, "number" ) then
+				local ProvidedValue = Config[ Option ]
+				-- If no value has been provided for this key, add it.
+				if ProvidedValue == nil then
+					Config[ Option ] = DefaultValue
+					Updated = true
+				-- If the default value is a table, check its keys as long as it's not set
+				-- to be ignored in the default config.
+				elseif IsType( DefaultValue, "table" ) and IsType( ProvidedValue, "table" )
+				and not ShouldIgnore( DefaultValue ) then
+					Updated = Shine.VerifyConfig( ProvidedValue, DefaultValue ) or Updated
+				end
+			end
+		end
+
+		for Option, Value in pairs( Config ) do
+			-- If the value no longer exists in the default config, and it's not
+			-- an array value or reserved key, remove it.
+			if DefaultConfig[ Option ] == nil
+			and not ( ReservedKeys and ReservedKeys[ Option ] )
+			and not IsType( Option, "number" ) then
+				Config[ Option ] = nil
+				Updated = true
+			end
+		end
+
+		return Updated
+	end
+end
+
+-- Checks a config for missing entries without checking sub-tables.
 function Shine.CheckConfig( Config, DefaultConfig, DontRemove, ReservedKeys )
 	local Updated
 
-	--Add new keys.
+	-- Add new keys.
 	for Option, Value in pairs( DefaultConfig ) do
 		if Config[ Option ] == nil then
 			Config[ Option ] = Value
@@ -113,7 +178,7 @@ function Shine.CheckConfig( Config, DefaultConfig, DontRemove, ReservedKeys )
 
 	if DontRemove then return Updated end
 
-	--Remove old keys.
+	-- Remove old keys.
 	for Option, Value in pairs( Config ) do
 		if DefaultConfig[ Option ] == nil
 		and not ( ReservedKeys and ReservedKeys[ Option ] ) then

--- a/lua/shine/core/shared/extensions.lua
+++ b/lua/shine/core/shared/extensions.lua
@@ -41,6 +41,10 @@ function Shine.GetModuleFile( ModuleName )
 end
 
 function Shine.LoadPluginModule( ModuleName, Plugin )
+	Plugin = Plugin or _G.Plugin
+	Shine.AssertAtLevel( Plugin and Plugin.AddModule,
+		"Called LoadPluginModule too early! Make sure the plugin has been registered first.", 3 )
+
 	local File = loadfile( Shine.GetModuleFile( ModuleName ) )
 	return File( Plugin )
 end

--- a/lua/shine/core/shared/extensions.lua
+++ b/lua/shine/core/shared/extensions.lua
@@ -242,6 +242,17 @@ function Shine:CanPluginLoad( Plugin )
 	end
 
 	local Gamemode = Shine.GetGamemode()
+
+	-- Allow external mods/gamemodes to decide whether the plugin can load if they know a plugin is compatible.
+	local Allowed = Hook.Call( "CanPluginLoad", Plugin, Gamemode )
+	if Allowed ~= nil then
+		if not Allowed then
+			return false, "plugin not compatible with gamemode: "..Gamemode
+		end
+
+		return true
+	end
+
 	-- Plugin has explicitly requested to be disabled for the gamemode.
 	local IsDisabled = Plugin.DisabledGamemodes and Plugin.DisabledGamemodes[ Gamemode ]
 	-- Plugin has expliclty requested to only be enabled for certain gamemodes.

--- a/lua/shine/core/shared/extensions.lua
+++ b/lua/shine/core/shared/extensions.lua
@@ -40,8 +40,9 @@ function Shine.GetModuleFile( ModuleName )
 	return StringFormat( "lua/shine/modules/%s", ModuleName )
 end
 
-function Shine.LoadPluginModule( ModuleName )
-	return Script.Load( Shine.GetModuleFile( ModuleName ), true )
+function Shine.LoadPluginModule( ModuleName, Plugin )
+	local File = loadfile( Shine.GetModuleFile( ModuleName ) )
+	return File( Plugin )
 end
 
 --Here we collect every extension file so we can be sure it exists before attempting to load it.

--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -7,6 +7,7 @@ local Shine = Shine
 local Clamp = math.Clamp
 local DebugSetUpValue = debug.setupvalue
 local Floor = math.floor
+local IsCallable = Shine.IsCallable
 local IsType = Shine.IsType
 local xpcall = xpcall
 local ReplaceMethod = Shine.ReplaceClassMethod
@@ -27,7 +28,6 @@ local ReservedNames = {}
 ]]
 local function Remove( Event, Index )
 	local EventHooks = Hooks[ Event ]
-
 	if not EventHooks then return end
 
 	local Priority = ReservedNames[ Event ][ Index ]
@@ -43,7 +43,14 @@ Hook.Remove = Remove
 	Inputs: Event to hook into, unique identifier, function to run, optional priority.
 ]]
 local function Add( Event, Index, Function, Priority )
-	Priority = Clamp( Floor( tonumber( Priority ) or 0 ), -20, 20 )
+	Shine.AssertAtLevel( Event ~= nil, "Event identifier must not be nil!", 3 )
+	Shine.AssertAtLevel( Index ~= nil, "Index must not be nil!", 3 )
+	Shine.AssertAtLevel( IsCallable( Function ), "Function must be callable!", 3 )
+	if Priority ~= nil then
+		Shine.TypeCheck( Priority, "number", 4, "Add" )
+	end
+
+	Priority = Clamp( Floor( Priority or 0 ), -20, 20 )
 
 	if not Hooks[ Event ] then
 		Hooks[ Event ] = {}

--- a/lua/shine/extensions/adverts.lua
+++ b/lua/shine/extensions/adverts.lua
@@ -5,6 +5,9 @@
 local Shine = Shine
 
 local IsType = Shine.IsType
+local setmetatable = setmetatable
+local StringFormat = string.format
+local StringUpper = string.upper
 local TableQuickCopy = table.QuickCopy
 local TableQuickShuffle = table.QuickShuffle
 local TableRemove = table.remove
@@ -15,19 +18,45 @@ Plugin.Version = "1.2"
 Plugin.PrintName = "Adverts"
 
 Plugin.HasConfig = true
+Plugin.CheckConfig = true
 Plugin.CheckConfigTypes = true
 Plugin.ConfigName = "Adverts.json"
+
+Plugin.AdvertTrigger = table.AsEnum{
+	"COUNTDOWN", "START_OF_ROUND", "END_OF_ROUND",
+	"MARINE_VICTORY", "ALIEN_VICTORY", "DRAW"
+}
+
 Plugin.DefaultConfig = {
+	Templates = {
+		-- Defines named template adverts, allowing many adverts to share the
+		-- same type/colour/prefix.
+		ChatNotification = {
+			Type = "chat",
+			Colour = { 255, 255, 255 },
+			Prefix = "[Info]",
+			PrefixColour = { 0, 200, 255 }
+		}
+	},
+	TriggeredAdverts = {
+		--[[
+		This would trigger a message at the start of a round (after the countdown).
+		{
+			Message = "Good luck and have fun!",
+			Template = "ChatNotification",
+			Trigger = "START_OF_ROUND"
+		}
+		]]
+	},
 	Adverts = {
 		{
 			Message = "Welcome to Natural Selection 2.",
-			Type = "chat",
-			Colour = { 255, 255, 255 }
+			-- Template should match a key in the "Templates" table.
+			Template = "ChatNotification"
 		},
 		{
 			Message = "This server is running the Shine administration mod.",
-			Type = "chat",
-			Colour = { 255, 255, 255 }
+			Template = "ChatNotification"
 		}
 	},
 	Interval = 60,
@@ -57,11 +86,105 @@ Plugin.ConfigMigrationSteps = {
 Plugin.TimerName = "Adverts"
 
 function Plugin:Initialise()
-	self.AdvertsList = TableQuickCopy( self.Config.Adverts )
+	self:ParseAdverts()
 	self:SetupTimer()
 	self.Enabled = true
 
 	return true
+end
+
+function Plugin:OnWebConfigReloaded()
+	self:ParseAdverts()
+	self:SetupTimer()
+end
+
+function Plugin:ParseAdverts()
+	local CurrentMapName = Shared.GetMapName()
+
+	local AdvertList = "Adverts"
+	local function IsValidAdvert( Advert, Index )
+		if not IsType( Advert, "string" ) and not IsType( Advert, "table" ) then
+			self:Print( "%s[ %d ] is neither a string or a table.", true, AdvertList, Index )
+			return false
+		end
+
+		if IsType( Advert, "table" ) and not IsType( Advert.Message, "string" ) then
+			self:Print( "%s[ %d ] has a missing or non-string message.", true, AdvertList, Index )
+			return false
+		end
+
+		return true
+	end
+
+	local function AssignTemplate( Advert )
+		if not IsType( Advert, "table" ) then return Advert end
+
+		local Template = self.Config.Templates[ Advert.Template ]
+
+		if IsType( Template, "table" ) then
+			-- Inherit values from the template.
+			return setmetatable( Advert, { __index = Template } )
+		end
+
+		return Advert
+	end
+
+	self.RequiresGameStateFiltering = false
+
+	-- Parse the list of cycling adverts, filtering out any that are invalid or not enabled
+	-- for the current map.
+	self.AdvertsList = Shine.Stream.Of( self.Config.Adverts )
+		:Map( AssignTemplate )
+		:Filter( IsValidAdvert )
+		:Filter( function( Advert )
+			if not IsType( Advert, "table" ) then return true end
+
+			if Advert.GameState then
+				self.RequiresGameStateFiltering = true
+			end
+
+			if Advert.Maps then
+				return Advert.Maps[ CurrentMapName ]
+			end
+			if Advert.ExcludedMaps then
+				return not Advert.ExcludedMaps[ CurrentMapName ]
+			end
+
+			return true
+		end )
+		:AsTable()
+
+	-- Collect all adverts set to run on a given trigger.
+	local TriggeredAdverts = self.Config.TriggeredAdverts
+	local TriggeredAdvertsByTrigger = Shine.Multimap()
+
+	AdvertList = "TriggeredAdverts"
+	local function IsValidTriggerAdvert( Advert, Index )
+		if not IsValidAdvert( Advert, Index ) then return false end
+
+		if not IsType( Advert, "table" ) or not IsType( Advert.Trigger, "string" ) then
+			self:Print( "%s[ %d ] must have a trigger defined.", true, AdvertList, Index )
+			return false
+		end
+
+		return true
+	end
+
+	Shine.Stream.Of( self.Config.TriggeredAdverts )
+		:Map( AssignTemplate )
+		:Filter( IsValidTriggerAdvert )
+		:ForEach( function( Advert, Index )
+			local TriggerName = StringUpper( Advert.Trigger )
+
+			if self.AdvertTrigger[ TriggerName ] then
+				TriggeredAdvertsByTrigger:Add( TriggerName, Advert )
+			else
+				self:Print( "%s[ %d ] has invalid trigger: %s",
+					true, AdvertList, Index, TriggerName )
+			end
+		end )
+
+	self.TriggeredAdvertsByTrigger = TriggeredAdvertsByTrigger
 end
 
 local function UnpackColour( Colour )
@@ -72,31 +195,13 @@ local function UnpackColour( Colour )
 		tonumber( Colour[ 3 ] ) or 255
 end
 
-function Plugin:ParseAdvert( ID, Advert )
+function Plugin:DisplayAdvert( Advert )
 	if IsType( Advert, "string" ) then
 		Shine:NotifyColour( nil, 255, 255, 255, Advert )
-
-		return true
-	end
-
-	if not IsType( Advert, "table" ) then
-		self:Print( "Misconfigured advert #%i, neither a table nor a string.", true, ID )
-
-		TableRemove( self.AdvertsList, ID )
-
-		return false
+		return
 	end
 
 	local Message = Advert.Message
-	if not IsType( Message, "string" ) then
-		self:Print( "Misconfigured advert #%i, missing or invalid \"Message\" value.",
-			true, ID )
-
-		TableRemove( self.AdvertsList, ID )
-
-		return false
-	end
-
 	local R, G, B = UnpackColour( Advert.Colour )
 	local Type = Advert.Type
 
@@ -107,7 +212,7 @@ function Plugin:ParseAdvert( ID, Advert )
 
  			Shine:NotifyDualColour( nil, PR, PG, PB, Advert.Prefix, R, G, B, Message )
 
- 			return true
+ 			return
 		end
 
 		Shine:NotifyColour( nil, R, G, B, Message )
@@ -130,8 +235,108 @@ function Plugin:ParseAdvert( ID, Advert )
 			Size = 2, FadeIn = 1
 		} )
 	end
+end
 
-	return true
+-- Enums error when accessing a field that is not present...
+local SafeGameStateLookup = {}
+for i = 1, #kGameState do
+	SafeGameStateLookup[ kGameState[ i ] ] = i
+end
+
+--[[
+	Filters the current advert list to those that are valid for the given
+	game state.
+
+	Returns the filtered list, and a boolean to indicate if any have been filtered
+	out.
+]]
+function Plugin:FilterAdvertListForState( Adverts, CurrentAdverts, GameState )
+	local function IsGameState( GameStateName )
+		return SafeGameStateLookup[ GameStateName ] == GameState
+	end
+
+	local function IsValidForGameState( Advert )
+		if not Advert.GameState then return true end
+
+		if IsType( Advert.GameState, "table" ) then
+			for i = 1, #Advert.GameState do
+				if IsGameState( Advert.GameState[ i ] ) then
+					return true
+				end
+			end
+		end
+
+		return IsGameState( Advert.GameState )
+	end
+
+	local OutputAdverts = {}
+	local HasChanged = false
+	for i = 1, #Adverts do
+		if IsValidForGameState( Adverts[ i ] ) then
+			local Index = #OutputAdverts + 1
+			OutputAdverts[ Index ] = Adverts[ i ]
+			if OutputAdverts[ Index ] ~= CurrentAdverts[ Index ] then
+				HasChanged = true
+			end
+		end
+	end
+
+	if #OutputAdverts ~= #CurrentAdverts then
+		HasChanged = true
+	end
+
+	return OutputAdverts, HasChanged
+end
+
+local StateToTrigger = Shine.Multimap( {
+	[ kGameState.Countdown ] = { Plugin.AdvertTrigger.COUNTDOWN },
+	[ kGameState.Started ] = { Plugin.AdvertTrigger.START_OF_ROUND },
+	[ kGameState.Team1Won ] = {
+		Plugin.AdvertTrigger.END_OF_ROUND,
+		Plugin.AdvertTrigger.MARINE_VICTORY
+	},
+	[ kGameState.Team2Won ] = {
+		Plugin.AdvertTrigger.END_OF_ROUND,
+		Plugin.AdvertTrigger.ALIEN_VICTORY
+	},
+	[ kGameState.Draw ] = {
+		Plugin.AdvertTrigger.END_OF_ROUND,
+		Plugin.AdvertTrigger.DRAW
+	}
+} )
+--[[
+	Gets the apprioriate trigger name for the given game state.
+]]
+function Plugin:GetTriggerNamesForGameState( GameState )
+	return StateToTrigger:Get( GameState )
+end
+
+--[[
+	Changes the current advert list based on the new game state, and triggers any
+	triggered adverts.
+]]
+function Plugin:SetGameState( Gamerules, NewState, OldState )
+	if self.RequiresGameStateFiltering then
+		local NewAdverts, HasListChanged = self:FilterAdvertListForState( self.AdvertsList,
+			self.CurrentAdvertsList or self.AdvertsList, NewState )
+		if HasListChanged then
+			-- Reset the advert list to the newly filtered version.
+			self.CurrentMessageIndex = 1
+			self.CurrentAdvertsList = NewAdverts
+		end
+	end
+
+	local Triggers = self:GetTriggerNamesForGameState( NewState )
+	if not Triggers then return end
+
+	for i = 1, #Triggers do
+		local Adverts = self.TriggeredAdvertsByTrigger:Get( Triggers[ i ] )
+		if Adverts then
+			for j = 1, #Adverts do
+				self:DisplayAdvert( Adverts[ j ] )
+			end
+		end
+	end
 end
 
 function Plugin:SetupTimer()
@@ -141,19 +346,26 @@ function Plugin:SetupTimer()
 
 	if #self.AdvertsList == 0 then return end
 
-	local Message = 1
+	self.CurrentMessageIndex = 1
+	if self.RequiresGameStateFiltering then
+		local Gamerules = GetGamerules()
+		local GameState = Gamerules and Gamerules:GetGameState() or kGameState.NotStarted
+		-- Make sure to filter down to the right list of adverts now.
+		self.CurrentAdvertsList = self:FilterAdvertListForState( self.AdvertsList,
+			self.AdvertsList, GameState )
+	else
+		self.CurrentAdvertsList = self.AdvertsList
+	end
 
 	self:CreateTimer( self.TimerName, self.Config.Interval, -1, function()
+		local Message = self.CurrentMessageIndex
 		-- Back to the start, randomise the order again.
 		if Message == 1 and self.Config.RandomiseOrder then
-			TableQuickShuffle( self.AdvertsList )
+			TableQuickShuffle( self.CurrentAdvertsList )
 		end
 
-		if self:ParseAdvert( Message, self.AdvertsList[ Message ] ) then
-			Message = ( Message % #self.AdvertsList ) + 1
-		elseif #self.AdvertsList == 0 then
-			self:DestroyTimer( self.TimerName )
-		end
+		self:DisplayAdvert( self.CurrentAdvertsList[ Message ] )
+		self.CurrentMessageIndex = ( Message % #self.CurrentAdvertsList ) + 1
 	end )
 end
 

--- a/lua/shine/extensions/adverts.lua
+++ b/lua/shine/extensions/adverts.lua
@@ -131,6 +131,17 @@ function Plugin:ParseAdverts()
 
 	self.RequiresGameStateFiltering = false
 
+	local function IsValidForMap( Advert )
+		if Advert.Maps then
+			return Advert.Maps[ CurrentMapName ]
+		end
+		if Advert.ExcludedMaps then
+			return not Advert.ExcludedMaps[ CurrentMapName ]
+		end
+
+		return true
+	end
+
 	-- Parse the list of cycling adverts, filtering out any that are invalid or not enabled
 	-- for the current map.
 	self.AdvertsList = Shine.Stream.Of( self.Config.Adverts )
@@ -143,14 +154,7 @@ function Plugin:ParseAdverts()
 				self.RequiresGameStateFiltering = true
 			end
 
-			if Advert.Maps then
-				return Advert.Maps[ CurrentMapName ]
-			end
-			if Advert.ExcludedMaps then
-				return not Advert.ExcludedMaps[ CurrentMapName ]
-			end
-
-			return true
+			return IsValidForMap( Advert )
 		end )
 		:AsTable()
 
@@ -173,6 +177,7 @@ function Plugin:ParseAdverts()
 	Shine.Stream.Of( self.Config.TriggeredAdverts )
 		:Map( AssignTemplate )
 		:Filter( IsValidTriggerAdvert )
+		:Filter( IsValidForMap )
 		:ForEach( function( Advert, Index )
 			local TriggerName = StringUpper( Advert.Trigger )
 

--- a/lua/shine/extensions/mapvote/server.lua
+++ b/lua/shine/extensions/mapvote/server.lua
@@ -634,6 +634,9 @@ function Plugin:CreateCommands()
 			} )
 
 			self:UpdateVoteCounters( self.StartingVote )
+			if Client then
+				self:NotifyVoted( Client )
+			end
 
 			return
 		end

--- a/lua/shine/extensions/mapvote/server.lua
+++ b/lua/shine/extensions/mapvote/server.lua
@@ -287,6 +287,9 @@ function Plugin:Initialise()
 
 	self.StartingVote = Shine:CreateVote( function() return self:GetVotesNeededToStart() end,
 		function() self:StartVote() end )
+	function self.StartingVote.OnReset()
+		self:ResetVoteCounters()
+	end
 
 	self.NextMap = {}
 	self.NextMap.Extends = 0
@@ -629,6 +632,8 @@ function Plugin:CreateCommands()
 				TargetName = PlayerName,
 				VotesNeeded = VotesNeeded
 			} )
+
+			self:UpdateVoteCounters( self.StartingVote )
 
 			return
 		end

--- a/lua/shine/extensions/mapvote/shared.lua
+++ b/lua/shine/extensions/mapvote/shared.lua
@@ -79,6 +79,7 @@ function Plugin:SetupDataTable()
 	self:AddNetworkMessage( "VoteOptions", VoteOptionsMessage, "Client" )
 	self:AddNetworkMessage( "EndVote", MessageTypes.Empty, "Client" )
 	self:AddNetworkMessage( "VoteProgress", MapVotesMessage, "Client" )
+	self:AddNetworkMessage( "ChosenMap", MessageTypes.MapName, "Client" )
 
 	self:AddNetworkMessage( "RequestVoteOptions", MessageTypes.Empty, "Server" )
 
@@ -357,6 +358,8 @@ do
 				end
 			end )
 
+			Shine.VoteMenu:MarkAsSelected( Button, Plugin.ChosenMap == Map )
+
 			if MapIcons[ Map ] then
 				SetupMapPreview( Button, Map )
 			end
@@ -383,8 +386,29 @@ function Plugin:ReceiveVoteProgress( Data )
 	end
 end
 
+function Plugin:ReceiveChosenMap( Data )
+	local MapName = Data.MapName
+
+	if self.ChosenMap then
+		-- Unmark the old selected map button if it's present.
+		local OldButton = self.MapButtons[ self.ChosenMap ]
+		if SGUI.IsValid( OldButton ) then
+			Shine.VoteMenu:MarkAsSelected( OldButton, false )
+		end
+	end
+
+	self.ChosenMap = MapName
+
+	-- Mark the selected map button.
+	local MapButton = self.MapButtons[ MapName ]
+	if SGUI.IsValid( MapButton ) then
+		Shine.VoteMenu:MarkAsSelected( MapButton, true )
+	end
+end
+
 function Plugin:ReceiveEndVote( Data )
 	self.EndTime = 0
+	self.ChosenMap = nil
 
 	TableEmpty( self.MapVoteCounts )
 	TableEmpty( self.MapButtons )

--- a/lua/shine/extensions/mapvote/shared.lua
+++ b/lua/shine/extensions/mapvote/shared.lua
@@ -23,6 +23,8 @@ local MapVotesMessage = {
 Shine:RegisterExtension( "mapvote", Plugin )
 
 function Plugin:SetupDataTable()
+	self:CallModuleEvent( "SetupDataTable" )
+
 	local MapNameField = "string (24)"
 
 	local MessageTypes = {
@@ -138,6 +140,8 @@ function Plugin:SetupDataTable()
 	} )
 end
 
+Shine.LoadPluginModule( "sh_vote.lua", Plugin )
+
 if Server then
 	function Plugin:ReceiveRequestVoteOptions( Client, Message )
 		self:SendVoteData( Client )
@@ -145,6 +149,8 @@ if Server then
 
 	return
 end
+
+Plugin.VoteButtonName = "Map Vote"
 
 local Shine = Shine
 local SGUI = Shine.GUI

--- a/lua/shine/extensions/mapvote/voting.lua
+++ b/lua/shine/extensions/mapvote/voting.lua
@@ -63,6 +63,7 @@ end
 
 function Plugin:ClientDisconnect( Client )
 	self.StartingVote:ClientDisconnect( Client )
+	self:UpdateVoteCounters( self.StartingVote )
 end
 
 --[[

--- a/lua/shine/extensions/mapvote/voting.lua
+++ b/lua/shine/extensions/mapvote/voting.lua
@@ -205,6 +205,13 @@ function Plugin:SendMapVoteCount( Client, Map, Count )
 end
 
 --[[
+	Sends a client's vote choice so their menu knows which map they have selected.
+]]
+function Plugin:SendVoteChoice( Client, Map )
+	self:SendNetworkMessage( Client, "ChosenMap", { MapName = Map }, true )
+end
+
+--[[
 	Adds a vote for a given map in the map vote.
 ]]
 function Plugin:AddVote( Client, Map, Revote )
@@ -228,15 +235,18 @@ function Plugin:AddVote( Client, Map, Revote )
 			self.Vote.VoteList[ OldVote ] = self.Vote.VoteList[ OldVote ] - 1
 		end
 
-		--Update all client's vote counters.
+		-- Update all client's vote counters.
 		self:SendMapVoteCount( nil, OldVote, self.Vote.VoteList[ OldVote ] )
 	end
 
 	local CurVotes = self.Vote.VoteList[ Choice ]
 	self.Vote.VoteList[ Choice ] = CurVotes + 1
 
-	--Update all client's vote counters.
+	-- Update all client's vote counters.
 	self:SendMapVoteCount( nil, Choice, self.Vote.VoteList[ Choice ] )
+	if Client ~= "Console" then
+		self:SendVoteChoice( Client, Choice )
+	end
 
 	if not Revote then
 		self.Vote.TotalVotes = self.Vote.TotalVotes + 1

--- a/lua/shine/extensions/mapvote/voting.lua
+++ b/lua/shine/extensions/mapvote/voting.lua
@@ -39,6 +39,10 @@ function Plugin:SendVoteOptions( Client, Options, Duration, NextMap, TimeLeft, S
 	end
 end
 
+function Plugin:ClientConnect( Client )
+	self:UpdateVoteCounters( self.StartingVote )
+end
+
 --[[
 	Send the map vote text and map options when a new player connects and a map vote is in progress.
 ]]

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -411,8 +411,7 @@ function Plugin:Initialise()
 
 	self.Vote = Shine:CreateVote( GetVotesNeeded, OnVotePassed, OnTimeout )
 	function self.Vote.OnReset()
-		self.dt.CurrentShuffleVotes = 0
-		self.dt.RequiredShuffleVotes = 0
+		self:ResetVoteCounters()
 	end
 
 	self.ShuffleOnNextRound = false
@@ -1102,8 +1101,7 @@ function Plugin:CreateCommands()
 					} )
 				end
 
-				self.dt.CurrentShuffleVotes = self.Vote:GetVotes()
-				self.dt.RequiredShuffleVotes = self:GetVotesNeeded()
+				self:UpdateVoteCounters( self.Vote )
 			end
 
 			--Somehow it didn't apply random settings??

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -869,6 +869,8 @@ function Plugin:ClientDisconnect( Client )
 end
 
 function Plugin:ClientConnect( Client )
+	self:UpdateVoteCounters( self.Vote )
+
 	if not self.ReconnectingClients or not self.ReconnectLogTimeout then return end
 
 	if SharedTime() > self.ReconnectLogTimeout then

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -859,6 +859,7 @@ end
 function Plugin:ClientDisconnect( Client )
 	self:BroadcastModuleEvent( "ClientDisconnect", Client )
 	self.Vote:ClientDisconnect( Client )
+	self:UpdateVoteCounters( self.Vote )
 	self.TeamPreferences[ Client ] = nil
 
 	if not self.ReconnectLogTimeout then return end
@@ -1102,6 +1103,7 @@ function Plugin:CreateCommands()
 				end
 
 				self:UpdateVoteCounters( self.Vote )
+				self:NotifyVoted( Client )
 			end
 
 			--Somehow it didn't apply random settings??

--- a/lua/shine/extensions/voterandom/shared.lua
+++ b/lua/shine/extensions/voterandom/shared.lua
@@ -8,10 +8,10 @@ Plugin.NotifyPrefixColour = {
 }
 
 function Plugin:SetupDataTable()
+	self:CallModuleEvent( "SetupDataTable" )
+
 	self:AddDTVar( "boolean", "HighlightTeamSwaps", false )
 	self:AddDTVar( "boolean", "DisplayStandardDeviations", false )
-	self:AddDTVar( "integer", "CurrentShuffleVotes", 0 )
-	self:AddDTVar( "integer", "RequiredShuffleVotes", 0 )
 
 	local MessageTypes = {
 		ShuffleType = {
@@ -67,8 +67,11 @@ function Plugin:SetupDataTable()
 end
 
 Shine:RegisterExtension( "voterandom", Plugin )
+Shine.LoadPluginModule( "sh_vote.lua", Plugin )
 
 if Server then return end
+
+Plugin.VoteButtonName = "Shuffle"
 
 Plugin.TeamType = table.AsEnum{
 	"MARINE", "ALIEN", "NONE"
@@ -132,35 +135,8 @@ function Plugin:SetupClientConfig()
 	} )
 end
 
-function Plugin:UpdateShuffleButton()
-	local ShuffleButton = Shine.VoteMenu:GetButtonByPlugin( "Shuffle" )
-	if not ShuffleButton then return end
-
-	if self.dt.CurrentShuffleVotes == 0 or self.dt.RequiredShuffleVotes == 0 then
-		ShuffleButton:SetText( ShuffleButton.DefaultText )
-		return
-	end
-
-	-- Update the button with the current vote count.
-	ShuffleButton:SetText( StringFormat( "%s (%d/%d)", ShuffleButton.DefaultText,
-		self.dt.CurrentShuffleVotes,
-		self.dt.RequiredShuffleVotes ) )
-end
-
-function Plugin:NetworkUpdate( Key, Old, New )
-	if Key == "RequiredShuffleVotes" or Key == "CurrentShuffleVotes" then
-		if not Shine.VoteMenu.Visible then return end
-
-		self:UpdateShuffleButton()
-	end
-end
-
 function Plugin:OnFirstThink()
-	Shine.VoteMenu:EditPage( "Main", function( VoteMenu )
-		if not self.Enabled then return end
-
-		self:UpdateShuffleButton()
-	end )
+	self:CallModuleEvent( "OnFirstThink" )
 
 	-- Defensive check in case the scoreboard code changes.
 	if not Scoreboard_GetPlayerRecord or not GUIScoreboard or not GUIScoreboard.UpdateTeam then return end

--- a/lua/shine/lib/debug.lua
+++ b/lua/shine/lib/debug.lua
@@ -4,6 +4,7 @@
 
 local assert = assert
 local DebugGetLocal = debug.getlocal
+local DebugGetMetaTable = debug.getmetatable
 local DebugGetUpValue = debug.getupvalue
 local DebugSetUpValue = debug.setupvalue
 local DebugUpValueJoin = debug.upvaluejoin
@@ -236,6 +237,17 @@ end
 ]]
 function Shine.IsType( Object, Type )
 	return type( Object ) == Type
+end
+
+--[[
+	Determines if a given object is callable. That is, if it is a function
+	or its metatable has a __call meta-method.
+]]
+function Shine.IsCallable( Object )
+	if type( Object ) == "function" then return true end
+
+	local Meta = DebugGetMetaTable( Object )
+	return Meta and type( Meta.__call ) == "function" or false
 end
 
 --[[

--- a/lua/shine/lib/locale.lua
+++ b/lua/shine/lib/locale.lua
@@ -212,9 +212,12 @@ function Locale:OnLoaded()
 
 		TableSort( Missing.Keys )
 
+		-- Ignore the array index when printing.
+		local function PrintValue( Value ) return LuaPrint( Value ) end
+
 		for Folder, MissingKeys in Missing:Iterate() do
 			LuaPrint( "Missing keys in: "..Folder )
-			Shine.Stream( MissingKeys ):ForEach( LuaPrint )
+			Shine.Stream( MissingKeys ):ForEach( PrintValue )
 		end
 	end ):AddParam{ Type = "string" }
 

--- a/lua/shine/lib/objects.lua
+++ b/lua/shine/lib/objects.lua
@@ -2,8 +2,16 @@
 	Sets up and loads objects.
 ]]
 
+local getmetatable = getmetatable
 local setmetatable = setmetatable
 
+--[[
+	Produces a meta-table that produces new instances by calling
+	itself.
+
+	On calling, the "Init" method will be invoked and be given all arguments
+	from the call. It should return the instance.
+]]
 function Shine.TypeDef( Parent )
 	local MetaTable = {}
 	MetaTable.__index = MetaTable
@@ -14,6 +22,18 @@ function Shine.TypeDef( Parent )
 		end,
 		__index = Parent
 	} )
+end
+
+--[[
+	Tests whether the given value implements the given meta-table.
+	This accounts for parents assigned in Shine.TypeDef().
+]]
+function Shine.Implements( Value, MetaTable )
+	local ValueMetaTable = getmetatable( Value )
+	while ValueMetaTable ~= nil and ValueMetaTable ~= MetaTable do
+		ValueMetaTable = getmetatable( ValueMetaTable ).__index
+	end
+	return ValueMetaTable == MetaTable
 end
 
 Shine.Objects = {}

--- a/lua/shine/lib/objects/stream.lua
+++ b/lua/shine/lib/objects/stream.lua
@@ -67,7 +67,7 @@ function Stream:Filter( Predicate )
 
 	for i = 1, Size do
 		self.Data[ i - Offset ] = self.Data[ i ]
-		if not Predicate( self.Data[ i ] ) then
+		if not Predicate( self.Data[ i ], i ) then
 			self.Data[ i ] = nil
 			Offset = Offset + 1
 		end
@@ -85,7 +85,7 @@ end
 ]]
 function Stream:ForEach( Function )
 	for i = 1, #self.Data do
-		Function( self.Data[ i ] )
+		Function( self.Data[ i ], i )
 	end
 
 	return self
@@ -98,7 +98,7 @@ end
 ]]
 function Stream:Map( Mapper )
 	for i = 1, #self.Data do
-		self.Data[ i ] = Mapper( self.Data[ i ] )
+		self.Data[ i ] = Mapper( self.Data[ i ], i )
 	end
 
 	return self

--- a/lua/shine/lib/player.lua
+++ b/lua/shine/lib/player.lua
@@ -118,14 +118,16 @@ end
 local function MoveToTeam( Gamerules, Players, TeamNumber )
 	for i = #Players, 1, -1 do
 		local Player = Players[ i ]
-		local Success, JoinSuccess, NewPlayer = xpcall( Gamerules.JoinTeam,
-			OnJoinError, Gamerules, Player, TeamNumber,
-			Player:GetTeamNumber() ~= TeamNumber, true )
+		if Player:GetTeamNumber() ~= TeamNumber then
+			local Success, JoinSuccess, NewPlayer = xpcall( Gamerules.JoinTeam,
+				OnJoinError, Gamerules, Player, TeamNumber,
+				true, true )
 
-		if Success then
-			Players[ i ] = NewPlayer
-		else
-			TableRemove( Players, i )
+			if Success then
+				Players[ i ] = NewPlayer
+			else
+				TableRemove( Players, i )
+			end
 		end
 	end
 end

--- a/lua/shine/lib/string.lua
+++ b/lua/shine/lib/string.lua
@@ -5,6 +5,7 @@
 local Floor = math.floor
 local StringFind = string.find
 local StringFormat = string.format
+local StringGSub = string.gsub
 local StringLen = string.len
 local StringSub = string.sub
 local TableConcat = table.concat
@@ -24,6 +25,31 @@ end
 ]]
 function string.StartsWith( String, Prefix )
 	return StringSub( String, 1, StringLen( Prefix ) ) == Prefix
+end
+
+do
+	local PatternReplacements = {
+		[ "(" ] = "%(",
+		[ ")" ] = "%)",
+		[ "." ] = "%.",
+		[ "%" ] = "%%",
+		[ "+" ] = "%+",
+		[ "-" ] = "%-",
+		[ "*" ] = "%*",
+		[ "?" ] = "%?",
+		[ "[" ] = "%[",
+		[ "]" ] = "%]",
+		[ "^" ] = "%^",
+		[ "$" ] = "%$",
+		[ "\0" ] = "%z"
+	}
+
+	--[[
+		Returns the given string with all Lua pattern control characters escaped.
+	]]
+	function string.PatternSafe( String )
+		return StringGSub( String, ".", PatternReplacements )
+	end
 end
 
 --[[

--- a/lua/shine/lib/table.lua
+++ b/lua/shine/lib/table.lua
@@ -590,3 +590,253 @@ do
 		return KeyValueIterator( Keys, Table )
 	end
 end
+
+do
+	local GetMetaTable = debug.getmetatable
+	local Max = math.max
+	local StringByte = string.byte
+	local StringFormat = string.format
+	local StringGSub = string.gsub
+	local StringRep = string.rep
+	local TableConcat = table.concat
+	local tostring = tostring
+	local type = type
+
+	local OBJECT_TYPE = "object"
+	local function IsTableArray( Table, MetaTable )
+		if MetaTable and MetaTable.__jsontype == OBJECT_TYPE then
+			return false
+		end
+
+		local NumberOfElements = 0
+		local ProvidedSize = Table.n or #Table
+		local MaxIndex = 0
+
+		for Key, Value in pairs( Table ) do
+			if type( Key ) ~= "number" then return false end
+			MaxIndex = Max( Key, MaxIndex )
+			NumberOfElements = NumberOfElements + 1
+		end
+
+		if MaxIndex > 10 and MaxIndex > ProvidedSize and MaxIndex > NumberOfElements * 2 then
+			-- Keep consistent behaviour with DKJSON
+			return false
+		end
+
+		return true, MaxIndex
+	end
+
+	local function NewLineIfNecessary( Buffer, FormattingOptions, IndentLevel )
+		if not FormattingOptions.PrettyPrint then return end
+
+		Buffer[ #Buffer + 1 ] = FormattingOptions.NewLineChar
+		Buffer[ #Buffer + 1 ] = StringRep( FormattingOptions.IndentChar,
+			FormattingOptions.IndentSize * IndentLevel )
+	end
+
+	local function GetLocaleSeparator()
+		return string.match( tostring( 1.5 ), "([^15+]+)" )
+	end
+	local DECIMAL_SEP = string.PatternSafe( GetLocaleSeparator() )
+	local NON_NUMBER_PATTERN = "[^0-9%-%+eE"..DECIMAL_SEP.."]"
+
+	local ToJSON
+	local ESCAPE_CHARS = {
+		[ "\"" ] = "\\\"", [ "\\" ] = "\\\\", [ "\b" ] = "\\b",
+		[ "\f" ] = "\\f", [ "\n" ] = "\\n",  [ "\r" ] = "\\r",
+		[ "\t" ] = "\\t"
+	}
+	local function ToUnicodeEscape( Value )
+		return StringFormat( "\\u%.4x", StringByte( Value ) )
+	end
+	local Writers = {
+		[ "nil" ] = function() return "null" end,
+		[ "boolean" ] = tostring,
+		[ "number" ] = function( Value )
+			return StringGSub( StringGSub( tostring( Value ), NON_NUMBER_PATTERN, "" ), DECIMAL_SEP, "." )
+		end,
+		[ "table" ] = function( Value, FormattingOptions, State )
+			return ToJSON( Value, FormattingOptions, State )
+		end,
+		[ "string" ] = function( Value )
+			-- The JSON specification states that normal unicode characters do not need to be escaped.
+			-- Thus we just escape the control characters it states are needed, plus a few extra
+			-- such as the null byte.
+			return StringFormat( "\"%s\"", StringGSub(
+				StringGSub( Value, "[\r\n\b\f\t\"\\]", ESCAPE_CHARS ),
+				"[%z\1-\31\127-\159]",
+				ToUnicodeEscape
+			) )
+		end
+	}
+	local LengthGetters = {
+		[ "nil" ] = function() return 4 end,
+		[ "boolean" ] = function( Value ) return #tostring( Value ) end,
+		[ "number" ] = function( Value ) return #Writers.number( Value ) end,
+		[ "string" ] = function( Value ) return #Writers.string( Value ) end
+	}
+
+	local function WriteValue( Value, Buffer, FormattingOptions, State )
+		local ValueType = type( Value )
+
+		local Writer = Writers[ ValueType ]
+		if not Writer then
+			error( "Unsupported value type: "..ValueType )
+		end
+
+		local Output = Writer( Value, FormattingOptions, State )
+		if Output then
+			Buffer[ #Buffer + 1 ] = Output
+		end
+	end
+
+	local function DetermineIfArrayFitsOnLine( Table, MaxIndex, FormattingOptions, State )
+		-- This doesn't account for the length of the key behind the array, but it's a good
+		-- enough approximation.
+		local Length = FormattingOptions.IndentSize * State.IndentLevel
+		local SEPARATOR_LENGTH = 2
+		for i = 1, MaxIndex do
+			local Value = Table[ i ]
+			local ValueType = type( Value )
+
+			local LengthGetter = LengthGetters[ ValueType ]
+			if not LengthGetter then
+				-- Objects in the array always look better with newlines.
+				return false
+			end
+
+			Length = Length + LengthGetter( Value ) + SEPARATOR_LENGTH
+
+			if Length > FormattingOptions.PrintMargin then
+				return false
+			end
+		end
+		return true
+	end
+
+	ToJSON = function( Table, FormattingOptions, State )
+		if State.Seen[ Table ] then
+			error( "Cycle in input table" )
+		end
+
+		State.Seen[ Table ] = true
+
+		local Buffer = State.Buffer
+		local IsArray, MaxIndex = IsTableArray( Table, GetMetaTable( Table ) )
+		local IsPrettyPrint = FormattingOptions.PrettyPrint
+
+		if IsArray then
+			Buffer[ #Buffer + 1 ] = "["
+
+			State.IndentLevel = State.IndentLevel + 1
+
+			local ShouldSeparate = false
+			if IsPrettyPrint then
+				ShouldSeparate = not DetermineIfArrayFitsOnLine( Table, MaxIndex, FormattingOptions, State )
+			end
+
+			for i = 1, MaxIndex do
+				if ShouldSeparate then
+					NewLineIfNecessary( Buffer, FormattingOptions, State.IndentLevel )
+				elseif IsPrettyPrint then
+					Buffer[ #Buffer + 1 ] = " "
+				end
+
+				WriteValue( Table[ i ], Buffer, FormattingOptions, State )
+
+				if i ~= MaxIndex then
+					Buffer[ #Buffer + 1 ] = ","
+				elseif not ShouldSeparate and IsPrettyPrint then
+					Buffer[ #Buffer + 1 ] = " "
+				end
+			end
+
+			State.IndentLevel = State.IndentLevel - 1
+
+			if MaxIndex >= 1 and ShouldSeparate then
+				NewLineIfNecessary( Buffer, FormattingOptions, State.IndentLevel )
+			end
+
+			Buffer[ #Buffer + 1 ] = "]"
+		else
+			Buffer[ #Buffer + 1 ] = "{"
+			State.IndentLevel = State.IndentLevel + 1
+
+			local WroteValues = false
+			for Key, Value in FormattingOptions.TableIterator( Table ) do
+				if WroteValues then
+					Buffer[ #Buffer + 1 ] = ","
+				end
+
+				WroteValues = true
+				NewLineIfNecessary( Buffer, FormattingOptions, State.IndentLevel )
+
+				local KeyType = type( Key )
+				if KeyType == "number" then
+					WriteValue( Key, Buffer, FormattingOptions, State )
+					Buffer[ #Buffer ] = StringFormat( "\"%s\"", Buffer[ #Buffer ] )
+				elseif KeyType == "string" then
+					WriteValue( Key, Buffer, FormattingOptions, State )
+				else
+					error( "Unsupported table key type: "..KeyType )
+				end
+
+				Buffer[ #Buffer + 1 ] = ":"
+				if FormattingOptions.PrettyPrint then
+					Buffer[ #Buffer + 1 ] = " "
+				end
+
+				WriteValue( Value, Buffer, FormattingOptions, State )
+			end
+
+			State.IndentLevel = State.IndentLevel - 1
+			if WroteValues then
+				NewLineIfNecessary( Buffer, FormattingOptions, State.IndentLevel )
+			end
+
+			Buffer[ #Buffer + 1 ] = "}"
+		end
+
+		State.Seen[ Table ] = false
+	end
+
+	local DEFAULT_OPTIONS = {
+		-- Whether to print the output in a nice, human-readable format.
+		PrettyPrint = true,
+		-- The number of times to repeat the indent character per indent level.
+		IndentSize = 4,
+		-- The indent character (ideally " " or "\t").
+		IndentChar = " ",
+		-- The new line character.
+		NewLineChar = "\n",
+		-- The iterator to use to iterate non-array tables.
+		TableIterator = SortedPairs,
+		-- Roughly how far along to allow text before wrapping arrays in pretty print mode.
+		PrintMargin = 80
+	}
+	local InheritFromDefault = { __index = DEFAULT_OPTIONS }
+
+	--[[
+		Outputs a table in JSON form, providing better formatting options than
+		DKJSON.
+
+		Unlike DKJSON, this throws any error encountered while serialising.
+	]]
+	function table.ToJSON( Table, FormattingOptions )
+		if not FormattingOptions then
+			FormattingOptions = DEFAULT_OPTIONS
+		else
+			FormattingOptions = setmetatable( FormattingOptions, InheritFromDefault )
+		end
+
+		local State = {
+			IndentLevel = 0,
+			Seen = {},
+			Buffer = {}
+		}
+
+		ToJSON( Table, FormattingOptions, State )
+
+		return TableConcat( State.Buffer )
+	end
+end

--- a/lua/shine/lib/table.lua
+++ b/lua/shine/lib/table.lua
@@ -300,6 +300,7 @@ do
 	local DebugGetInfo = debug.getinfo
 	local getmetatable = getmetatable
 	local Notify = Shared.Message
+	local pcall = pcall
 	local StringFind = string.find
 	local StringFormat = string.format
 	local StringLower = string.lower
@@ -308,6 +309,12 @@ do
 	local tonumber = tonumber
 	local tostring = tostring
 	local type = type
+
+	local function GetClassName( Value )
+		if Value.GetClassName then
+			return StringFormat( "%s (%s)", Value, Value:GetClassName() )
+		end
+	end
 
 	local DefaultPrinters = {
 		string = function( Value )
@@ -326,8 +333,10 @@ do
 				return tostring( Meta.__towatch( Value ) )
 			end
 
-			if Value.GetClassName then
-				return StringFormat( "%s (%s)", Value, Value:GetClassName() )
+			-- Some userdata may error for unknown keys.
+			local Success, Name = pcall( GetClassName, Value )
+			if Success and Name then
+				return Name
 			end
 
 			return tostring( Value )

--- a/lua/shine/modules/sh_vote.lua
+++ b/lua/shine/modules/sh_vote.lua
@@ -32,9 +32,6 @@ if Server then
 	return
 end
 
-local SGUI = Shine.GUI
-local TickTexture = PrecacheAsset( "ui/checkmark.dds" )
-
 local StringFormat = string.format
 
 function Module:ReceiveHasVoted( Message )

--- a/lua/shine/modules/sh_vote.lua
+++ b/lua/shine/modules/sh_vote.lua
@@ -48,23 +48,13 @@ function Module:UpdateVoteButton()
 
 	if self.dt.CurrentVotes == 0 or self.dt.RequiredVotes == 0 then
 		Button:SetText( Button.DefaultText )
-
-		if SGUI.IsValid( Button.CheckMark ) then
-			Button.CheckMark:Destroy()
-			Button.CheckMark = nil
-		end
+		Shine.VoteMenu:MarkAsSelected( Button, false )
 
 		return
 	end
 
-	if self.HasVoted and not SGUI.IsValid( Button.CheckMark ) then
-		local CheckMark = SGUI:Create( "Image", Button )
-		local Height = Button:GetSize().y * 0.75
-		CheckMark:SetAnchor( "CentreRight" )
-		CheckMark:SetSize( Vector2( Height, Height ) )
-		CheckMark:SetPos( Vector2( -Height, -Height * 0.5 ) )
-		CheckMark:SetTexture( TickTexture )
-		Button.CheckMark = CheckMark
+	if self.HasVoted then
+		Shine.VoteMenu:MarkAsSelected( Button, true )
 	end
 
 	-- Update the button with the current vote count.

--- a/lua/shine/modules/sh_vote.lua
+++ b/lua/shine/modules/sh_vote.lua
@@ -8,12 +8,14 @@ local Module = {}
 function Module:SetupDataTable()
 	self:AddDTVar( "integer", "CurrentVotes", 0 )
 	self:AddDTVar( "integer", "RequiredVotes", 0 )
+	self:AddNetworkMessage( "HasVoted", { HasVoted = "boolean" }, "Client" )
 end
 
 if Server then
 	function Module:ResetVoteCounters()
 		self.dt.CurrentVotes = 0
 		self.dt.RequiredVotes = 0
+		self:SendNetworkMessage( nil, "HasVoted", { HasVoted = false }, true )
 	end
 
 	function Module:UpdateVoteCounters( VoteObject )
@@ -21,12 +23,24 @@ if Server then
 		self.dt.RequiredVotes = VoteObject.VotesNeeded()
 	end
 
+	function Module:NotifyVoted( Client )
+		self:SendNetworkMessage( Client, "HasVoted", { HasVoted = true }, true )
+	end
+
 	Plugin:AddModule( Module )
 
 	return
 end
 
+local SGUI = Shine.GUI
+local TickTexture = PrecacheAsset( "ui/checkmark.dds" )
+
 local StringFormat = string.format
+
+function Module:ReceiveHasVoted( Message )
+	self.HasVoted = Message.HasVoted
+	self:UpdateVoteButton()
+end
 
 function Module:UpdateVoteButton()
 	local Button = Shine.VoteMenu:GetButtonByPlugin( self.VoteButtonName )
@@ -34,7 +48,23 @@ function Module:UpdateVoteButton()
 
 	if self.dt.CurrentVotes == 0 or self.dt.RequiredVotes == 0 then
 		Button:SetText( Button.DefaultText )
+
+		if SGUI.IsValid( Button.CheckMark ) then
+			Button.CheckMark:Destroy()
+			Button.CheckMark = nil
+		end
+
 		return
+	end
+
+	if self.HasVoted and not SGUI.IsValid( Button.CheckMark ) then
+		local CheckMark = SGUI:Create( "Image", Button )
+		local Height = Button:GetSize().y * 0.75
+		CheckMark:SetAnchor( "CentreRight" )
+		CheckMark:SetSize( Vector2( Height, Height ) )
+		CheckMark:SetPos( Vector2( -Height, -Height * 0.5 ) )
+		CheckMark:SetTexture( TickTexture )
+		Button.CheckMark = CheckMark
 	end
 
 	-- Update the button with the current vote count.

--- a/lua/shine/modules/sh_vote.lua
+++ b/lua/shine/modules/sh_vote.lua
@@ -1,0 +1,62 @@
+--[[
+	Provides vote tracking by updating a vote menu button.
+]]
+
+local Plugin = ...
+local Module = {}
+
+function Module:SetupDataTable()
+	self:AddDTVar( "integer", "CurrentVotes", 0 )
+	self:AddDTVar( "integer", "RequiredVotes", 0 )
+end
+
+if Server then
+	function Module:ResetVoteCounters()
+		self.dt.CurrentVotes = 0
+		self.dt.RequiredVotes = 0
+	end
+
+	function Module:UpdateVoteCounters( VoteObject )
+		self.dt.CurrentVotes = VoteObject:GetVotes()
+		self.dt.RequiredVotes = VoteObject.VotesNeeded()
+	end
+
+	Plugin:AddModule( Module )
+
+	return
+end
+
+local StringFormat = string.format
+
+function Module:UpdateVoteButton()
+	local Button = Shine.VoteMenu:GetButtonByPlugin( self.VoteButtonName )
+	if not Button then return end
+
+	if self.dt.CurrentVotes == 0 or self.dt.RequiredVotes == 0 then
+		Button:SetText( Button.DefaultText )
+		return
+	end
+
+	-- Update the button with the current vote count.
+	Button:SetText( StringFormat( "%s (%d/%d)", Button.DefaultText,
+		self.dt.CurrentVotes,
+		self.dt.RequiredVotes ) )
+end
+
+function Module:NetworkUpdate( Key, Old, New )
+	if Key == "RequiredVotes" or Key == "CurrentVotes" then
+		if not Shine.VoteMenu.Visible then return end
+
+		self:UpdateVoteButton()
+	end
+end
+
+function Module:OnFirstThink()
+	Shine.VoteMenu:EditPage( "Main", function( VoteMenu )
+		if not self.Enabled then return end
+
+		self:UpdateVoteButton()
+	end )
+end
+
+Plugin:AddModule( Module )

--- a/test/extensions/adverts.lua
+++ b/test/extensions/adverts.lua
@@ -1,0 +1,197 @@
+--[[
+	Adverts plugin test.
+]]
+
+local UnitTest = Shine.UnitTest
+local Adverts = UnitTest:LoadExtension( "adverts" )
+if not Adverts then return end
+
+Adverts = UnitTest.MockOf( Adverts )
+
+Adverts.Config = {
+	Templates = {
+		ChatNotification = {
+			Type = "chat",
+			Colour = { 255, 255, 255 },
+			Prefix = "[Info]",
+			PrefixColour = { 0, 200, 255 }
+		},
+		RoundStarted = {
+			Type = "chat",
+			Colour = { 255, 255, 255 },
+			Prefix = "[Hint]",
+			PrefixColour = { 0, 200, 255 },
+			GameState = "Started"
+		},
+		PreGame = {
+			Type = "chat",
+			Colour = { 255, 255, 255 },
+			Prefix = "[Hint]",
+			PrefixColour = { 0, 200, 255 },
+			GameState = { "NotStarted", "WarmUp" }
+		}
+	},
+	Adverts = {
+		{
+			Message = "This server is running the Shine administration mod.",
+			Template = "ChatNotification"
+		},
+		{
+			Message = "Did you know that Aliens bite things?",
+			Template = "RoundStarted"
+		},
+		{
+			Message = "Get ready to shoot/bite!",
+			Template = "PreGame"
+		},
+		"A string advert.",
+		{
+			-- This is invalid
+			Message = 1
+		},
+		{
+			Message = "I can't be used on any map",
+			Maps = { [ "ns2_invalid" ] = true }
+		},
+		{
+			Message = "I can't be used on the current map",
+			ExcludedMaps = { [ Shared.GetMapName() ] = true }
+		}
+	},
+	TriggeredAdverts = {
+		{
+			Message = "Get zem!",
+			Template = "RoundStarted",
+			Trigger = "START_OF_ROUND"
+		},
+		{
+			Message = "",
+			Trigger = "INVALID"
+		}
+	}
+}
+
+UnitTest:Test( "ParseAdverts parses as expected", function( Assert )
+	Adverts:ParseAdverts()
+
+	Assert:Equals( 4, #Adverts.AdvertsList )
+	local function AssertMatchesTemplate( Advert, Template )
+		for Key, Value in pairs( Template ) do
+			Assert.Equals( "Advert does not match template at key: "..Key, Value, Advert[ Key ] )
+		end
+	end
+	for i = 1, 3 do
+		local Advert = Adverts.AdvertsList[ i ]
+		AssertMatchesTemplate( Advert, Adverts.Config.Templates[ Advert.Template ] )
+	end
+	Assert.Equals( "Expected final advert to be a string", "A string advert.", Adverts.AdvertsList[ 4 ] )
+
+	Assert.DeepEquals( "Triggered advert multimap not mapped as expected", {
+		START_OF_ROUND = {
+			{
+				Message = "Get zem!",
+				Template = "RoundStarted",
+				Trigger = "START_OF_ROUND"
+			}
+		}
+	}, Adverts.TriggeredAdvertsByTrigger:AsTable() )
+	AssertMatchesTemplate( Adverts.TriggeredAdvertsByTrigger:Get( "START_OF_ROUND" )[ 1 ], Adverts.Config.Templates.RoundStarted )
+end )
+
+UnitTest:Test( "FilterAdvertListForState filters when adverts should be", function( Assert )
+	local AdvertsList = {
+		{
+			Message = "This server is running the Shine administration mod.",
+		},
+		{
+			Message = "Did you know that Aliens bite things?",
+			GameState = "Started"
+		},
+		{
+			Message = "Get ready to shoot/bite!",
+			GameState = { "NotStarted", "WarmUp" }
+		}
+	}
+
+	local Filtered, HasListChanged = Adverts:FilterAdvertListForState( AdvertsList, AdvertsList, kGameState.Started )
+	Assert.True( "Expected list to be marked as changed", HasListChanged )
+	Assert.ArrayEquals( "Expected only adverts valid for gamestate",
+		{ AdvertsList[ 1 ], AdvertsList[ 2 ] }, Filtered )
+end )
+
+UnitTest:Test( "FilterAdvertListForState produces same list when all match", function( Assert )
+	local AdvertsList = {
+		{
+			Message = "This server is running the Shine administration mod.",
+		},
+		{
+			Message = "Did you know that Aliens bite things?",
+			GameState = "Started"
+		},
+		{
+			Message = "Get ready to shoot/bite!"
+		}
+	}
+	local Filtered, HasListChanged = Adverts:FilterAdvertListForState( AdvertsList, AdvertsList, kGameState.Started )
+	Assert.False( "Expected list to not be marked as changed", HasListChanged )
+	Assert.ArrayEquals( "Expected output to be identical to input", AdvertsList, Filtered )
+end )
+
+Adverts.RequiresGameStateFiltering = false
+local Displayed = {}
+function Adverts:DisplayAdvert( Advert )
+	Displayed[ Advert ] = true
+end
+
+Adverts.TriggeredAdvertsByTrigger = Shine.Multimap( {
+	[ Adverts.AdvertTrigger.START_OF_ROUND ] = {
+		{
+			Message = "1"
+		},
+		{
+			Message = "2"
+		}
+	}
+} )
+
+UnitTest:Test( "SetGameState - Displays adverts for triggers", function( Assert )
+	Adverts:SetGameState( nil, kGameState.Started, kGameState.Countdown )
+
+	local AdvertsTriggered = Adverts.TriggeredAdvertsByTrigger:Get( Adverts.AdvertTrigger.START_OF_ROUND )
+	for i = 1, #AdvertsTriggered do
+		Assert.True( "Advert should have been triggered", Displayed[ AdvertsTriggered[ i ] ] )
+	end
+end )
+
+Adverts.RequiresGameStateFiltering = true
+Adverts.AdvertsList = {
+	{
+		Message = "1"
+	},
+	{
+		Message = "2"
+	}
+}
+Adverts.CurrentAdvertsList = Adverts.AdvertsList
+Adverts.CurrentMessageIndex = 2
+
+function Adverts:FilterAdvertListForState()
+	return self.AdvertsList, false
+end
+
+UnitTest:Test( "SetGameState - Does nothing if no triggers or filter change", function( Assert )
+	Adverts:SetGameState( nil, kGameState.Countdown, kGameState.PreGame )
+	Assert.Equals( "Advert list should not have changed", Adverts.AdvertsList, Adverts.CurrentAdvertsList )
+	Assert.Equals( "Advert index should not have changed", 2, Adverts.CurrentMessageIndex )
+end )
+
+Adverts.CurrentAdvertsList = {}
+function Adverts:FilterAdvertListForState()
+	return self.AdvertsList, true
+end
+
+UnitTest:Test( "SetGameState - Updates current advert list on filter change", function( Assert )
+	Adverts:SetGameState( nil, kGameState.Countdown, kGameState.PreGame )
+	Assert.Equals( "Advert list should have changed", Adverts.AdvertsList, Adverts.CurrentAdvertsList )
+	Assert.Equals( "Advert index should have reset", 1, Adverts.CurrentMessageIndex )
+end )

--- a/test/extensions/adverts.lua
+++ b/test/extensions/adverts.lua
@@ -67,6 +67,16 @@ Adverts.Config = {
 		{
 			Message = "",
 			Trigger = "INVALID"
+		},
+		{
+			Message = "I can't be used on any map",
+			Maps = { [ "ns2_invalid" ] = true },
+			Trigger = "START_OF_ROUND"
+		},
+		{
+			Message = "I can't be used on the current map",
+			ExcludedMaps = { [ Shared.GetMapName() ] = true },
+			Trigger = "START_OF_ROUND"
 		}
 	}
 }

--- a/test/lib/objects.lua
+++ b/test/lib/objects.lua
@@ -38,3 +38,14 @@ UnitTest:Test( "TypeDef inheritance", function( Assert )
 	local Instance = Child( false )
 	Assert:True( InitCalled )
 end )
+
+UnitTest:Test( "Implements", function( Assert )
+	local Base = Shine.TypeDef()
+	Base.Init = function( self ) return self end
+
+	local Child = Shine.TypeDef( Base )
+	local Value = Child()
+
+	Assert.True( "Object should implement its metatable", Shine.Implements( Value, Child ) )
+	Assert.True( "Object should implement the parent metatable", Shine.Implements( Value, Base ) )
+end )

--- a/test/lib/string.lua
+++ b/test/lib/string.lua
@@ -14,6 +14,12 @@ UnitTest:Test( "EndsWith", function( Assert )
 	Assert:False( string.EndsWith( "Test", "abc" ) )
 end )
 
+UnitTest:Test( "PatternSafe", function( Assert )
+	local Pattern = string.PatternSafe( ".*+-?()[]%^$\0" )
+	Assert.Equals( "Pattern should be escaped", "%.%*%+%-%?%(%)%[%]%%%^%$%z", Pattern )
+	Assert.True( "Should be able to search without error", pcall( string.find, ".*+-?()[]%^$", Pattern ) )
+end )
+
 do
 	local InterpolationTests = {
 		{

--- a/test/test_init.lua
+++ b/test/test_init.lua
@@ -12,12 +12,14 @@ UnitTest.Results = {}
 local assert = assert
 local DebugTraceback = debug.traceback
 local getmetatable = getmetatable
+local pairs = pairs
 local pcall = pcall
 local select = select
 local setmetatable = setmetatable
 local StringExplode = string.Explode
 local StringFormat = string.format
 local TableConcat = table.concat
+local type = type
 local xpcall = xpcall
 
 local IsType = Shine.IsType
@@ -139,6 +141,23 @@ do
 	end
 end
 
+local function DeepEquals( Table1, Table2 )
+	if type( Table1 ) ~= type( Table2 ) then return false end
+	if type( Table1 ) ~= "table" then return Table1 == Table2 end
+
+	for Key, Value in pairs( Table1 ) do
+		local Table2Val = Table2[ Key ]
+		if not DeepEquals( Value, Table2Val ) then return false end
+	end
+
+	for Key, Value in pairs( Table2 ) do
+		local Table1Val = Table1[ Key ]
+		if not DeepEquals( Value, Table1Val ) then return false end
+	end
+
+	return true
+end
+
 UnitTest.Assert = {
 	Equals = function( A, B ) return A == B end,
 	NotEquals = function( A, B ) return A ~= B end,
@@ -154,6 +173,8 @@ UnitTest.Assert = {
 
 		return true
 	end,
+
+	DeepEquals = DeepEquals,
 
 	True = function( A ) return A == true end,
 	Truthy = function( A ) return A end,


### PR DESCRIPTION
### Adverts
* Adverts can now use templates to avoid repeating colours in messages.
* Adverts can now have a coloured prefix.
* Adverts can now be triggered on certain events, such as a round starting, as well as having a cycle.
* Adverts may be filtered by map/game state.

### Vote Menu
* When voting, buttons will show a tick on the button if you have already voted.
* The "Map Vote" button now displays a counter for the current number of votes to change the map.

### Config
* Fixed web configs not properly validating/migrating data.
* Added a recursive config check option for plugins, which checks all values in the default config except arrays and explicitly ignored tables using `Shine.IgnoreWhenChecking()`.
* Added `OnWebConfigReloaded` event for plugins.
* Improved the output format of configs when they are updated to make it more readable.