### PR TITLE
Improve AFK Kick config and unstuck behaviour

### DIFF
--- a/locale/shine/extensions/unstuck/enGB.json
+++ b/locale/shine/extensions/unstuck/enGB.json
@@ -2,6 +2,10 @@
 	"ERROR_NOT_ALIVE": "You cannot be unstuck when you are dead.",
 	"ERROR_WAIT": "You must wait {TimeLeft:Duration} before using unstuck again.",
 	"SUCCESS": "Successfully unstuck.",
+	"UNSTICKING": "You will be unstuck in {TimeLeft:Duration}...",
 	"ERROR_FAIL": "Unable to unstick. Try again in {TimeLeft:Duration}.",
+	"ERROR_MOVED": "You cannot be unstuck when moving.",
+	"ERROR_IN_PROGRESS": "You have already requested to be unstuck.",
+	"ERROR_NOT_APPLICABLE": "You cannot be unstuck as a spectator.",
 	"NOTIFY_PREFIX": "[Unstuck]"
 }

--- a/locale/shine/extensions/unstuck/enGB.json
+++ b/locale/shine/extensions/unstuck/enGB.json
@@ -4,7 +4,7 @@
 	"SUCCESS": "Successfully unstuck.",
 	"UNSTICKING": "You will be unstuck in {TimeLeft:Duration}...",
 	"ERROR_FAIL": "Unable to unstick. Try again in {TimeLeft:Duration}.",
-	"ERROR_MOVED": "You cannot be unstuck when moving.",
+	"ERROR_MOVED": "You cannot be unstuck when you are moving.",
 	"ERROR_IN_PROGRESS": "You have already requested to be unstuck.",
 	"ERROR_NOT_APPLICABLE": "You cannot be unstuck as a spectator.",
 	"NOTIFY_PREFIX": "[Unstuck]"

--- a/lua/shine/extensions/unstuck/server.lua
+++ b/lua/shine/extensions/unstuck/server.lua
@@ -7,15 +7,20 @@ local Shine = Shine
 local Ceil = math.ceil
 
 local Plugin = Plugin
-Plugin.Version = "1.0"
+Plugin.Version = "1.1"
 
 Plugin.HasConfig = true
 Plugin.ConfigName = "Unstuck.json"
 
 Plugin.DefaultConfig = {
+	-- The distance around the player to check for a valid location.
 	DistanceToCheck = 6,
+	-- The time between successful unstick requests (in seconds).
 	TimeBetweenUse = 30,
-	MinTime = 5
+	-- The minimum time to wait between unstick requests (in seconds).
+	MinTime = 5,
+	-- How long to wait before moving a player (forces them to be stationary for this time).
+	DelayBeforeMovingInSeconds = 0
 }
 
 Plugin.CheckConfig = true
@@ -24,11 +29,56 @@ Plugin.CheckConfigTypes = true
 Plugin.PrintName = "Unstuck"
 
 function Plugin:Initialise()
-	self.Users = {}
+	self.NextUsageTimes = {}
+	self.ClientsBeingUnstuck = {}
 
 	self:CreateCommands()
 
 	self.Enabled = true
+
+	return true
+end
+
+local function IsInEntityBounds( Entity, Origin )
+	local Extents = Entity:GetExtents()
+	local Coords = Entity:GetCoords()
+
+	local LocalOrigin = Coords:GetInverse():TransformPoint( Origin )
+	local Mins, Maxs = -Extents, Extents
+
+	return LocalOrigin.x > Mins.x and LocalOrigin.y > Mins.y and LocalOrigin.z > Mins.z
+		and LocalOrigin.x < Maxs.x and LocalOrigin.y < Maxs.y and LocalOrigin.z < Maxs.z
+end
+
+local function IsPlayerContainedIn( ClassName, PlayerOrigin, DistanceToCheck )
+	local Entities = GetEntitiesWithinRange( ClassName, PlayerOrigin, DistanceToCheck )
+
+	for i = 1, #Entities do
+		local Entity = Entities[ i ]
+		if IsInEntityBounds( Entity, PlayerOrigin ) then
+			return true
+		end
+	end
+
+	return false
+end
+
+-- A list of class names of objects that should not permit unsticking
+-- when a player is in their (oriented) bounding box.
+Plugin.BlockingClassNames = {
+	"BoneWall"
+}
+
+function Plugin:ShouldPlayerBeUnstuck( Player )
+	local PlayerOrigin = Player:GetOrigin()
+	local DistanceToCheck = self.Config.DistanceToCheck
+
+	for i = 1, #self.BlockingClassNames do
+		local ClassName = self.BlockingClassNames[ i ]
+		if IsPlayerContainedIn( ClassName, PlayerOrigin, DistanceToCheck ) then
+			return false
+		end
+	end
 
 	return true
 end
@@ -38,6 +88,11 @@ function Plugin:UnstickPlayer( Player, Pos )
 	if Player:GetTeamNumber() == kTeamReadyRoom then
 		GetGamerules():JoinTeam( Player, kTeamReadyRoom, true )
 		return true
+	end
+
+	-- Make sure the player isn't inside something that's supposed to block them.
+	if not self:ShouldPlayerBeUnstuck( Player ) then
+		return false
 	end
 
 	local TechID = kTechId.Skulk
@@ -81,38 +136,77 @@ function Plugin:CreateCommands()
 	local function Unstick( Client )
 		if not Client then return end
 
+		if self.ClientsBeingUnstuck[ Client ] then
+			self:NotifyTranslatedError( Client, "ERROR_IN_PROGRESS" )
+			return
+		end
+
 		local Player = Client:GetControllingPlayer()
 		if not Player then return end
 
+		if Player:isa( "Spectator" ) then
+			self:NotifyTranslatedError( Client, "ERROR_NOT_APPLICABLE" )
+			return
+		end
+
 		if not Player:GetIsAlive() then
 			self:NotifyTranslatedError( Client, "ERROR_NOT_ALIVE" )
-
 			return
 		end
 
 		local Time = Shared.GetTime()
 
-		local NextUse = self.Users[ Client ]
+		local NextUse = self.NextUsageTimes[ Client ]
 		if NextUse and NextUse > Time then
 			self:SendTranslatedError( Client, "ERROR_WAIT", {
 				TimeLeft = Ceil( NextUse - Time )
 			} )
-
 			return
 		end
 
-		local Success = self:UnstickPlayer( Player, Player:GetOrigin() )
+		local InitialOrigin = Player:GetOrigin()
+		local function UnstickPlayer()
+			self.ClientsBeingUnstuck[ Client ] = nil
 
-		if Success then
-			self:NotifyTranslated( Client, "SUCCESS" )
+			if not Shine:IsValidClient( Client ) then return end
+			if Player ~= Client:GetControllingPlayer() then return end
 
-			self.Users[ Client ] = Time + self.Config.TimeBetweenUse
-		else
-			self:SendTranslatedError( Client, "ERROR_FAIL", {
-				TimeLeft = Ceil( self.Config.MinTime )
+			if not Player:GetIsAlive() then
+				self:NotifyTranslatedError( Client, "ERROR_NOT_ALIVE" )
+				return
+			end
+
+			local CurrentOrigin = Player:GetOrigin()
+			if CurrentOrigin ~= InitialOrigin then
+				self:NotifyTranslatedError( Client, "ERROR_MOVED" )
+				return
+			end
+
+			local Success = self:UnstickPlayer( Player, CurrentOrigin )
+
+			if Success then
+				self:NotifyTranslated( Client, "SUCCESS" )
+
+				self.NextUsageTimes[ Client ] = Time + self.Config.TimeBetweenUse
+			else
+				self:SendTranslatedError( Client, "ERROR_FAIL", {
+					TimeLeft = Ceil( self.Config.MinTime )
+				} )
+
+				self.NextUsageTimes[ Client ] = Time + self.Config.MinTime
+			end
+		end
+
+		-- There's no point delaying unsticking for those in the ready room.
+		if self.Config.DelayBeforeMovingInSeconds > 0 and Player:GetTeamNumber() ~= kTeamReadyRoom then
+			self.ClientsBeingUnstuck[ Client ] = true
+
+			self:SendTranslatedNotify( Client, "UNSTICKING", {
+				TimeLeft = self.Config.DelayBeforeMovingInSeconds
 			} )
-
-			self.Users[ Client ] = Time + self.Config.MinTime
+			self:SimpleTimer( self.Config.DelayBeforeMovingInSeconds, UnstickPlayer )
+		else
+			UnstickPlayer()
 		end
 	end
 	local UnstickCommand = self:BindCommand( "sh_unstuck", { "unstuck", "stuck" }, Unstick, true )

--- a/lua/shine/extensions/unstuck/shared.lua
+++ b/lua/shine/extensions/unstuck/shared.lua
@@ -19,6 +19,7 @@ function Plugin:SetupDataTable()
 			"ERROR_WAIT", "ERROR_FAIL"
 		}
 	} )
+	self:AddTranslatedNotify( "UNSTICKING", MessageTypes.TimeLeft )
 end
 
 Shine:RegisterExtension( "unstuck", Plugin )


### PR DESCRIPTION
#### AFK Kick
* Time resetting behaviour can now be configured to one of 3 modes:
  * `STRICT` - the existing mode, where time is only reduced with activity, not reset.
  * `LENIENT_FOR_SPECTATORS` - equivalent to the old `LenientModeForSpectators` option, resets time for spectator activity, but still applies strict tracking to non-spectators.
  * `LENIENT` - resets time for any player activity.

#### Unstuck
* The plugin will no longer unstick players that are trapped in bone walls.
* Added the `DelayBeforeMovingInSeconds` option, which allows for enforcing a delay between a player using the unstuck command and them being moved. If the player moves between this delay they will not be unstuck.