### PR TITLE
Reserved slot, vanilla vote control and datatable improvements

### DIFF
--- a/lua/shine/core/server/permissions.lua
+++ b/lua/shine/core/server/permissions.lua
@@ -1094,7 +1094,7 @@ function Shine:IsInGroup( Client, Group )
 	return StringLower( Group ) == "guest"
 end
 
---Deny vote kicks on players that are above in immunity level.
+-- Deny vote kicks on players that are above in immunity level.
 Shine.Hook.Add( "NS2StartVote", "ImmunityCheck", function( VoteName, Client, Data )
 	if VoteName ~= "VoteKickPlayer" then return end
 
@@ -1105,7 +1105,11 @@ Shine.Hook.Add( "NS2StartVote", "ImmunityCheck", function( VoteName, Client, Dat
 	if not TargetClient then return end
 
 	if not Shine:CanTarget( Client, TargetClient ) then
-		return false
+		Shine:SendTranslatedCommandError( Client, "ERROR_CANT_TARGET", {
+			PlayerName = TargetClient:GetControllingPlayer():GetName()
+		}, nil, false )
+
+		return false, false
 	end
 end )
 

--- a/lua/shine/core/shared/commands.lua
+++ b/lua/shine/core/shared/commands.lua
@@ -38,8 +38,12 @@ do
 	end
 
 	if Server then
-		function Shine:SendTranslatedCommandError( Client, Name, Data, Source )
-			Data.IsConsole = not self:IsCommandFromChat()
+		function Shine:SendTranslatedCommandError( Client, Name, Data, Source, ToConsole )
+			if ToConsole ~= nil then
+				Data.IsConsole = ToConsole
+			else
+				Data.IsConsole = not self:IsCommandFromChat()
+			end
 			self:ApplyNetworkMessage( Client, GetNetworkMessageName( Name, Source ), Data, true )
 		end
 	end

--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -653,10 +653,13 @@ Add( "Think", "ReplaceMethods", function()
 	local OldStartVote = StartVote
 	if OldStartVote then
 		StartVote = function( VoteName, Client, Data )
-			if Call( "NS2StartVote", VoteName, Client, Data ) == false then
-				Shine.SendNetworkMessage( Client, "VoteCannotStart", {
-					reason = kVoteCannotStartReason.DisabledByAdmin
-				}, true )
+			local Allowed, Reason = Call( "NS2StartVote", VoteName, Client, Data )
+			if Allowed == false then
+				if Reason == nil or IsType( Reason, "number" ) then
+					Shine.SendNetworkMessage( Client, "VoteCannotStart", {
+						reason = Reason or kVoteCannotStartReason.DisabledByAdmin
+					}, true )
+				end
 
 				return
 			end

--- a/lua/shine/extensions/mapvote/voting.lua
+++ b/lua/shine/extensions/mapvote/voting.lua
@@ -117,7 +117,7 @@ function Plugin:NS2StartVote( VoteName, Client, Data )
 	if not self:IsEndVote() and not self.CyclingMap then return end
 
 	if self.BlockedEndOfMapVotes[ VoteName ] then
-		return false
+		return false, kVoteCannotStartReason.Waiting
 	end
 end
 

--- a/lua/shine/extensions/mapvote/voting.lua
+++ b/lua/shine/extensions/mapvote/voting.lua
@@ -104,6 +104,23 @@ function Plugin:OnVoteStart( ID )
 	end
 end
 
+-- Block these votes when the end of map vote is running.
+Plugin.BlockedEndOfMapVotes = {
+	VoteResetGame = true,
+	VoteRandomizeRR = true,
+	VotingForceEvenTeams = true,
+	VoteChangeMap = true,
+	VoteAddCommanderBots = true
+}
+
+function Plugin:NS2StartVote( VoteName, Client, Data )
+	if not self:IsEndVote() and not self.CyclingMap then return end
+
+	if self.BlockedEndOfMapVotes[ VoteName ] then
+		return false
+	end
+end
+
 function Plugin:GetVoteConstraint( Category, Type, PercentageTotal )
 	local Constraint = self.Config.Constraints[ Category ][ Type ]
 	if StringUpper( Constraint.Type ) == self.ConstraintType.PERCENT then

--- a/lua/shine/extensions/reservedslots.lua
+++ b/lua/shine/extensions/reservedslots.lua
@@ -7,33 +7,45 @@
 local Shine = Shine
 
 local Floor = math.floor
+local GetNumClientsTotal = Server.GetNumClientsTotal
 local GetNumPlayersTotal = Server.GetNumPlayersTotal
 local GetMaxPlayers = Server.GetMaxPlayers
+local GetMaxSpectators = Server.GetMaxSpectators
 local Max = math.max
 local tonumber = tonumber
 
 local Plugin = {}
-Plugin.Version = "2.1"
+Plugin.Version = "2.2"
 
 Plugin.HasConfig = true
 Plugin.ConfigName = "ReservedSlots.json"
+
+Plugin.SlotType = table.AsEnum{
+	"PLAYABLE", "ALL"
+}
 
 Plugin.DefaultConfig = {
 	-- How many slots?
 	Slots = 2,
 	-- Should a player with reserved access use up a slot straight away?
-	TakeSlotInstantly = true
+	TakeSlotInstantly = true,
+	-- Which type(s) of slot should be reserved?
+	SlotType = Plugin.SlotType.PLAYABLE
 }
 
 Plugin.CheckConfig = true
 Plugin.CheckConfigTypes = true
 
+do
+	local Validator = Shine.Validator()
+	Validator:AddFieldRule( "SlotType",
+		Validator.InEnum( Plugin.SlotType, Plugin.SlotType.PLAYABLE ) )
+	Plugin.ConfigValidator = Validator
+end
+
 function Plugin:Initialise()
 	self.Config.Slots = Max( Floor( tonumber( self.Config.Slots ) or 0 ), 0 )
-
-	if self.Config.Slots > 0 then
-		self:SetReservedSlotCount( self:GetFreeReservedSlots() )
-	end
+	self:SetReservedSlotCount( self:GetFreeReservedSlots() )
 
 	self:CreateCommands()
 	self.Enabled = true
@@ -59,14 +71,24 @@ function Plugin:CreateCommands()
 	SetSlotCommand:Help( "Sets the number of reserved slots." )
 end
 
+function Plugin:GetNumOccupiedReservedSlots()
+	local _, Count = Shine:GetClientsWithAccess( "sh_reservedslot" )
+	return Count
+end
+
 function Plugin:GetFreeReservedSlots()
+	-- If considering all slots, then the reserved slot count is offset by the
+	-- number of spectator slots to produce the number of reserved playable slots.
+	local Offset = self.Config.SlotType == self.SlotType.ALL
+		and self:GetMaxSpectatorSlots() or 0
+
 	local Slots = self.Config.Slots
 	if not self.Config.TakeSlotInstantly then
-		return Slots
+		return Max( Slots - Offset, 0 )
 	end
 
-	local _, Count = Shine:GetClientsWithAccess( "sh_reservedslot" )
-	return Max( Slots - Count, 0 )
+	local Count = self:GetNumOccupiedReservedSlots()
+	return Max( Slots - Count - Offset, 0 )
 end
 
 --[[
@@ -81,8 +103,16 @@ function Plugin:GetRealPlayerCount()
 	return GetNumPlayersTotal() - 1
 end
 
+function Plugin:GetRealClientCount()
+	return GetNumClientsTotal() - 1
+end
+
 function Plugin:GetMaxPlayers()
 	return GetMaxPlayers()
+end
+
+function Plugin:GetMaxSpectatorSlots()
+	return GetMaxSpectators()
 end
 
 function Plugin:HasReservedSlotAccess( Client )
@@ -100,44 +130,87 @@ end
 function Plugin:ClientDisconnect( Client )
 	if not self.Config.TakeSlotInstantly then return end
 
-	if self.Config.Slots > 0 and self:HasReservedSlotAccess( Client ) then
+	if self:HasReservedSlotAccess( Client ) then
 		self:SetReservedSlotCount( self:GetFreeReservedSlots() )
 	end
 end
+
+Plugin.ConnectionHandlers = {
+	-- Consumes playable slots only. Spectator slots are handled entirely by the default handler.
+	[ Plugin.SlotType.PLAYABLE ] = function( self, ID )
+		local NumPlayers = self:GetRealPlayerCount()
+		local MaxPlayers = self:GetMaxPlayers()
+
+		local Slots = self.Config.Slots
+
+		-- Deduct reserved slot users from the number of reserved slots empty.
+		if self.Config.TakeSlotInstantly then
+			Slots = self:GetFreeReservedSlots()
+			self:SetReservedSlotCount( Slots )
+		end
+
+		-- Allow if there's less players than public slots.
+		if NumPlayers < MaxPlayers - Slots then
+			return true
+		end
+
+		-- Allow if they have reserved access and we're not full.
+		if NumPlayers < MaxPlayers and self:HasReservedSlotAccess( ID ) then
+			return true
+		end
+
+		-- Here either they have reserved slot access but the server is full,
+		-- or they don't have reserved slot access and there's no free public slots.
+		-- Thus, fall through to the default NS2 behaviour which handles spectator slots.
+	end,
+	-- Consumes all slots, spectator slots will be blocked if they are reserved.
+	[ Plugin.SlotType.ALL ] = function( self, ID )
+		local NumClients = self:GetRealClientCount()
+		local MaxClients = self:GetMaxPlayers() + self:GetMaxSpectatorSlots()
+
+		local Slots = self.Config.Slots
+
+		-- Deduct reserved slot users from the number of reserved slots empty.
+		if self.Config.TakeSlotInstantly then
+			self:SetReservedSlotCount( self:GetFreeReservedSlots() )
+			-- The reserved slot count only applies to playable slots, this includes
+			-- spectator slots.
+			Slots = Max( Slots - self:GetNumOccupiedReservedSlots(), 0 )
+		end
+
+		-- If only spectator slots are free, then the default handler needs to run
+		-- to assign them to a spectator slot properly.
+		local ALLOWED
+		local ShouldFallThrough = self:GetRealPlayerCount() >= self:GetMaxPlayers()
+		if not ShouldFallThrough then
+			ALLOWED = true
+		end
+
+		-- Allow if all slots have not yet been filled.
+		if NumClients < MaxClients - Slots then
+			return ALLOWED
+		end
+
+		-- Allow if they have reserved access and we're not full.
+		if NumClients < MaxClients and self:HasReservedSlotAccess( ID ) then
+			return ALLOWED
+		end
+
+		-- Deny entirely if the server is completely full or they have no
+		-- reserved slot access and only reserved slots are left.
+		return false, "Server is currently full."
+	end
+}
 
 --[[
 	Checks the given NS2ID to see if it has reserved slot access.
 
 	If they do, or if the server has enough free non-reserved slots, they are allowed in.
-	Otherwise NS2/another listener decides what happens to them.
+	If the client will be assigned to a spectator slot, then this will defer to the default
+	handler.
 ]]
 function Plugin:CheckConnectionAllowed( ID )
-	ID = tonumber( ID )
-
-	local NumPlayers = self:GetRealPlayerCount()
-	local MaxPlayers = self:GetMaxPlayers()
-
-	local Slots = self.Config.Slots
-
-	-- Deduct reserved slot users from the number of reserved slots empty.
-	if self.Config.TakeSlotInstantly then
-		Slots = self:GetFreeReservedSlots()
-		self:SetReservedSlotCount( Slots )
-	end
-
-	-- Allow if there's less players than public slots.
-	if NumPlayers < MaxPlayers - Slots then
-		return true
-	end
-
-	-- Allow if they have reserved access and we're not full.
-	if NumPlayers < MaxPlayers and self:HasReservedSlotAccess( ID ) then
-		return true
-	end
-
-	-- Here either they have reserved slot access but the server is full,
-	-- or they don't have reserved slot access and there's no free public slots.
-	-- Thus, fall through to the default NS2 behaviour which handles spectator slots.
+	return self.ConnectionHandlers[ self.Config.SlotType ]( self, tonumber( ID ) )
 end
 
 Shine:RegisterExtension( "reservedslots", Plugin )

--- a/lua/shine/lib/datatables.lua
+++ b/lua/shine/lib/datatables.lua
@@ -47,18 +47,18 @@ function DataTableMeta:__SetChangeCallback( Table, Func )
 end
 
 if Server then
+	local getmetatable = getmetatable
+	local StringFormat = string.format
+
+	-- These are the same, but doing it this way makes it more future proof.
+	local AngleMeta = getmetatable( Angles() )
+	local VectorMeta = getmetatable( Vector() )
+
 	local TypeCheckers = {
-		string = function( Value )
-			return type( Value ) == "string" and Value or nil
+		angle = tonumber,
+		angles = function( Value )
+			return getmetatable( Value ) == AngleMeta and Value:isa( "Angles" ) and Value or nil
 		end,
-		integer = function( Value )
-			Value = tonumber( Value )
-
-			if not Value then return nil end
-
-			return Floor( Value )
-		end,
-		float = tonumber,
 		boolean = function( Value )
 			if type( Value ) == "boolean" then
 				return Value
@@ -68,14 +68,24 @@ if Server then
 		end,
 		entityid = tonumber,
 		enum = tonumber,
+		float = tonumber,
+		integer = function( Value )
+			Value = tonumber( Value )
+
+			if not Value then return nil end
+
+			return Floor( Value )
+		end,
+		resource = tonumber,
+		string = function( Value )
+			return type( Value ) == "string" and Value or nil
+		end,
+		time = tonumber,
 		vector = function( Value )
-			return Value.isa and Value:isa( "Vector" ) and Value or nil
-		end,
-		angle = function( Value )
-			return Value.isa and Value:isa( "Angles" ) and Value or nil
-		end,
-		time = tonumber
+			return getmetatable( Value ) == VectorMeta and Value:isa( "Vector" ) and Value or nil
+		end
 	}
+	TypeCheckers.position = TypeCheckers.vector
 
 	local function TypeCheck( Type, Value )
 		return TypeCheckers[ Type ]( Value )
@@ -86,7 +96,10 @@ if Server then
 		if Cached == nil or Cached == Value then return end
 
 		Value = TypeCheck( self.__Values[ Key ], Value )
-		if Value == nil then return end
+		if Value == nil then
+			error( StringFormat( "Invalid value provided for datatable field %s (expected %s, got %s)",
+				Key, self.__Values[ Key ], type( Value ) ), 2 )
+		end
 
 		RealData[ self ][ Key ] = Value
 

--- a/lua/shine/lib/datatables.lua
+++ b/lua/shine/lib/datatables.lua
@@ -92,18 +92,21 @@ if Server then
 	end
 
 	function DataTableMeta:__newindex( Key, Value )
-		local Cached = RealData[ self ][ Key ]
-		if Cached == nil or Cached == Value then return end
+		local FieldType = self.__Values[ Key ]
+		if not FieldType then return end
 
-		Value = TypeCheck( self.__Values[ Key ], Value )
-		if Value == nil then
+		local Cached = RealData[ self ][ Key ]
+		if Cached == Value then return end
+
+		local CoercedValue = TypeCheck( FieldType, Value )
+		if CoercedValue == nil then
 			error( StringFormat( "Invalid value provided for datatable field %s (expected %s, got %s)",
-				Key, self.__Values[ Key ], type( Value ) ), 2 )
+				Key, FieldType, type( Value ) ), 2 )
 		end
 
-		RealData[ self ][ Key ] = Value
+		RealData[ self ][ Key ] = CoercedValue
 
-		self:__SendChange( Key, Value )
+		self:__SendChange( Key, CoercedValue )
 	end
 
 	function DataTableMeta:__SendChange( Key, Value )

--- a/test/extensions/reservedslots.lua
+++ b/test/extensions/reservedslots.lua
@@ -11,6 +11,7 @@ local MockPlugin = UnitTest.MockOf( Plugin )
 
 MockPlugin.Config.TakeSlotInstantly = false
 MockPlugin.Config.Slots = 2
+MockPlugin.Config.SlotType = MockPlugin.SlotType.PLAYABLE
 
 local REAL_SLOT_COUNT = 2
 MockPlugin.SetReservedSlotCount = function( self, NumSlots ) REAL_SLOT_COUNT = NumSlots end
@@ -18,10 +19,12 @@ MockPlugin.SetReservedSlotCount = function( self, NumSlots ) REAL_SLOT_COUNT = N
 local MAX_PLAYERS = 10
 local PLAYER_COUNT = 1
 local HAS_RESERVED_ACCESS = false
+local OCCUPIED_RESERVED_SLOTS = 0
 
 MockPlugin.HasReservedSlotAccess = function() return HAS_RESERVED_ACCESS end
 MockPlugin.GetMaxPlayers = function() return MAX_PLAYERS end
 MockPlugin.GetRealPlayerCount = function() return PLAYER_COUNT end
+MockPlugin.GetNumOccupiedReservedSlots = function() return OCCUPIED_RESERVED_SLOTS end
 
 UnitTest:Test( "CheckConnectionAllowed - Free public slots allows always", function( Assert )
 	-- 10 max, 1 connected, allowed regardless of reserved slot access.
@@ -29,38 +32,112 @@ UnitTest:Test( "CheckConnectionAllowed - Free public slots allows always", funct
 	Assert:Equals( 2, REAL_SLOT_COUNT )
 end )
 
+PLAYER_COUNT = 8
 UnitTest:Test( "CheckConnectionAllowed - No free public slots and no access abstains", function( Assert )
-	PLAYER_COUNT = 8
 	-- 10 max, 8 connected, 2 reserved slots, so do not allow (let NS2 decide).
 	Assert:Nil( MockPlugin:CheckConnectionAllowed( 1 ) )
 	Assert:Equals( 2, REAL_SLOT_COUNT )
 end )
 
+HAS_RESERVED_ACCESS = true
 UnitTest:Test( "CheckConnectionAllowed - No free public slots allows with access and not full", function( Assert )
-	HAS_RESERVED_ACCESS = true
 	-- 10 max, 8 connected, 2 reserved slots, has reserved slot access, so allow.
 	Assert:True( MockPlugin:CheckConnectionAllowed( 1 ) )
 	Assert:Equals( 2, REAL_SLOT_COUNT )
 end )
 
+PLAYER_COUNT = MAX_PLAYERS
 UnitTest:Test( "CheckConnectionAllowed - Full server abstains even with access", function( Assert )
-	PLAYER_COUNT = MAX_PLAYERS
 	-- 10 max, 10 connected, 2 reserved slots, has reserved slot access, so do not allow as the server is full
 	-- (let NS2 decide/handle spectator slots)
 	Assert:Nil( MockPlugin:CheckConnectionAllowed( 1 ) )
 	Assert:Equals( 2, REAL_SLOT_COUNT )
 end )
 
-MockPlugin.GetFreeReservedSlots = function() return 1 end
+OCCUPIED_RESERVED_SLOTS = 1
+PLAYER_COUNT = 8
+HAS_RESERVED_ACCESS = false
 MockPlugin.Config.TakeSlotInstantly = true
 
 UnitTest:Test( "CheckConnectionAllowed - Updates slot count with TakeSlotInstantly", function( Assert )
-	PLAYER_COUNT = 8
-	HAS_RESERVED_ACCESS = false
-
 	-- 10 max, 8 connected.
 	-- Should allow, as the slots will update to just 1 free slot (from GetFreeReservedSlots)
 	-- and thus the public slot count is 9.
+	Assert:True( MockPlugin:CheckConnectionAllowed( 1 ) )
+	Assert:Equals( 1, REAL_SLOT_COUNT )
+end )
+
+MockPlugin.Config.SlotType = MockPlugin.SlotType.ALL
+REAL_SLOT_COUNT = 0
+OCCUPIED_RESERVED_SLOTS = 0
+
+HAS_RESERVED_ACCESS = false
+
+local CLIENT_COUNT = 1
+local MAX_SPECTATORS = 10
+MockPlugin.GetRealClientCount = function() return CLIENT_COUNT end
+MockPlugin.GetMaxSpectatorSlots = function() return MAX_SPECTATORS end
+
+PLAYER_COUNT = 1
+UnitTest:Test( "CheckConnectionAllowed - ALL: Free public slot allows", function( Assert )
+	-- 10 max, 1 connected, allowed regardless of reserved slot access.
+	Assert:True( MockPlugin:CheckConnectionAllowed( 1 ) )
+	Assert:Equals( 0, REAL_SLOT_COUNT )
+end )
+
+PLAYER_COUNT = 10
+CLIENT_COUNT = 10
+UnitTest:Test( "CheckConnectionAllowed - ALL: Free spectator slot allows", function( Assert )
+	-- 10/10 players, 10 max spectators, 0 spectators, 0 occupied slots
+	-- Should fall through to assign to a spectator slot.
+	Assert:Nil( MockPlugin:CheckConnectionAllowed( 1 ) )
+	Assert:Equals( 0, REAL_SLOT_COUNT )
+end )
+
+CLIENT_COUNT = 18
+UnitTest:Test( "CheckConnectionAllowed - ALL: No free unreserved spectator slots denies", function( Assert )
+	-- 10/10 players, 8/10 spectators, only reserved slots remaining.
+	-- Should deny as no public slots are left.
+	Assert:False( MockPlugin:CheckConnectionAllowed( 1 ) )
+	Assert:Equals( 0, REAL_SLOT_COUNT )
+end )
+
+HAS_RESERVED_ACCESS = true
+UnitTest:Test( "CheckConnectionAllowed - ALL: No free unreserved spectator slots allows with access", function( Assert )
+	-- 10/10 players, 8/10 spectators, only reserved slots remaining but has access.
+	-- Should fall through to assign to a spectator slot.
+	Assert:Nil( MockPlugin:CheckConnectionAllowed( 1 ) )
+	Assert:Equals( 0, REAL_SLOT_COUNT )
+end )
+
+CLIENT_COUNT = 20
+UnitTest:Test( "CheckConnectionAllowed - ALL: No free slots at all denies", function( Assert )
+	-- 10/10 players, 10/10 spectators, no slots remaining.
+	-- Should deny as no slots are left.
+	Assert:False( MockPlugin:CheckConnectionAllowed( 1 ) )
+	Assert:Equals( 0, REAL_SLOT_COUNT )
+end )
+
+OCCUPIED_RESERVED_SLOTS = 1
+CLIENT_COUNT = 18
+HAS_RESERVED_ACCESS = false
+
+UnitTest:Test( "CheckConnectionAllowed - ALL: Updates slot count with TakeSlotInstantly", function( Assert )
+	-- 10 max spectators, 8 connected.
+	-- Should fall through, as one of the reserved spectator slots is counted as occupied already
+	-- and thus the public spectator slot count is 9.
+	Assert:Nil( MockPlugin:CheckConnectionAllowed( 1 ) )
+	Assert:Equals( 0, REAL_SLOT_COUNT )
+end )
+
+MockPlugin.Config.Slots = MAX_SPECTATORS + 2
+PLAYER_COUNT = 8
+CLIENT_COUNT = 8
+
+UnitTest:Test( "CheckConnectionAllowed - ALL: Updates slot count when reserved includes playable + spectator", function( Assert )
+	-- 8/10 players, all spectator slots reserved + 2 playable slots reserved.
+	-- 1 player has consumed a reserved slot already, and thus there are in fact
+	-- 9 public player slots, so this should be allowed.
 	Assert:True( MockPlugin:CheckConnectionAllowed( 1 ) )
 	Assert:Equals( 1, REAL_SLOT_COUNT )
 end )


### PR DESCRIPTION
#### Reserved Slots
* Added new `SlotType` option. Can be either:
  * `PLAYABLE` - the existing behaviour.
  * `ALL` - treats all slots as a single max player limit, including spectator slots. This allows for reserving spectator slots.

#### Map Vote
* The end of map vote now blocks vanilla votes that would interfere or not function correctly while it is ongoing.

#### Other
* Changed the error message when attempting to vote kick a player that has a higher immunity to state they cannot be targeted.
* Fixed a few issues with datatables.