### PR TITLE
Improvements to AFK kick, chatbox, map vote, shuffle and welcome messages

### DIFF
--- a/locale/shine/extensions/mapvote/enGB.json
+++ b/locale/shine/extensions/mapvote/enGB.json
@@ -62,5 +62,9 @@
 	"MAP_EXTENDED_ROUNDS": "{Duration:Sign:shortened|extended} the map by {Duration:Abs} {Duration:Abs::Pluralise:round|rounds}.",
 	"SET_MAP_ROUNDS": "set the round limit to {Duration} {Duration:Pluralise:round|rounds}.",
 	"NOTIFY_PREFIX": "[Map Vote]",
-	"PLUGIN_DISABLED": "Map vote plugin disabled. Current vote cancelled."
+	"PLUGIN_DISABLED": "Map vote plugin disabled. Current vote cancelled.",
+	"ON_VOTE_ACTION": "When a map vote starts:",
+	"USE_SERVER_SETTINGS": "Use Server Settings",
+	"OPEN_MENU": "Open Vote Menu",
+	"DO_NOT_OPEN_MENU": "Do Nothing"
 }

--- a/locale/shine/extensions/voterandom/enGB.json
+++ b/locale/shine/extensions/voterandom/enGB.json
@@ -88,5 +88,36 @@
 	"TEAM_PREFERENCE": "Shuffle Team Preference:",
 	"MARINE": "Marines",
 	"ALIEN": "Aliens",
-	"NONE": "No Preference"
+	"NONE": "No Preference",
+
+	"DISABLE_AUTO_SHUFFLE": "Disable Shuffle",
+	"ENABLE_AUTO_SHUFFLE": "Enable Shuffle",
+
+	"PLAYER_VOTED_ENABLE_AUTO_HIVE_BASED": "{PlayerName} voted to enable automatic Hive skill based teams ({VotesNeeded} more {VotesNeeded:Pluralise:vote|votes} needed)",
+	"PLAYER_VOTED_ENABLE_AUTO_KDR_BASED": "{PlayerName} voted to enable automatic KDR based teams ({VotesNeeded} more {VotesNeeded:Pluralise:vote|votes} needed)",
+	"PLAYER_VOTED_ENABLE_AUTO_RANDOM_BASED": "{PlayerName} voted to enable automatic random teams ({VotesNeeded} more {VotesNeeded:Pluralise:vote|votes} needed)",
+	"PLAYER_VOTED_ENABLE_AUTO_SCORE_BASED": "{PlayerName} voted to enable automatic score based teams ({VotesNeeded} more {VotesNeeded:Pluralise:vote|votes} needed)",
+	"PLAYER_VOTED_ENABLE_AUTO_PRIVATE_HIVE_BASED": "You voted to enable automatic Hive skill based teams ({VotesNeeded} more {VotesNeeded:Pluralise:vote|votes} needed)",
+	"PLAYER_VOTED_ENABLE_AUTO_PRIVATE_KDR_BASED": "You voted to enable automatic KDR based teams ({VotesNeeded} more {VotesNeeded:Pluralise:vote|votes} needed)",
+	"PLAYER_VOTED_ENABLE_AUTO_PRIVATE_RANDOM_BASED": "You voted to enable automatic random teams ({VotesNeeded} more {VotesNeeded:Pluralise:vote|votes} needed)",
+	"PLAYER_VOTED_ENABLE_AUTO_PRIVATE_SCORE_BASED": "You voted to enable automatic score based teams ({VotesNeeded} more {VotesNeeded:Pluralise:vote|votes} needed)",
+
+	"PLAYER_VOTED_DISABLE_AUTO_HIVE_BASED": "{PlayerName} voted to disable automatic Hive skill based teams ({VotesNeeded} more {VotesNeeded:Pluralise:vote|votes} needed)",
+	"PLAYER_VOTED_DISABLE_AUTO_KDR_BASED": "{PlayerName} voted to disable automatic KDR based teams ({VotesNeeded} more {VotesNeeded:Pluralise:vote|votes} needed)",
+	"PLAYER_VOTED_DISABLE_AUTO_RANDOM_BASED": "{PlayerName} voted to disable automatic random teams ({VotesNeeded} more {VotesNeeded:Pluralise:vote|votes} needed)",
+	"PLAYER_VOTED_DISABLE_AUTO_SCORE_BASED": "{PlayerName} voted to disable automatic score based teams ({VotesNeeded} more {VotesNeeded:Pluralise:vote|votes} needed)",
+	"PLAYER_VOTED_DISABLE_AUTO_PRIVATE_HIVE_BASED": "You voted to disable automatic Hive skill based teams ({VotesNeeded} more {VotesNeeded:Pluralise:vote|votes} needed)",
+	"PLAYER_VOTED_DISABLE_AUTO_PRIVATE_KDR_BASED": "You voted to disable automatic KDR based teams ({VotesNeeded} more {VotesNeeded:Pluralise:vote|votes} needed)",
+	"PLAYER_VOTED_DISABLE_AUTO_PRIVATE_RANDOM_BASED": "You voted to disable automatic random teams ({VotesNeeded} more {VotesNeeded:Pluralise:vote|votes} needed)",
+	"PLAYER_VOTED_DISABLE_AUTO_PRIVATE_SCORE_BASED": "You voted to disable automatic score based teams ({VotesNeeded} more {VotesNeeded:Pluralise:vote|votes} needed)",
+
+	"AUTO_SHUFFLE_DISABLED_HIVE_BASED": "Automatic Hive skill based teams have been disabled.",
+	"AUTO_SHUFFLE_DISABLED_KDR_BASED": "Automatic KDR based teams have been disabled.",
+	"AUTO_SHUFFLE_DISABLED_RANDOM_BASED": "Automatic score based teams have been disabled.",
+	"AUTO_SHUFFLE_DISABLED_SCORE_BASED": "Automatic random teams have been disabled.",
+
+	"AUTO_SHUFFLE_ENABLED_HIVE_BASED": "Automatic Hive skill based teams have been enabled.",
+	"AUTO_SHUFFLE_ENABLED_KDR_BASED": "Automatic KDR based teams have been enabled.",
+	"AUTO_SHUFFLE_ENABLED_RANDOM_BASED": "Automatic score based teams have been enabled.",
+	"AUTO_SHUFFLE_ENABLED_SCORE_BASED": "Automatic random teams have been enabled."
 }

--- a/lua/shine/core/client/config_gui.lua
+++ b/lua/shine/core/client/config_gui.lua
@@ -18,7 +18,7 @@ local Percentage = Units.Percentage
 local Spacing = Units.Spacing
 local UnitVector = Units.UnitVector
 
-ConfigMenu.Size = UnitVector( HighResScaled( 600 ), HighResScaled( 500 ) )
+ConfigMenu.Size = UnitVector( HighResScaled( 700 ), HighResScaled( 500 ) )
 ConfigMenu.EasingTime = 0.25
 
 local function NeedsToScale()
@@ -156,7 +156,7 @@ local SettingsTypes = {
 	Radio = {
 		Create = function( Panel, Entry )
 			local RadioPanel = Panel:Add( "Panel" )
-			RadioPanel:SetAutoSize( UnitVector( Percentage( 75 ), HighResScaled( 56 ) ) )
+			RadioPanel:SetAutoSize( UnitVector( Percentage( 100 ), HighResScaled( 56 ) ) )
 
 			local TranslationSource = Entry.TranslationSource or "Core"
 

--- a/lua/shine/core/client/votemenu_gui.lua
+++ b/lua/shine/core/client/votemenu_gui.lua
@@ -652,6 +652,14 @@ function VoteMenu:GetButtonByPlugin( PluginName )
 	return nil
 end
 
+local PluginNames = {
+	Shuffle = "voterandom",
+	[ "Map Vote" ] = "mapvote",
+	Surrender = "votesurrender",
+	Unstuck = "unstuck",
+	MOTD = "motd"
+}
+
 --[[
 	Default page.
 ]]
@@ -659,10 +667,16 @@ VoteMenu:AddPage( "Main", function( self )
 	local ActivePlugins = Shine.ActivePlugins
 
 	for i = 1, #ActivePlugins do
-		local Plugin = ActivePlugins[ i ]
-		local Text = Locale:GetPhrase( "Core", Plugin )
-		local Button = self:AddSideButton( Text, ClickFuncs[ Plugin ] )
-		Button.Plugin = Plugin
+		local PluginButton = ActivePlugins[ i ]
+
+		local Enabled, Plugin = Shine:IsExtensionEnabled( PluginNames[ PluginButton ] )
+		local Text = Locale:GetPhrase( "Core", PluginButton )
+		if Enabled then
+			Text = Plugin.GetVoteButtonText and Plugin:GetVoteButtonText() or Text
+		end
+
+		local Button = self:AddSideButton( Text, ClickFuncs[ PluginButton ] )
+		Button.Plugin = PluginButton
 		Button.DefaultText = Text
 	end
 

--- a/lua/shine/core/shared/config.lua
+++ b/lua/shine/core/shared/config.lua
@@ -236,6 +236,7 @@ do
 	local StringExplode = string.Explode
 	local StringUpper = string.upper
 	local TableBuild = table.Build
+	local TableConcat = table.concat
 	local TableRemove = table.remove
 	local tonumber = tonumber
 	local unpack = unpack
@@ -304,7 +305,9 @@ do
 			end
 			return Value
 		end,
-		MessageFunc
+		function()
+			return "Elements of "..MessageFunc()
+		end
 	end
 
 	function Validator.IsType( Type, DefaultValue )
@@ -315,6 +318,31 @@ do
 		function()
 			return StringFormat( "%%s must be a %s", Type )
 		end
+	end
+
+	function Validator.IsAnyType( Types, DefaultValue )
+		return function( Value )
+			for i = 1, #Types do
+				if IsType( Value, Types[ i ] ) then
+					return false
+				end
+			end
+			return true
+		end,
+		Validator.Constant( DefaultValue ),
+		function()
+			return StringFormat( "%%s must have type %s", TableConcat( Types, " or " ) )
+		end
+	end
+
+	-- If the value is of the given type, then it will be validated with the given predicate.
+	function Validator.IfType( Type, CheckPredicate, FixFunction, MessageSupplier )
+		return function( Value )
+			if not IsType( Value, Type ) then
+				return false
+			end
+			return CheckPredicate( Value )
+		end, FixFunction, MessageSupplier
 	end
 
 	function Validator:AddRule( Rule )

--- a/lua/shine/extensions/afkkick/server.lua
+++ b/lua/shine/extensions/afkkick/server.lua
@@ -41,6 +41,7 @@ Plugin.DefaultConfig = {
 	KickOnConnect = false,
 	KickTimeIsAFKThreshold = 0.25,
 	MarkPlayersAFK = true,
+	CheckSteamOverlay = true,
 	WarnActions = {
 		-- Actions to perform to players when they are warned.
 		-- May be any of: MoveToSpectate, MoveToReadyRoom, Notify
@@ -354,13 +355,17 @@ function Plugin:ResetAFKTime( Client )
 	end
 end
 
+function Plugin:IsSteamOverlayOpenFor( DataTable )
+	return DataTable.SteamOverlayIsOpen and self.Config.CheckSteamOverlay
+end
+
 function Plugin:SubtractAFKTime( Client, Time )
 	local DataTable = self.Users:Get( Client )
 	if not DataTable then return end
 
 	-- Do not subtract any time if the player's Steam overlay is open.
 	-- It could be possible to leave the voice chat button going with it open.
-	if DataTable.SteamOverlayIsOpen then return end
+	if self:IsSteamOverlayOpenFor( DataTable ) then return end
 
 	DataTable.Warn = false
 	DataTable.LastMove = SharedTime()
@@ -551,7 +556,7 @@ function Plugin:OnProcessMove( Player, Input )
 	-- Track frozen player's input, but do not punish them if they are not providing any.
 	local IsPlayerFrozen = self:IsPlayerFrozen( Player )
 
-	if not ( MovementIsEmpty and AnglesMatch or DataTable.SteamOverlayIsOpen ) then
+	if not ( MovementIsEmpty and AnglesMatch or self:IsSteamOverlayOpenFor( DataTable ) ) then
 		DataTable.LastMove = Time
 
 		local Leniency = self:GetLeniency( self:IsClientPartiallyImmune( Client ) )

--- a/lua/shine/extensions/chatbox/client.lua
+++ b/lua/shine/extensions/chatbox/client.lua
@@ -168,6 +168,10 @@ local Spacing = Units.Spacing
 
 local Colours = {
 	Background = Colour( 0.6, 0.6, 0.6, 0.4 ),
+	Team1Background = Colour( 104 / 255, 191 / 255, 1, 0.4 ),
+	Team2Background = Colour( 0.8, 0.5, 0.1, 0.4 ),
+	NeutralTeamBackground = Colour( 1, 1, 1, 0.4 ),
+
 	Dark = Colour( 0.2, 0.2, 0.2, 0.8 ),
 	Highlight = Colour( 0.5, 0.5, 0.5, 0.8 ),
 	ModeText = Colour( 1, 1, 1, 1 ),
@@ -187,13 +191,13 @@ local Skin = {
 			Colour = Colours.Background,
 			States = {
 				Team1 = {
-					Colour = Colour( 104 / 255, 191 / 255, 1, 0.4 )
+					Colour = Colours.Team1Background
 				},
 				Team2 = {
-					Colour = Colour( 0.8, 0.5, 0.1, 0.4 )
+					Colour = Colours.Team2Background
 				},
 				NeutralTeam = {
-					Colour = Colour( 1, 1, 1, 0.4 )
+					Colour = Colours.NeutralTeamBackground
 				}
 			}
 		},
@@ -265,6 +269,9 @@ local function UpdateOpacity( self, Opacity )
 	local ScaledOpacity = AlphaScale( Opacity )
 
 	Colours.Background.a = Opacity
+	Colours.Team1Background.a = Opacity
+	Colours.Team2Background.a = Opacity
+	Colours.NeutralTeamBackground.a = Opacity
 	Colours.Dark.a = ScaledOpacity
 	Colours.Highlight.a = ScaledOpacity
 

--- a/lua/shine/extensions/mapvote/shared.lua
+++ b/lua/shine/extensions/mapvote/shared.lua
@@ -191,6 +191,17 @@ function Plugin:SetupClientConfig()
 		.." by entering sh_mapvote_onvote <%s> into the console.", TableConcat( self.VoteAction, "|" ) ) )
 
 	self:BindCommand( "sh_mapvote_onvote", function( Choice )
+		if not Choice then
+			local Explanations = {
+				[ self.VoteAction.USE_SERVER_SETTINGS ] = "respect server settings",
+				[ self.VoteAction.OPEN_MENU ] = "open",
+				[ self.VoteAction.DO_NOT_OPEN_MENU ] = "do nothing"
+			}
+
+			Print( "The vote menu is currently set to %s when a map vote starts.", Explanations[ self.Config.OnVoteAction ] )
+			return
+		end
+
 		self.Config.OnVoteAction = self.VoteAction[ Choice ] or self.VoteAction.USE_SERVER_SETTINGS
 		self:SaveConfig( true )
 
@@ -201,7 +212,7 @@ function Plugin:SetupClientConfig()
 		}
 
 		Print( "The vote menu will %s when a map vote starts.", Explanations[ self.Config.OnVoteAction ] )
-	end ):AddParam{ Type = "string", Optional = true, Default = self.VoteAction.USE_SERVER_SETTINGS }
+	end ):AddParam{ Type = "string", Optional = true }
 
 	Shine:RegisterClientSetting( {
 		Type = "Radio",

--- a/lua/shine/extensions/mapvote/voting.lua
+++ b/lua/shine/extensions/mapvote/voting.lua
@@ -29,7 +29,8 @@ function Plugin:SendVoteOptions( Client, Options, Duration, NextMap, TimeLeft, S
 		Duration = Duration,
 		NextMap = NextMap,
 		TimeLeft = TimeLeft,
-		ShowTime = ShowTime
+		ShowTime = ShowTime,
+		ForceMenuOpen = self.Config.ForceMenuOpenOnMapVote
 	}
 
 	if Client then
@@ -315,12 +316,7 @@ function Plugin:ExtendMap( Time, NextMap )
 
 	if NextMap then
 		if not self.VoteOnEnd then
-			self:SimpleTimer( ExtendTime * self.Config.NextMapVote, function()
-				local Players = Shine.GetAllPlayers()
-				if #Players > 0 then
-					self:StartVote( true )
-				end
-			end )
+			self.NextMapVoteTime = Time + ExtendTime * self.Config.NextMapVote
 		end
 	else
 		if not self.Config.EnableNextMapVote then return end
@@ -334,10 +330,7 @@ function Plugin:ExtendMap( Time, NextMap )
 		end
 
 		if not self.VoteOnEnd then
-			self:DestroyTimer( self.NextMapTimer )
-			self:CreateTimer( self.NextMapTimer, NextVoteTime, 1, function()
-				self:StartVote( true )
-			end )
+			self.NextMapVoteTime = Time + NextVoteTime
 		end
 	end
 end

--- a/lua/shine/extensions/welcomemessages/server.lua
+++ b/lua/shine/extensions/welcomemessages/server.lua
@@ -33,6 +33,22 @@ Plugin.CheckConfig = true
 Plugin.CheckConfigTypes = true
 Plugin.SilentConfigSave = true
 
+Plugin.ConfigMigrationSteps = {
+	{
+		VersionTo = "1.3",
+		Apply = function( Config )
+			if not IsType( Config.Users, "table" ) then return end
+
+			-- Remove any remaining "Said" entries.
+			for ID, Data in pairs( Config.Users ) do
+				if IsType( Data, "table" ) then
+					Data.Said = nil
+				end
+			end
+		end
+	}
+}
+
 do
 	local Validator = Shine.Validator()
 

--- a/lua/shine/extensions/welcomemessages/server.lua
+++ b/lua/shine/extensions/welcomemessages/server.lua
@@ -5,14 +5,17 @@
 local Shine = Shine
 
 local GetOwner = Server.GetOwner
+local IsType = Shine.IsType
 local StringFormat = string.format
 local TableEmpty = table.Empty
+local tostring = tostring
 
 local Plugin = Plugin
-Plugin.Version = "1.2"
+Plugin.Version = "1.3"
 
 Plugin.HasConfig = true
 Plugin.ConfigName = "WelcomeMessages.json"
+Plugin.MessageDisplayHistoryFile = "config://shine/temp/welcomemessages_history.json"
 
 Plugin.DefaultConfig = {
 	MessageDelay = 5,
@@ -30,11 +33,91 @@ Plugin.CheckConfig = true
 Plugin.CheckConfigTypes = true
 Plugin.SilentConfigSave = true
 
+do
+	local Validator = Shine.Validator()
+
+	local function ValidateColour( Key, Validator )
+		Validator:AddFieldRule( Key, Validator.IsType( "table", { 255, 255, 255 } ) )
+		Validator:AddFieldRule( Key, Validator.Each( Validator.IsType( "number", 255 ) ) )
+		Validator:AddFieldRule( Key, Validator.Each( Validator.Clamp( 0, 255 ) ) )
+	end
+
+	local function AddMessageRules( Key, PrintKey, Validator, Message )
+		if Message.Colour then
+			ValidateColour( { Key..".Colour", PrintKey..".Colour" }, Validator )
+		end
+		if Message.PrefixColour then
+			ValidateColour( { Key..".PrefixColour", PrintKey..".PrefixColour" }, Validator )
+		end
+
+		Validator:AddFieldRule( { Key..".Prefix", PrintKey..".Prefix" }, Validator.IsAnyType( { "string", "nil" } ) )
+		Validator:AddFieldRule( { Key..".Message", PrintKey..".Message" }, Validator.IsType( "string" ) )
+	end
+
+	local function ValidateUserEntry( ID, Entry )
+		local Key = StringFormat( "Users[ \"%s\" ]", ID )
+
+		local EntryValidator = Shine.Validator()
+		EntryValidator:AddFieldRule( { "Welcome", Key..".Welcome" },
+			EntryValidator.IsAnyType( { "string", "table", "nil" } ) )
+		EntryValidator:AddFieldRule( { "Leave", Key..".Leave" },
+			EntryValidator.IsAnyType( { "string", "table", "nil" } ) )
+
+		if IsType( Entry.Welcome, "table" ) then
+			AddMessageRules( "Welcome", StringFormat( "%s.Welcome", Key ), EntryValidator, Entry.Welcome )
+		end
+
+		if IsType( Entry.Leave, "table" ) then
+			AddMessageRules( "Leave", StringFormat( "%s.Leave", Key ), EntryValidator, Entry.Leave )
+		end
+
+		return EntryValidator:Validate( Entry )
+	end
+
+	Validator:AddRule( {
+		Matches = function( self, Config )
+			local Failed = false
+
+			for ID, MessageData in pairs( Config.Users ) do
+				if not IsType( MessageData, "table" ) then
+					Print( "Welcome message for user %s was not a table and will be removed.", ID )
+					Config.Users[ ID ] = nil
+
+					Failed = true
+				elseif ValidateUserEntry( ID, MessageData ) then
+					Failed = true
+				end
+			end
+
+			return Failed
+		end
+	} )
+
+	Plugin.ConfigValidator = Validator
+end
+
 function Plugin:Initialise()
 	self.Welcomed = {}
+	self.AlreadyDisplayedMessages = Shine.LoadJSONFile( self.MessageDisplayHistoryFile ) or {}
 	self.Enabled = true
 
 	return true
+end
+
+function Plugin:SaveMessageDisplayHistory()
+	Shine.SaveJSONFile( self.AlreadyDisplayedMessages, self.MessageDisplayHistoryFile )
+end
+
+function Plugin:RememberMessageDisplay( ID )
+	self.AlreadyDisplayedMessages[ ID ] = true
+	self:SaveMessageDisplayHistory()
+end
+
+function Plugin:ForgetMessageDisplay( ID )
+	if not self.AlreadyDisplayedMessages[ ID ] then return end
+
+	self.AlreadyDisplayedMessages[ ID ] = nil
+	self:SaveMessageDisplayHistory()
 end
 
 function Plugin:ShouldShowMessage( Client )
@@ -42,20 +125,46 @@ function Plugin:ShouldShowMessage( Client )
 		or not Client:GetIsVirtual() )
 end
 
+local function ToColour( ColourDef )
+	if not ColourDef then
+		return { 255, 255, 255 }
+	end
+
+	local R = ColourDef[ 1 ] or 255
+	local G = ColourDef[ 2 ] or 255
+	local B = ColourDef[ 3 ] or 255
+
+	return R, G, B
+end
+
+function Plugin:DisplayMessage( Message )
+	if IsType( Message, "string" ) then
+		Shine:NotifyColour( nil, 255, 255, 255, Message )
+		return
+	end
+
+	local R, G, B = ToColour( Message.Colour )
+
+	if Message.Prefix then
+		local PR, PG, PB = ToColour( Message.PrefixColour )
+		Shine:NotifyDualColour( nil, PR, PG, PB, Message.Prefix,
+			R, G, B, Message.Message )
+	else
+		Shine:NotifyColour( nil, R, G, B, Message.Message )
+	end
+end
+
 function Plugin:ClientConnect( Client )
 	self:SimpleTimer( self.Config.MessageDelay, function()
 		if not self:ShouldShowMessage( Client ) then return end
 
-		local ID = Client:GetUserId()
-		local MessageTable = self.Config.Users[ tostring( ID ) ]
+		local ID = tostring( Client:GetUserId() )
+		local MessageTable = self.Config.Users[ ID ]
 
 		if MessageTable and MessageTable.Welcome then
-			if not MessageTable.Said then
-				Shine:NotifyColour( nil, 255, 255, 255, MessageTable.Welcome )
-
-				MessageTable.Said = true
-
-				self:SaveConfig()
+			if not self.AlreadyDisplayedMessages[ ID ] then
+				self:RememberMessageDisplay( ID )
+				self:DisplayMessage( MessageTable.Welcome )
 			end
 
 			self.Welcomed[ Client ] = true
@@ -92,20 +201,17 @@ local TeamColours = {
 }
 
 function Plugin:ClientDisconnect( Client )
+	local ID = tostring( Client:GetUserId() )
+
+	self:ForgetMessageDisplay( ID )
+
 	if not self.Welcomed[ Client ] then return end
 
 	self.Welcomed[ Client ] = nil
 
-	local ID = Client:GetUserId()
-	local MessageTable = self.Config.Users[ tostring( ID ) ]
-
+	local MessageTable = self.Config.Users[ ID ]
 	if MessageTable and MessageTable.Leave then
-		Shine:NotifyColour( nil, 255, 255, 255, MessageTable.Leave )
-
-		MessageTable.Said = nil
-
-		self:SaveConfig()
-
+		self:DisplayMessage( MessageTable.Leave )
 		return
 	end
 
@@ -133,7 +239,6 @@ end
 
 function Plugin:OnScriptDisconnect( Client, Reason )
 	local Player = Client:GetControllingPlayer()
-
 	if not Player then return end
 
 	local Team = Player.GetTeamNumber and Player:GetTeamNumber()
@@ -148,7 +253,6 @@ function Plugin:PostJoinTeam( Gamerules, Player, OldTeam, NewTeam, Force, ShineF
 	if not Player then return end
 
 	local Client = GetOwner( Player )
-
 	if Client then
 		Client.DisconnectTeam = NewTeam
 	end

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -835,8 +835,7 @@ end
 ]]
 function ControlMeta:FadeTo( Element, Start, End, Delay, Duration, Callback, EaseFunc, Power )
 	local EasingData = self:EaseValue( Element, Start, End, Delay, Duration, Callback, Easers.Fade )
-	EasingData.EaseFunc = EaseFunc
-	EasingData.Power = Power
+	AddEaseFunc( EasingData, EaseFunc, Power )
 
 	return EasingData
 end

--- a/lua/shine/lib/gui/objects/slider.lua
+++ b/lua/shine/lib/gui/objects/slider.lua
@@ -160,6 +160,17 @@ function Slider:SetFraction( Fraction )
 	self:SizeLines()
 end
 
+function Slider:ChangeValue( Value )
+	local OldValue = self.Value
+
+	self:SetValue( Value )
+
+	if OldValue ~= self.Value then
+		self:OnSlide( self.Value )
+		self:OnValueChanged( self.Value )
+	end
+end
+
 function Slider:GetValue()
 	return self.Value
 end
@@ -177,6 +188,20 @@ function Slider:SetBounds( Min, Max )
 
 	--Update our slider value to clamp it inside the new bounds if needed.
 	self:SetValue( self.Value )
+end
+
+function Slider:PlayerKeyPress( Key, Down )
+	if not self:MouseIn( self.Background ) then return end
+
+	if Key == InputKey.Left or Key == InputKey.Down then
+		self:ChangeValue( self:GetValue() - 1 * 10 ^ -self.Decimals )
+		return true
+	end
+
+	if Key == InputKey.Right or Key == InputKey.Up then
+		self:ChangeValue( self:GetValue() + 1 * 10 ^ -self.Decimals )
+		return true
+	end
 end
 
 local GetCursorPos

--- a/lua/shine/lib/gui/objects/tooltip.lua
+++ b/lua/shine/lib/gui/objects/tooltip.lua
@@ -9,11 +9,11 @@ local SGUI = Shine.GUI
 local Tooltip = {}
 Tooltip.IsWindow = true
 
-local Texture = "ui/insight_resources.dds"
-
 local Padding = Vector( 0, 8, 0 )
 
-local TextureCoords = { 265, 0, 1023, 98 }
+SGUI.AddBoundProperty( Tooltip, "Colour", "Background:SetColor" )
+SGUI.AddBoundProperty( Tooltip, "Texture", "Background:SetTexture" )
+SGUI.AddBoundProperty( Tooltip, "TexturePixelCoordinates", "Background:SetTexturePixelCoordinates" )
 
 function Tooltip:Initialise()
 	self.BaseClass.Initialise( self )
@@ -21,16 +21,12 @@ function Tooltip:Initialise()
 	local Manager = GetGUIManager()
 
 	local Background = Manager:CreateGraphicItem()
-	Background:SetTexture( Texture )
 	self.Background = Background
 end
 
 function Tooltip:SetSize( Vec )
 	self.Size = Vec
-
 	self.Background:SetSize( Vec )
-	self.Background:SetTexturePixelCoordinates( TextureCoords[ 1 ], TextureCoords[ 2 ],
-		TextureCoords[ 3 ], TextureCoords[ 4 ] )
 end
 
 function Tooltip:SetTextColour( Col )
@@ -38,14 +34,7 @@ function Tooltip:SetTextColour( Col )
 
 	if not self.Text then return end
 
-	if self.Visible then
-		self.Text:SetColor( Col )
-	else
-		local TextCol = SGUI.CopyColour( Col )
-		TextCol.a = 0
-
-		self.Text:SetColor( TextCol )
-	end
+	self.Text:SetColor( Col )
 end
 
 function Tooltip:SetText( Text, Font, Scale )
@@ -56,12 +45,13 @@ function Tooltip:SetText( Text, Font, Scale )
 	end
 
 	local TextObj = GetGUIManager():CreateTextItem()
-	--Align center doesn't want to play nice...
+	-- Align center doesn't want to play nice...
 	TextObj:SetAnchor( GUIItem.Middle, GUIItem.Top )
 	TextObj:SetTextAlignmentX( GUIItem.Align_Center )
 	TextObj:SetText( Text )
 	TextObj:SetFontName( Font or Fonts.kAgencyFB_Small )
 	TextObj:SetPosition( Padding )
+	TextObj:SetInheritsParentAlpha( true )
 	if Scale then
 		TextObj:SetScale( Scale )
 	end
@@ -69,14 +59,12 @@ function Tooltip:SetText( Text, Font, Scale )
 	local WidthScale = Scale and Scale.x or 1
 	local HeightScale = Scale and Scale.y or 1
 
-	local Width = TextObj:GetTextWidth( Text ) * WidthScale + 32
+	local Width = TextObj:GetTextWidth( Text ) * WidthScale + 16
 	local Height = TextObj:GetTextHeight( Text ) * HeightScale + 16
 
 	self:SetSize( Vector( Width, Height, 0 ) )
 
-	local TextCol = self.TextCol
-	TextCol.a = self.Visible and 1 or 0
-	TextObj:SetColor( TextCol )
+	TextObj:SetColor( self.TextCol )
 
 	self.Text = TextObj
 
@@ -93,16 +81,11 @@ end
 
 function Tooltip:FadeIn()
 	local Start = self.Background:GetColor()
+	Start.a = 0
+
 	local End = Colour( Start.r, Start.g, Start.b, 1 )
 
 	self:FadeTo( self.Background, Start, End, 0, 0.2 )
-
-	if not self.Text then return end
-
-	Start = self.Text:GetColor()
-	End = Colour( Start.r, Start.g, Start.b, 1 )
-
-	self:FadeTo( self.Text, Start, End, 0, 0.2 )
 end
 
 function Tooltip:FadeOut( Callback )
@@ -117,18 +100,8 @@ function Tooltip:FadeOut( Callback )
 		if Callback then
 			Callback()
 		end
-
-		--Remember to remove the fade on the text!
-		self:StopFade( self.Text )
 		self:Destroy()
 	end )
-
-	if not self.Text then return end
-
-	Start = self.Text:GetColor()
-	End = Colour( Start.r, Start.g, Start.b, 0 )
-
-	self:FadeTo( self.Text, Start, End, 0, 0.2 )
 end
 
 function Tooltip:OnLoseWindowFocus()

--- a/lua/shine/lib/gui/skins/default.lua
+++ b/lua/shine/lib/gui/skins/default.lua
@@ -153,7 +153,8 @@ local Skin = {
 	},
 	Tooltip = {
 		Default = {
-			TextColour = BrightText
+			TextColour = BrightText,
+			Colour = DarkButton
 		}
 	}
 }

--- a/lua/shine/modules/sh_vote.lua
+++ b/lua/shine/modules/sh_vote.lua
@@ -164,6 +164,10 @@ function Module:UpdateVoteButton()
 		return
 	end
 
+	if self.VoteButtonCheckMarkXScale then
+		Button.CheckMarkXScale = self.VoteButtonCheckMarkXScale
+	end
+
 	if self.HasVoted then
 		Shine.VoteMenu:MarkAsSelected( Button, true )
 	end

--- a/test/extensions/voterandom/voterandom.lua
+++ b/test/extensions/voterandom/voterandom.lua
@@ -544,8 +544,8 @@ UnitTest:Test( "OptimiseTeams with commanders", function( Assert )
 	VoteShuffle:OptimiseTeams( TeamMembers, RankFunc, TeamSkills )
 
 	-- It should never swap the commanders.
-	Assert:ArrayEquals( { Players[ 1 ], Players[ 6 ], Players[ 3 ] }, TeamMembers[ 1 ] )
-	Assert:ArrayEquals( { Players[ 4 ], Players[ 5 ], Players[ 2 ] }, TeamMembers[ 2 ] )
+	Assert:DeepEquals( { Players[ 1 ], Players[ 6 ], Players[ 3 ] }, TeamMembers[ 1 ] )
+	Assert:DeepEquals( { Players[ 4 ], Players[ 5 ], Players[ 2 ] }, TeamMembers[ 2 ] )
 end, nil, 5 )
 
 VoteShuffle.OptimiseHappiness = BalanceModule.OptimiseHappiness


### PR DESCRIPTION
#### AFK Kick
* Checking the Steam overlay can now be disabled using the config option `CheckSteamOverlay = false`.

#### Chatbox
* Opening the chatbox in team chat will now change the background colour slightly to reflect the team you are on. This should help make it clearer when it has been opened in team chat mode vs. global chat.

#### Map Vote
* The map vote menu may now be opened automatically for players when a map vote starts using the config option `ForceMenuOpenOnMapVote = true`.
  * The menu will not open if a game is in progress or about to start.
  * Clients may override this behaviour in the client config menu or using the `sh_mapvote_onvote` command in the console.

#### Vote Shuffle
* Implemented an improved team optimisation pass that produces much more balanced teams compared to the old method in most cases.
  * The optimisation process will pick the best team composition from the old and new methods.
  * The new method is unaffected by the `StandardDeviationTolerance` option. This option should be considered deprecated.
  * The behaviour of `AverageValueTolerance` remains unchanged.
* When forcing shuffles with `AlwaysEnabled = true`, the vote will now be to disable the automatic shuffle for the next round start. If it is disabled, it can still be voted back to enabled again as long as the round doesn't start.

#### Welcome Messages
* Join and leave messages for specific players can now [have their own colour, prefix and prefix colour](https://github.com/Person8880/Shine/wiki/Welcome-messages#message-format).
* The config is no longer used to track which players have had their message displayed across map changes. This has been moved to a separate file to prevent the config being constantly changed by the server.
