### PR TITLE
Fix mouse cursor disappearing and menus being left on screen

### DIFF
--- a/lua/shine/core/client/adminmenu.lua
+++ b/lua/shine/core/client/adminmenu.lua
@@ -59,6 +59,8 @@ function AdminMenu:Create()
 end
 
 function AdminMenu:Close()
+	if not self.Visible then return end
+
 	self:ForceHide()
 
 	if self.ToDestroyOnClose then
@@ -137,16 +139,24 @@ AdminMenu:BindVisibilityToEvents( "OnHelpScreenDisplay", "OnHelpScreenHide" )
 function AdminMenu:PlayerKeyPress( Key, Down )
 	if not self.Visible then return end
 
-	if Key == InputKey.Escape and Down then
+	if ( Key == InputKey.Escape or GetIsBinding( Key, "Use" ) ) and Down then
 		self:Close()
 
-		return true
+		return Key == InputKey.Escape or nil
 	end
 end
 
 Hook.Add( "PlayerKeyPress", "AdminMenu_KeyPress", function( Key, Down )
-	AdminMenu:PlayerKeyPress( Key, Down )
+	return AdminMenu:PlayerKeyPress( Key, Down )
 end, 1 )
+
+-- Close when logging in/out of a command structure to avoid mouse problems.
+Hook.Add( "OnCommanderLogout", "AdminMenuLogout", function()
+	AdminMenu:Close()
+end )
+Hook.Add( "OnCommanderLogin", "AdminMenuLogin", function()
+	AdminMenu:Close()
+end )
 
 function AdminMenu:AddTab( Name, Data )
 	self.Tabs[ Name ] = Data

--- a/lua/shine/core/client/config_gui.lua
+++ b/lua/shine/core/client/config_gui.lua
@@ -78,6 +78,12 @@ function ConfigMenu:Create()
 	end
 end
 
+function ConfigMenu:Close()
+	if not self.Menu or not self.Visible then return end
+
+	self.Menu:Close()
+end
+
 Shine.Hook.Add( "OnResolutionChanged", "ClientConfig_OnResolutionChanged", function()
 	if not ConfigMenu.Menu then return end
 
@@ -87,6 +93,18 @@ Shine.Hook.Add( "OnResolutionChanged", "ClientConfig_OnResolutionChanged", funct
 	if ConfigMenu.Visible then
 		ConfigMenu:Create()
 	end
+end )
+
+Shine.Hook.Add( "PlayerKeyPress", "ConfigMenu_KeyPress", function( Key, Down )
+	return Shine.AdminMenu.PlayerKeyPress( ConfigMenu, Key, Down )
+end, 1 )
+
+-- Close when logging in/out of a command structure to avoid mouse problems.
+Shine.Hook.Add( "OnCommanderLogout", "ConfigMenuLogout", function()
+	ConfigMenu:Close()
+end )
+Shine.Hook.Add( "OnCommanderLogin", "ConfigMenuLogin", function()
+	ConfigMenu:Close()
 end )
 
 function ConfigMenu:SetIsVisible( Bool, IgnoreAnim )

--- a/lua/shine/core/client/votemenu_gui.lua
+++ b/lua/shine/core/client/votemenu_gui.lua
@@ -223,7 +223,7 @@ function VoteMenu:PlayerKeyPress( Key, Down )
 	end
 
 	local IsCloseKey = Key == InputKey.MouseButton0 or Key == InputKey.MouseButton1
-		or Key == InputKey.Escape
+		or Key == InputKey.Escape or GetIsBinding( Key, "Use" )
 
 	if Down and IsCloseKey then
 		self:ForceHide()
@@ -254,7 +254,11 @@ Hook.Add( "Think", "VoteMenuThink", function( DeltaTime )
 	VoteMenu:Think( DeltaTime )
 end )
 
-Hook.Add( "OnCommanderUILogout", "VoteMenuLogout", function()
+-- Close when logging in/out of a command structure to avoid mouse problems.
+Hook.Add( "OnCommanderLogout", "VoteMenuLogout", function()
+	VoteMenu:ForceHide()
+end )
+Hook.Add( "OnCommanderLogin", "VoteMenuLogin", function()
 	VoteMenu:ForceHide()
 end )
 

--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -453,6 +453,18 @@ if Client then
 		SetupGlobalHook( "ChatUI_EnterChatMessage", "StartChat", "ActivePre" )
 		SetupGlobalHook( "CommanderUI_Logout", "OnCommanderUILogout", "PassivePost" )
 
+		SetupClassHook( "Commander", "OnDestroy", "OnCommanderLogout", function( OldFunc, Commander )
+			-- Do nothing if the commander isn't the local player.
+			if not Commander.hudSetup then return OldFunc( Commander ) end
+
+			OldFunc( Commander )
+
+			-- Call after the mouse has been disabled for the commander to allow SGUI elements
+			-- to properly close themselves and avoid getting stuck on screen.
+			Call( "OnCommanderLogout", Commander )
+		end )
+		SetupClassHook( "Commander", "OnInitLocalClient", "OnCommanderLogin", "PassivePre" )
+
 		SetupClassHook( "HelpScreen", "Display", "OnHelpScreenDisplay", "PassivePost" )
 		SetupClassHook( "HelpScreen", "Hide", "OnHelpScreenHide", "PassivePost" )
 	end, -20 )

--- a/lua/shine/extensions/chatbox/client.lua
+++ b/lua/shine/extensions/chatbox/client.lua
@@ -1177,6 +1177,27 @@ function Plugin:CloseChat()
 	self.Visible = false
 end
 
+-- Close and re-open the chatbox when logging in/out of a command structure to
+-- avoid the mouse disappearing and/or elements getting stuck on the screen.
+function Plugin:OnCommanderLogin()
+	if not self.Visible then return end
+
+	local WasDeletingOnClose = self.Config.DeleteOnClose
+	local WasTeamChat = self.TeamChat
+
+	-- Ensure existing text entry state is preserved.
+	self.Config.DeleteOnClose = false
+	self:CloseChat()
+	self.Config.DeleteOnClose = WasDeletingOnClose
+
+	self:SimpleTimer( 0, function()
+		-- Wait a frame to allow the commander mouse to be pushed/popped first.
+		self:StartChat( WasTeamChat )
+	end )
+end
+
+Plugin.OnCommanderLogout = Plugin.OnCommanderLogin
+
 do
 	local TeamStates = {
 		[ kMarineTeamType ] = "Team1",

--- a/lua/shine/extensions/chatbox/client.lua
+++ b/lua/shine/extensions/chatbox/client.lua
@@ -1158,7 +1158,7 @@ function Plugin:AutoCompleteCommand( Text )
 	self.AutoCompleteTimer:Debounce()
 end
 
-function Plugin:CloseChat()
+function Plugin:CloseChat( ForcePreserveText )
 	if not SGUI.IsValid( self.MainPanel ) then return end
 
 	self.MainPanel:SetIsVisible( false )
@@ -1166,7 +1166,7 @@ function Plugin:CloseChat()
 
 	SGUI:EnableMouse( false )
 
-	if self.Config.DeleteOnClose then
+	if not ForcePreserveText and self.Config.DeleteOnClose then
 		self.TextEntry:SetText( "" )
 		self.TextEntry:ResetUndoState()
 		self:DestroyAutoCompletePanel()
@@ -1182,13 +1182,10 @@ end
 function Plugin:OnCommanderLogin()
 	if not self.Visible then return end
 
-	local WasDeletingOnClose = self.Config.DeleteOnClose
 	local WasTeamChat = self.TeamChat
 
 	-- Ensure existing text entry state is preserved.
-	self.Config.DeleteOnClose = false
-	self:CloseChat()
-	self.Config.DeleteOnClose = WasDeletingOnClose
+	self:CloseChat( true )
 
 	self:SimpleTimer( 0, function()
 		-- Wait a frame to allow the commander mouse to be pushed/popped first.

--- a/lua/shine/lib/gui/objects/tabbedpanel.lua
+++ b/lua/shine/lib/gui/objects/tabbedpanel.lua
@@ -227,6 +227,17 @@ function TabPanel:RemoveTab( Index )
 	end
 end
 
+function TabPanel:Close()
+	-- Again for external usage.
+	if self.OnClose then
+		if self:OnClose() then
+			return
+		end
+	end
+
+	self:SetIsVisible( false )
+end
+
 function TabPanel:AddCloseButton()
 	local CloseButton = SGUI:Create( "Button", self )
 	CloseButton:SetSize( Vector( self.TitleBarHeight, self.TitleBarHeight, 0 ) )
@@ -236,14 +247,7 @@ function TabPanel:AddCloseButton()
 	CloseButton:SetStyleName( "CloseButton" )
 
 	function CloseButton.DoClick()
-		--Again for external usage.
-		if self.OnClose then
-			if self:OnClose() then
-				return
-			end
-		end
-
-		self:SetIsVisible( false )
+		self:Close()
 	end
 
 	self.CloseButton = CloseButton


### PR DESCRIPTION
* Fixed edge cases that would result in the cursor disappearing when becoming a commander if menus were open at the time of entry.
* Fixed edge cases where menus would remain on the screen without a mouse cursor when leaving a command structure.