### PR TITLE
Fix minor chatbox and vote bugs, improve shuffle auto-assignment

### DIFF
--- a/lua/shine/core/client/config_gui.lua
+++ b/lua/shine/core/client/config_gui.lua
@@ -310,8 +310,10 @@ ConfigMenu:AddTab( "Plugins", {
 
 			if State then
 				EnableButton:SetText( Locale:GetPhrase( "Core", "DISABLE_PLUGIN" ) )
+				EnableButton:SetStyleName( "DangerButton" )
 			else
 				EnableButton:SetText( Locale:GetPhrase( "Core", "ENABLE_PLUGIN" ) )
+				EnableButton:SetStyleName( "SuccessButton" )
 			end
 		end
 

--- a/lua/shine/extensions/basecommands/shared.lua
+++ b/lua/shine/extensions/basecommands/shared.lua
@@ -310,6 +310,7 @@ function Plugin:SetupAdminMenuCommands()
 			ChangeMap:SetPos( Vector( 16, -48, 0 ) )
 			ChangeMap:SetText( self:GetPhrase( "CHANGE_MAP" ) )
 			ChangeMap:SetFont( Fonts.kAgencyFB_Small )
+			ChangeMap:SetStyleName( "DangerButton" )
 			function ChangeMap.DoClick()
 				local Selected = List:GetSelectedRow()
 				if not Selected then return end
@@ -385,6 +386,7 @@ function Plugin:SetupAdminMenuCommands()
 			UnloadPlugin:SetPos( Vector( 16, -48, 0 ) )
 			UnloadPlugin:SetText( self:GetPhrase( "UNLOAD_PLUGIN" ) )
 			UnloadPlugin:SetFont( Fonts.kAgencyFB_Small )
+			UnloadPlugin:SetStyleName( "DangerButton" )
 			function UnloadPlugin.DoClick( Button )
 				local Plugin, Enabled = GetSelectedPlugin()
 				if not Plugin then return false end
@@ -396,13 +398,13 @@ function Plugin:SetupAdminMenuCommands()
 					Menu:Destroy()
 
 					Shine.AdminMenu:RunCommand( "sh_unloadplugin", Plugin )
-				end, self:GetPhrase( "UNLOAD_PLUGIN_TIP" ) )
+				end, self:GetPhrase( "UNLOAD_PLUGIN_TIP" ) ):SetStyleName( "DangerButton" )
 
 				Menu:AddButton( self:GetPhrase( "PERMANENTLY" ), function()
 					Menu:Destroy()
 
 					Shine.AdminMenu:RunCommand( "sh_unloadplugin", Plugin.." true" )
-				end, self:GetPhrase( "UNLOAD_PLUGIN_SAVE_TIP" ) )
+				end, self:GetPhrase( "UNLOAD_PLUGIN_SAVE_TIP" ) ):SetStyleName( "DangerButton" )
 			end
 
 			local LoadPlugin = SGUI:Create( "Button", Panel )
@@ -411,6 +413,7 @@ function Plugin:SetupAdminMenuCommands()
 			LoadPlugin:SetPos( Vector( -144, -48, 0 ) )
 			LoadPlugin:SetText( self:GetPhrase( "LOAD_PLUGIN" ) )
 			LoadPlugin:SetFont( Fonts.kAgencyFB_Small )
+			LoadPlugin:SetStyleName( "SuccessButton" )
 			local function NormalLoadDoClick( Button )
 				local Plugin = GetSelectedPlugin()
 				if not Plugin then return false end
@@ -421,13 +424,13 @@ function Plugin:SetupAdminMenuCommands()
 					Menu:Destroy()
 
 					Shine.AdminMenu:RunCommand( "sh_loadplugin", Plugin )
-				end, self:GetPhrase( "LOAD_PLUGIN_TIP" ) )
+				end, self:GetPhrase( "LOAD_PLUGIN_TIP" ) ):SetStyleName( "SuccessButton" )
 
 				Menu:AddButton( self:GetPhrase( "PERMANENTLY" ), function()
 					Menu:Destroy()
 
 					Shine.AdminMenu:RunCommand( "sh_loadplugin", Plugin.." true" )
-				end, self:GetPhrase( "LOAD_PLUGIN_SAVE_TIP" ) )
+				end, self:GetPhrase( "LOAD_PLUGIN_SAVE_TIP" ) ):SetStyleName( "SuccessButton" )
 			end
 
 			local function ReloadDoClick()

--- a/lua/shine/extensions/chatbox/chatline.lua
+++ b/lua/shine/extensions/chatbox/chatline.lua
@@ -177,6 +177,7 @@ end
 
 do
 	local WordWrap = SGUI.WordWrap
+	local FORCE_NEW_LINE_FRACTION = 0.9
 
 	function ChatLine:ComputeWrapping( XPos )
 		if self.ComputedWrapping then return end
@@ -195,7 +196,15 @@ do
 			return
 		end
 
-		local Remaining = WordWrap( MessageLabel, Text, XPos, MaxWidth, 1 )
+		local Remaining
+		if XPos / MaxWidth > FORCE_NEW_LINE_FRACTION then
+			-- Not enough room to bother wrapping, start on a new line.
+			MessageLabel:SetText( "" )
+			Remaining = Text
+		else
+			Remaining = WordWrap( MessageLabel, Text, XPos, MaxWidth, 1 )
+		end
+
 		if Remaining == "" then
 			self:RemoveWrappedLine()
 			return

--- a/lua/shine/extensions/chatbox/client.lua
+++ b/lua/shine/extensions/chatbox/client.lua
@@ -913,6 +913,9 @@ function Plugin:OnResolutionChanged( OldX, OldY, NewX, NewY )
 
 	if not self.Visible then
 		self.MainPanel:SetIsVisible( false )
+	else
+		self:CloseChat()
+		self:StartChat( self.TeamChat )
 	end
 
 	for i = 1, #Recreate do

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -602,7 +602,7 @@ do
 			end
 
 			local Client = Player:GetClient()
-			if not Client then return end
+			if not Shine:IsValidClient( Client ) then return end
 
 			-- Bot and we don't want to deal with them, so kick them out.
 			if Client:GetIsVirtual() and not self.Config.ApplyToBots then

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -1151,11 +1151,6 @@ function Plugin:CreateCommands()
 				self:NotifyVoted( Client )
 			end
 
-			--Somehow it didn't apply random settings??
-			if VotesNeeded == 0 and not self.RandomApplied then
-				self:ApplyRandomSettings()
-			end
-
 			return
 		end
 

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -687,18 +687,18 @@ end
 
 function Plugin:GetOptimalTeamForPlayer( Player, Team1Players, Team2Players, SkillGetter )
 	local Team1Skills = Shine.Stream( Team1Players ):Map( function( Player )
-		return SkillGetter( Player, 1 )
+		return SkillGetter( Player, 1 ) or 0
 	end ):AsTable()
 
 	local Team2Skills = Shine.Stream( Team2Players ):Map( function( Player )
-		return SkillGetter( Player, 2 )
+		return SkillGetter( Player, 2 ) or 0
 	end ):AsTable()
 
 	local StdDev1, Average1 = StandardDeviation( Team1Skills )
 	local StdDev2, Average2 = StandardDeviation( Team2Skills )
 
 	local function GetCostWithPlayerOnTeam( Skills, TeamNumber, AverageOther, StdDevOther )
-		Skills[ #Skills + 1 ] = SkillGetter( Player, TeamNumber )
+		Skills[ #Skills + 1 ] = SkillGetter( Player, TeamNumber ) or 0
 
 		local StdDev, Average = StandardDeviation( Skills )
 		local AverageDiff = Abs( Average - AverageOther )

--- a/lua/shine/extensions/voterandom/team_balance.lua
+++ b/lua/shine/extensions/voterandom/team_balance.lua
@@ -402,6 +402,10 @@ do
 		local State = Optimiser.CurrentPotentialState
 		return TeamCost( State.AverageDiffBefore, State.StdDiffBefore )
 	end
+
+	function BalanceModule:GetCostFromDiff( AverageDiff, StdDiff )
+		return TeamCost( AverageDiff, StdDiff )
+	end
 end
 
 function BalanceModule:OptimiseTeams( TeamMembers, RankFunc, TeamSkills )

--- a/lua/shine/extensions/votesurrender/server.lua
+++ b/lua/shine/extensions/votesurrender/server.lua
@@ -99,7 +99,7 @@ function Plugin:GetTeamPlayerCount( Team )
 	local Count = 0
 	local function CountPlayers( Player )
 		local Client = GetOwner( Player )
-		if Client and self:IsValidVoter( Client ) then
+		if Shine:IsValidClient( Client ) and self:IsValidVoter( Client ) then
 			Count = Count + 1
 		end
 	end

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -548,42 +548,49 @@ function SGUI.DestroyScript( Script )
 	return GetGUIManager():DestroyGUIScript( Script )
 end
 
---[[
-	Creates an SGUI control.
-	Input: SGUI control class name, optional parent object.
-	Output: SGUI control object.
-]]
-function SGUI:Create( Class, Parent )
-	local MetaTable = self.Controls[ Class ]
+do
+	local ID = 0
 
-	assert( MetaTable, "[SGUI] Invalid SGUI class passed to SGUI:Create!" )
+	--[[
+		Creates an SGUI control.
+		Input: SGUI control class name, optional parent object.
+		Output: SGUI control object.
+	]]
+	function SGUI:Create( Class, Parent )
+		local MetaTable = self.Controls[ Class ]
 
-	local Table = {}
+		assert( MetaTable, "[SGUI] Invalid SGUI class passed to SGUI:Create!" )
 
-	local Control = setmetatable( Table, MetaTable )
-	Control.Class = Class
-	Control:Initialise()
+		ID = ID + 1
 
-	self.ActiveControls:Add( Control, true )
+		local Table = {}
 
-	--If it's a window then we give it focus.
-	if MetaTable.IsWindow and not Parent then
-		local Windows = self.Windows
+		local Control = setmetatable( Table, MetaTable )
+		Control.Class = Class
+		Control.ID = ID
+		Control:Initialise()
 
-		Windows[ #Windows + 1 ] = Control
+		self.ActiveControls:Add( Control, true )
 
-		self:SetWindowFocus( Control )
+		--If it's a window then we give it focus.
+		if MetaTable.IsWindow and not Parent then
+			local Windows = self.Windows
 
-		Control.IsAWindow = true
+			Windows[ #Windows + 1 ] = Control
+
+			self:SetWindowFocus( Control )
+
+			Control.IsAWindow = true
+		end
+
+		self.SkinManager:ApplySkin( Control )
+
+		if not Parent then return Control end
+
+		Control:SetParent( Parent )
+
+		return Control
 	end
-
-	self.SkinManager:ApplySkin( Control )
-
-	if not Parent then return Control end
-
-	Control:SetParent( Parent )
-
-	return Control
 end
 
 --[[

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -19,7 +19,7 @@ SGUI.AddProperty( ControlMeta, "Skin" )
 SGUI.AddProperty( ControlMeta, "StyleName" )
 
 function ControlMeta:__tostring()
-	return StringFormat( "[SGUI] %s | %s | %i Children", self.Class,
+	return StringFormat( "[SGUI - %s] %s | %s | %i Children", self.ID, self.Class,
 		self:IsValid() and "ACTIVE" or "DESTROYED",
 		self.Children and self.Children:GetCount() or 0 )
 end

--- a/lua/shine/lib/gui/layout/types/horizontal.lua
+++ b/lua/shine/lib/gui/layout/types/horizontal.lua
@@ -40,13 +40,11 @@ function Horizontal:GetElementSizeOffset( Size )
 	return Size.x, 0
 end
 
-function Horizontal:ModifyFillElementSize( Size, FillSize )
-	Size.x = FillSize
-end
-
-function Horizontal:ModifyFillElementPos( X, Y, Pos, Size )
-	Pos.x = X
-	return X + Size.x, Y
+function Horizontal:GetFillElementSize( Element, Width, Height, FillSizePerElement )
+	local Size = Element:GetSize()
+	Size.x = FillSizePerElement
+	Size.y = Height
+	return Size
 end
 
 Shine.GUI.Layout:RegisterType( "Horizontal", Horizontal, "Directional" )

--- a/lua/shine/lib/gui/layout/types/vertical.lua
+++ b/lua/shine/lib/gui/layout/types/vertical.lua
@@ -40,13 +40,11 @@ function Vertical:GetElementSizeOffset( Size )
 	return 0, Size.y
 end
 
-function Vertical:ModifyFillElementSize( Size, FillSize )
-	Size.y = FillSize
-end
-
-function Vertical:ModifyFillElementPos( X, Y, Pos, Size )
-	Pos.y = Y
-	return X, Y + Size.y
+function Vertical:GetFillElementSize( Element, Width, Height, FillSizePerElement )
+	local Size = Element:GetSize()
+	Size.x = Width
+	Size.y = FillSizePerElement
+	return Size
 end
 
 Shine.GUI.Layout:RegisterType( "Vertical", Vertical, "Directional" )

--- a/lua/shine/lib/gui/objects/panel.lua
+++ b/lua/shine/lib/gui/objects/panel.lua
@@ -179,9 +179,11 @@ function Panel:Add( Class, Created )
 end
 
 function Panel:SetSize( Size )
+	local OldSize = self:GetSize()
+
 	self.BaseClass.SetSize( self, Size )
 
-	if not self.Stencil then return end
+	if not self.Stencil or Size == OldSize then return end
 
 	self.Stencil:SetSize( Size )
 
@@ -192,8 +194,8 @@ function Panel:SetSize( Size )
 		if Size.y < self.MaxHeight then
 			self:SetMaxHeight( self.MaxHeight )
 		else
-			--Make sure the parent gets reset, and we clear the MaxHeight field
-			--so auto-resize is calculated from the panel height which is now larger.
+			-- Make sure the parent gets reset, and we clear the MaxHeight field
+			-- so auto-resize is calculated from the panel height which is now larger.
 			self.ScrollParent:SetPosition( Vector( 0, 0, 0 ) )
 			self.MaxHeight = nil
 		end
@@ -273,6 +275,8 @@ function Panel:SetScrollbarWidth( Width )
 end
 
 function Panel:SetMaxHeight( Height, ForceInstantScroll )
+	local OldMaxHeight = self.MaxHeight
+
 	self.MaxHeight = Height
 
 	if not self.ShowScrollbar then return end
@@ -284,6 +288,7 @@ function Panel:SetMaxHeight( Height, ForceInstantScroll )
 		if SGUI.IsValid( self.Scrollbar ) then
 			self.Scrollbar:Destroy()
 			self.Scrollbar = nil
+			self.MaxHeight = nil
 
 			if self.ScrollParentPos then
 				self.ScrollParentPos.y = 0
@@ -352,7 +357,7 @@ function Panel:SetMaxHeight( Height, ForceInstantScroll )
 
 	self.Scrollbar:SetScrollSize( NewScrollSize )
 
-	if self.StickyScroll and OldPos >= OldSize then
+	if self.StickyScroll and OldPos >= OldSize and ( OldMaxHeight ~= Height or ForceInstantScroll ) then
 		local ShouldSmooth = NewScrollSize < OldScrollSize and self:ComputeVisibility()
 			and not ForceInstantScroll
 		if not ShouldSmooth then

--- a/lua/shine/lib/gui/objects/scrollbar.lua
+++ b/lua/shine/lib/gui/objects/scrollbar.lua
@@ -100,9 +100,7 @@ function Scrollbar:ScrollToBottom( Smoothed )
 	local Diff = self.Size.y - self.ScrollSizeVec.y
 
 	self.Pos = Diff
-
 	self.BarPos.y = Diff
-
 	self.Bar:SetPosition( self.BarPos )
 
 	if self.Parent and self.Parent.OnScrollChange then

--- a/lua/shine/lib/math.lua
+++ b/lua/shine/lib/math.lua
@@ -139,6 +139,6 @@ do
 			Sum = Sum + ( Values[ i ] - Average ) ^ 2
 		end
 
-		return Sqrt( Sum / Count )
+		return Sqrt( Sum / Count ), Average
 	end
 end

--- a/test/extensions/voterandom/voterandom.lua
+++ b/test/extensions/voterandom/voterandom.lua
@@ -107,6 +107,26 @@ UnitTest:Test( "AddPlayersRandomly", function( Assert )
 	Assert:Equals( 3, #TeamMembers[ 2 ] )
 end )
 
+UnitTest:Test( "GetOptimalTeamForPlayer - Uneven teams", function( Assert )
+	local Team1Players = { 1000, 1000, 1000, 1000, 1500 }
+	local Team2Players = { 1000, 1000, 1000, 1000, 1000 }
+
+	local function SkillGetter( Player ) return Player end
+
+	local TeamToJoin = VoteShuffle:GetOptimalTeamForPlayer( 2000, Team1Players, Team2Players, SkillGetter )
+	Assert.Equals( "Should pick team 2 as the optimal team", 2, TeamToJoin )
+end )
+
+UnitTest:Test( "GetOptimalTeamForPlayer - Even teams", function( Assert )
+	local Team1Players = { 1000, 1000, 1000, 1000, 1000 }
+	local Team2Players = { 1000, 1000, 1000, 1000, 1000 }
+
+	local function SkillGetter( Player ) return Player end
+
+	local TeamToJoin = VoteShuffle:GetOptimalTeamForPlayer( 2000, Team1Players, Team2Players, SkillGetter )
+	Assert.Nil( "Should not pick an optimal team, both are equivalent", TeamToJoin )
+end )
+
 local function FakePlayer( SteamID, TeamNumber, IsCommander )
 	return {
 		GetClient = function()


### PR DESCRIPTION
#### Chatbox
* Fixed text potentially wrapping badly on lower resolutions.
* Fixed the history always scrolling to the bottom when opened, regardless of previous scroll state.
* Fixed changing the size of the chatbox always re-opening it in global chat mode regardless of the previous mode.

#### Shuffle
* Improved automatic team assignment logic when teams are blocked to better determine which team a new player should be placed on.

#### General
* Votes will now pass when a player leaving causes the total required votes to equal the total votes cast, rather than requiring another vote.