### PR TITLE
Map vote similarity checks, performance improvements

### DIFF
--- a/locale/shine/extensions/chatbox/enGB.json
+++ b/locale/shine/extensions/chatbox/enGB.json
@@ -5,6 +5,7 @@
 	"AUTO_CLOSE": "Auto close after sending.",
 	"AUTO_DELETE": "Auto delete on close.",
 	"SMOOTH_SCROLL": "Use smooth scrolling.",
+	"SCROLL_TO_BOTTOM": "Scroll to bottom on open.",
 	"MESSAGE_MEMORY": "Message memory",
 	"OPACITY": "Opacity (%)",
 	"SCALE": "Scale (will re-open chatbox)",

--- a/locale/shine/extensions/mapvote/enGB.json
+++ b/locale/shine/extensions/mapvote/enGB.json
@@ -17,6 +17,7 @@
 	"VOTE_FAIL_ALREADY_VOTED": "You have already voted to begin a map vote.",
 	"VOTE_FAIL_INVALID_MAP": "{MapName} is not a valid map choice.",
 	"VOTE_FAIL_VOTED_MAP": "You have already voted for {MapName}",
+	"VOTE_FAIL_TOO_LATE": "It is too far into the current round to begin a map vote.",
 	"TEAM_CHANGE_FAIL_VOTE": "You cannot join a team whilst the map vote is in progress.",
 	"TEAM_CHANGE_FAIL_MAP_CHANGE": "The map is now changing, you cannot join a team.",
 	"EXTENDING_ROUND": "Extending the current map for another round.",

--- a/lua/shine/core/server/commands.lua
+++ b/lua/shine/core/server/commands.lua
@@ -563,7 +563,7 @@ local function MatchStringRestriction( ParsedArg, Restriction )
 
 	-- Escape any patterns in the string.
 	Restriction = StringPatternSafe( Restriction )
-	Restriction = StringGSub( Restriction, "*", "(.-)" ).."$"
+	Restriction = StringGSub( Restriction, "%%%*", "(.-)" ).."$"
 
 	return StringFind( ParsedArg, Restriction ) ~= nil
 end

--- a/lua/shine/core/server/commands.lua
+++ b/lua/shine/core/server/commands.lua
@@ -828,4 +828,4 @@ Shine.Hook.Add( "PlayerSay", "CommandExecute", function( Client, Message )
 	if CommandObj.Silent then return "" end
 	if Shine.Config.SilentChatCommands then return "" end
 	if Directive == "/" then return "" end
-end, -20 )
+end, Shine.Hook.MAX_PRIORITY )

--- a/lua/shine/core/server/config.lua
+++ b/lua/shine/core/server/config.lua
@@ -199,9 +199,7 @@ do
 			self.ConfigPath or GetConfigPath( false, true ) )
 
 		if not ConfigFile then -- Something's gone horribly wrong!
-			Shine.Error = "Error writing config file: "..Err
-
-			Notify( Shine.Error )
+			Notify( "Error writing config file: "..Err )
 
 			return
 		end
@@ -564,6 +562,4 @@ end
 
 Shine:LoadExtensionConfigs()
 
-if not Shine.Error then
-	Shine.Hook.CallOnce( "PostloadConfig" )
-end
+Shine.Hook.CallOnce( "PostloadConfig" )

--- a/lua/shine/core/server/config.lua
+++ b/lua/shine/core/server/config.lua
@@ -338,7 +338,7 @@ function Shine:LoadExtensionConfigs()
 					self:LoadWebPlugins( DontEnableNow, true )
 				end )
 			end
-		end, -20 )
+		end, self.Hook.MAX_PRIORITY )
 	end
 end
 

--- a/lua/shine/core/server/logging.lua
+++ b/lua/shine/core/server/logging.lua
@@ -95,11 +95,11 @@ end
 --Periodically save the log file.
 Shine.Hook.Add( "EndGame", "SaveLog", function()
 	Shine:SaveLog()
-end, -20 )
+end, Shine.Hook.MAX_PRIORITY )
 
 Shine.Hook.Add( "MapChange", "SaveLog", function()
 	Shine:SaveLog()
-end, -20 )
+end, Shine.Hook.MAX_PRIORITY )
 
 Shine.Timer.Create( "LogSave", 300, -1, function()
 	Shine:SaveLog()

--- a/lua/shine/core/server/permissions.lua
+++ b/lua/shine/core/server/permissions.lua
@@ -177,7 +177,7 @@ function Shine:LoadUsers( Web, Reload )
 			self.Hook.Add( "ClientConnect", "LoadUsers", function( Client )
 				self:RequestUsers()
 				self.Hook.Remove( "ClientConnect", "LoadUsers" )
-			end, -20 )
+			end, self.Hook.MAX_PRIORITY )
 		end
 
 		return
@@ -294,11 +294,11 @@ do
 
 		GameID = GameID + 1
 		GameIDs:Add( Client, GameID )
-	end, -20 )
+	end, Shine.Hook.MAX_PRIORITY )
 
 	Shine.Hook.Add( "ClientDisconnect", "AssignGameID", function( Client )
 		GameIDs:Remove( Client )
-	end, -20 )
+	end, Shine.Hook.MAX_PRIORITY )
 end
 
 local function GetIDFromClient( Client )

--- a/lua/shine/core/server/permissions.lua
+++ b/lua/shine/core/server/permissions.lua
@@ -230,9 +230,7 @@ function Shine:SaveUsers( Silent )
 	local Success, Err = self.SaveJSONFile( self.UserData, UserPath )
 
 	if not Success then
-		self.Error = "Error writing user file: "..Err
-
-		Notify( self.Error )
+		Notify( "Error writing user file: "..Err )
 
 		return
 	end

--- a/lua/shine/core/shared/extensions.lua
+++ b/lua/shine/core/shared/extensions.lua
@@ -615,7 +615,7 @@ if Server then
 		end
 
 		Shine.SendNetworkMessage( Client, "Shine_PluginSync", Message, true )
-	end, -20 )
+	end, Shine.Hook.MAX_PRIORITY )
 
 	return
 end
@@ -717,4 +717,4 @@ Hook.Add( "OnMapLoad", "AutoLoadExtensions", function()
 			Shine:EnableExtension( Plugin )
 		end
 	end
-end, -20 )
+end, Shine.Hook.MAX_PRIORITY )

--- a/lua/shine/extensions/afkkick/server.lua
+++ b/lua/shine/extensions/afkkick/server.lua
@@ -261,6 +261,8 @@ do
 			self:CreateTimer( "AFKCheck", 1, -1, function() self:EvaluatePlayers() end )
 		end
 
+		self.dt.CheckSteamOverlay = self.Config.CheckSteamOverlay
+
 		self.Enabled = true
 
 		return true

--- a/lua/shine/extensions/afkkick/server.lua
+++ b/lua/shine/extensions/afkkick/server.lua
@@ -532,7 +532,7 @@ function Plugin:OnProcessMove( Player, Input )
 	end
 
 	local Pitch, Yaw = Input.pitch, Input.yaw
-	local DeltaTime = Time - DataTable.LastMeasurement
+	local DeltaTime = Max( Time - DataTable.LastMeasurement, 0 )
 
 	DataTable.LastMeasurement = Time
 

--- a/lua/shine/extensions/afkkick/server.lua
+++ b/lua/shine/extensions/afkkick/server.lua
@@ -10,12 +10,13 @@ local GetMaxPlayers = Server.GetMaxPlayers
 local GetNumPlayersTotal = Server.GetNumPlayersTotal
 local GetOwner = Server.GetOwner
 local Max = math.max
-local xpcall = xpcall
+local Random = math.random
 local SharedTime = Shared.GetTime
 local StringTimeToString = string.TimeToString
+local xpcall = xpcall
 
 local Plugin = Plugin
-Plugin.Version = "1.8"
+Plugin.Version = "1.9"
 Plugin.PrintName = "AFKKick"
 
 Plugin.HasConfig = true
@@ -41,7 +42,10 @@ Plugin.DefaultConfig = {
 	KickOnConnect = false,
 	KickTimeIsAFKThreshold = 0.25,
 	MarkPlayersAFK = true,
-	CheckSteamOverlay = true,
+	-- How frequently to sample player movement (in seconds, defaulting to ~4 times per second).
+	-- Lower values will have a negative impact on performance, while higher values will reduce
+	-- the accuracy of AFK checks.
+	SampleIntervalInSeconds = 0.25,
 	WarnActions = {
 		-- Actions to perform to players when they are warned.
 		-- May be any of: MoveToSpectate, MoveToReadyRoom, Notify
@@ -261,7 +265,7 @@ do
 			self:CreateTimer( "AFKCheck", 1, -1, function() self:EvaluatePlayers() end )
 		end
 
-		self.dt.CheckSteamOverlay = self.Config.CheckSteamOverlay
+		self.SampleInterval = self.Config.SampleIntervalInSeconds
 
 		self.Enabled = true
 
@@ -332,6 +336,7 @@ function Plugin:ClientConnect( Client )
 	self.Users:Add( Client, {
 		LastMove = MeasureStartTime,
 		LastMeasurement = MeasureStartTime,
+		NextSample = MeasureStartTime,
 		AFKAmount = 0,
 		Pos = Player:GetOrigin(),
 		Ang = Player:GetViewAngles(),
@@ -357,17 +362,9 @@ function Plugin:ResetAFKTime( Client )
 	end
 end
 
-function Plugin:IsSteamOverlayOpenFor( DataTable )
-	return DataTable.SteamOverlayIsOpen and self.Config.CheckSteamOverlay
-end
-
 function Plugin:SubtractAFKTime( Client, Time )
 	local DataTable = self.Users:Get( Client )
 	if not DataTable then return end
-
-	-- Do not subtract any time if the player's Steam overlay is open.
-	-- It could be possible to leave the voice chat button going with it open.
-	if self:IsSteamOverlayOpenFor( DataTable ) then return end
 
 	DataTable.Warn = false
 	DataTable.LastMove = SharedTime()
@@ -377,20 +374,6 @@ function Plugin:SubtractAFKTime( Client, Time )
 	if DataTable.IsAFK then
 		DataTable.IsAFK = false
 		Shine.Hook.Call( "AFKChanged", Client, DataTable.IsAFK )
-	end
-end
-
-function Plugin:ReceiveSteamOverlay( Client, Data )
-	local DataTable = self.Users:Get( Client )
-	if not DataTable then return end
-
-	-- Players with their Steam overlay open are treated as AFK, regardless of
-	-- input received.
-	DataTable.SteamOverlayIsOpen = Data.Open
-
-	if self.Logger:IsTraceEnabled() then
-		self.Logger:Trace( "Steam overlay of %s is now %s.", Shine.GetClientInfo( Client ),
-			Data.Open and "open" or "closed" )
 	end
 end
 
@@ -463,11 +446,10 @@ function Plugin:EvaluatePlayer( Client, DataTable, Params )
 			local WarnActions = self:GetWarnActions( IsPartiallyImmune )
 
 			if self.Logger:IsDebugEnabled() then
-				self.Logger:Debug( "Applying %s warn actions to %s as their last move time was %.2f vs. %.2f (no movement for %.2f seconds). Steam overlay is %s.",
+				self.Logger:Debug( "Applying %s warn actions to %s as their last move time was %.2f vs. %.2f (no movement for %.2f seconds).",
 					IsPartiallyImmune and "partial immunity" or "normal",
 					Shine.GetClientInfo( Client ),
-					DataTable.LastMove, Time, TimeSinceLastMove,
-					DataTable.SteamOverlayIsOpen and "open" or "closed" )
+					DataTable.LastMove, Time, TimeSinceLastMove )
 			end
 
 			for i = 1, #WarnActions do
@@ -486,9 +468,8 @@ function Plugin:EvaluatePlayer( Client, DataTable, Params )
 		self.Logger:Info( "Client %s was AFK for over %s. Player count: %d. Min Players: %d. Kicking...",
 			Shine.GetClientInfo( Client ), StringTimeToString( KickTime ),
 			NumPlayers, self.Config.MinPlayers )
-		self.Logger:Debug( "AFK amount was %.2f vs. time since last move of %.2f. Steam overlay is %s.",
-			AFKAmount, TimeSinceLastMove,
-			DataTable.SteamOverlayIsOpen and "open" or "closed" )
+		self.Logger:Debug( "AFK amount was %.2f vs. time since last move of %.2f.",
+			AFKAmount, TimeSinceLastMove )
 
 		self:KickClient( Client )
 	end
@@ -509,6 +490,7 @@ function Plugin:EvaluatePlayers()
 		NumPlayers = NumPlayers,
 		Gamerules = Gamerules
 	}
+
 	for Client, DataTable in self.Users:Iterate() do
 		self:EvaluatePlayer( Client, DataTable, Params )
 	end
@@ -535,7 +517,13 @@ function Plugin:OnProcessMove( Player, Input )
 	if not DataTable then return end
 
 	local Time = SharedTime()
-	if DataTable.LastMove > Time then return end
+	if DataTable.LastMove > Time or DataTable.NextSample > Time then return end
+
+	-- Sample input in a fixed interval. We don't necessarily need to see every single
+	-- move command to know if they're AFK (and we work on delta-time between measurements
+	-- so we don't really care how long a time there is between them.)
+	-- We apply a random offset to the time to avoid clients being able to predict the window.
+	DataTable.NextSample = Time + self.SampleInterval + Random() * self.SampleInterval * 0.5
 
 	local IsSpectator = Player:GetTeamNumber() == kSpectatorIndex
 	if IsSpectator and self.Config.IgnoreSpectators then
@@ -558,7 +546,7 @@ function Plugin:OnProcessMove( Player, Input )
 	-- Track frozen player's input, but do not punish them if they are not providing any.
 	local IsPlayerFrozen = self:IsPlayerFrozen( Player )
 
-	if not ( MovementIsEmpty and AnglesMatch or self:IsSteamOverlayOpenFor( DataTable ) ) then
+	if not ( MovementIsEmpty and AnglesMatch ) then
 		DataTable.LastMove = Time
 
 		local Leniency = self:GetLeniency( self:IsClientPartiallyImmune( Client ) )

--- a/lua/shine/extensions/afkkick/shared.lua
+++ b/lua/shine/extensions/afkkick/shared.lua
@@ -6,10 +6,7 @@ local Plugin = {}
 Plugin.NotifyPrefixColour = { 255, 50, 0 }
 
 function Plugin:SetupDataTable()
-	self:AddDTVar( "boolean", "CheckSteamOverlay", true )
-
 	self:AddNetworkMessage( "AFKNotify", {}, "Client" )
-	self:AddNetworkMessage( "SteamOverlay", { Open = "boolean" }, "Server" )
 	self:AddTranslatedNotify( "WARN_KICK_ON_CONNECT", {
 		AFKTime = "integer"
 	} )
@@ -63,41 +60,6 @@ function Plugin:SetupAFKScoreboardPrefix()
 	end
 end
 
-local OVERLAY_TIMER_NAME = "SteamOverlayCheck"
-local GetIsSteamOverlayActive
 function Plugin:OnFirstThink()
-	GetIsSteamOverlayActive = Client.GetIsSteamOverlayActive
 	self:SetupAFKScoreboardPrefix()
-
-	if self.dt.CheckSteamOverlay then
-		self:SetupSteamOverlayCheck()
-	end
-end
-
-function Plugin:NetworkUpdate( Key, Old, New )
-	if Key == "CheckSteamOverlay" then
-		if New then
-			self:SetupSteamOverlayCheck()
-		else
-			self:DestroyTimer( OVERLAY_TIMER_NAME )
-		end
-	end
-end
-
-function Plugin:SetupSteamOverlayCheck()
-	self:CreateTimer( OVERLAY_TIMER_NAME, 1, -1, function()
-		self:CheckSteamOverlay()
-	end )
-end
-
-local SteamOverlayIsOpen = false
-function Plugin:CheckSteamOverlay()
-	local CurrentOverlayState = GetIsSteamOverlayActive()
-
-	-- Watch the Steam overlay. If it's opened, then the server should ignore all input
-	-- from the player until it closes, thus treating them as AFK.
-	if CurrentOverlayState ~= SteamOverlayIsOpen then
-		SteamOverlayIsOpen = CurrentOverlayState
-		self:SendNetworkMessage( "SteamOverlay", { Open = SteamOverlayIsOpen }, true )
-	end
 end

--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -1100,7 +1100,7 @@ function Plugin:CreateAdminCommands()
 end
 
 function Plugin:CreateAllTalkCommands()
-	local function GenerateAllTalkCommand( Command, ChatCommand, ConfigOption, CommandNotifyString )
+	local function GenerateAllTalkCommand( Command, ChatCommand, ConfigOption, CommandNotifyString, HelpName )
 		local function CommandFunc( Client, Enable )
 			self:SetAllTalkEnabled( ConfigOption, Enable )
 
@@ -1115,13 +1115,14 @@ function Plugin:CreateAllTalkCommands()
 		local Command = self:BindCommand( Command, ChatCommand, CommandFunc )
 		Command:AddParam{ Type = "boolean", Optional = true,
 			Default = function() return not self.Config[ ConfigOption ] end }
-		Command:Help( StringFormat( "Enables or disables %s.", CommandNotifyString ) )
+		Command:Help( StringFormat( "Enables or disables %s.", HelpName ) )
 	end
 
-	GenerateAllTalkCommand( "sh_alltalk", "alltalk", "AllTalk", "ALLTALK_TOGGLED" )
+	GenerateAllTalkCommand( "sh_alltalk", "alltalk", "AllTalk", "ALLTALK_TOGGLED", "all talk" )
 	GenerateAllTalkCommand( "sh_alltalkpregame", "alltalkpregame", "AllTalkPreGame",
-		"ALLTALK_PREGAME_TOGGLED" )
-	GenerateAllTalkCommand( "sh_alltalklocal", "alltalklocal", "AllTalkLocal", "ALLTALK_LOCAL_TOGGLED" )
+		"ALLTALK_PREGAME_TOGGLED", "all talk in the pregame" )
+	GenerateAllTalkCommand( "sh_alltalklocal", "alltalklocal", "AllTalkLocal",
+		"ALLTALK_LOCAL_TOGGLED", "local all talk" )
 end
 
 function Plugin:CreateGameplayCommands()

--- a/lua/shine/extensions/chatbox/client.lua
+++ b/lua/shine/extensions/chatbox/client.lua
@@ -33,13 +33,16 @@ local Plugin = {}
 Plugin.HasConfig = true
 Plugin.ConfigName = "ChatBox.json"
 
+Plugin.Version = "1.1"
+
 Plugin.DefaultConfig = {
-	AutoClose = true, --Should the chatbox close after sending a message?
-	DeleteOnClose = true, --Should whatever's entered be deleted if the chatbox is closed before sending?
-	MessageMemory = 50, --How many messages should the chatbox store before removing old ones?
-	SmoothScroll = true, --Should the scrolling be smoothed?
-	Opacity = 0.4, --How opaque should the chatbox be?
-	Pos = {}, --Remembers the position of the chatbox when it's moved.
+	AutoClose = true, -- Should the chatbox close after sending a message?
+	DeleteOnClose = true, -- Should whatever's entered be deleted if the chatbox is closed before sending?
+	MessageMemory = 50, -- How many messages should the chatbox store before removing old ones?
+	SmoothScroll = true, -- Should the scrolling be smoothed?
+	ScrollToBottomOnOpen = false, -- Should the chatbox scroll to the bottom when re-opened?
+	Opacity = 0.4, -- How opaque should the chatbox be?
+	Pos = {}, -- Remembers the position of the chatbox when it's moved.
 	Scale = 1 -- Sets a scale multiplier, requires recreating the chatbox when changed.
 }
 
@@ -703,10 +706,6 @@ do
 
 	local Elements = {
 		{
-			Type = "Label",
-			Values = { "SETTINGS_TITLE" }
-		},
-		{
 			Type = "CheckBox",
 			ConfigValue = "AutoClose",
 			Values = function( self )
@@ -728,6 +727,13 @@ do
 			end,
 			Values = function( self )
 				return GetCheckBoxSize( self ), self.Config.SmoothScroll, "SMOOTH_SCROLL"
+			end
+		},
+		{
+			Type = "CheckBox",
+			ConfigValue = "ScrollToBottomOnOpen",
+			Values = function( self )
+				return GetCheckBoxSize( self ), self.Config.ScrollToBottomOnOpen, "SCROLL_TO_BOTTOM"
 			end
 		},
 		{
@@ -1241,11 +1247,15 @@ do
 
 		self:RefreshLayout( true )
 
-		--Get our text entry accepting input.
+		if self.Config.ScrollToBottomOnOpen then
+			self.ChatBox:ScrollToBottom( false )
+		end
+
+		-- Get our text entry accepting input.
 		self.TextEntry:RequestFocus()
 		self.Visible = true
 
-		--Set this so we don't accept text input straight away, avoids the bind button making it in.
+		-- Set this so we don't accept text input straight away, avoids the bind button making it in.
 		self.OpenTime = Clock()
 
 		return true

--- a/lua/shine/extensions/mapvote/cycle.lua
+++ b/lua/shine/extensions/mapvote/cycle.lua
@@ -231,18 +231,21 @@ function Plugin:GetNextMap()
 	return Map
 end
 
-function Plugin:Think()
+function Plugin:SetupEmptyCheckTimer()
 	if not self.Config.CycleOnEmpty then return end
-	if SharedTime() <= ( self.MapCycle.time * 60 ) then return end
-	if Shine.GameIDs:GetCount() > self.Config.EmptyPlayerCount then return end
 
-	if not self.Cycled then
-		self.Cycled = true
+	self:CreateTimer( "EmptyCheck", 1, -1, function()
+		if SharedTime() <= ( self.MapCycle.time * 60 ) then return end
+		if Shine.GameIDs:GetCount() > self.Config.EmptyPlayerCount then return end
 
-		Shine:LogString( "Server is at or below empty player count and map has exceeded its timelimit. Cycling to next map..." )
+		if not self.Cycled then
+			self.Cycled = true
 
-		MapCycle_ChangeMap( self:GetNextMap() )
-	end
+			Shine:LogString( "Server is at or below empty player count and map has exceeded its timelimit. Cycling to next map..." )
+
+			MapCycle_ChangeMap( self:GetNextMap() )
+		end
+	end )
 end
 
 local LastMapsFile = "config://shine/temp/lastmaps.json"

--- a/lua/shine/extensions/mapvote/cycle.lua
+++ b/lua/shine/extensions/mapvote/cycle.lua
@@ -159,11 +159,15 @@ function Plugin:IsValidMapChoice( Map, PlayerCount )
 	return true
 end
 
+function Plugin:GetCurrentMap()
+	return Shared.GetMapName()
+end
+
 --[[
 	Returns the next map in the map cycle or the map that's been voted for next.
 ]]
 function Plugin:GetNextMap()
-	local CurMap = Shared.GetMapName()
+	local CurMap = self:GetCurrentMap()
 
 	local Winner = self.NextMap.Winner
 	if Winner and Winner ~= CurMap then return Winner end --Winner decided.
@@ -261,7 +265,7 @@ function Plugin:SaveLastMaps()
 	end
 
 	-- Store the last played maps in an ever repeating cycle.
-	local CurrentMap = Shared.GetMapName()
+	local CurrentMap = self:GetCurrentMap()
 	for i = #Data, 1, -1 do
 		if Data[ i ] == CurrentMap then
 			TableRemove( Data, i )
@@ -292,7 +296,7 @@ function Plugin:LoadMapStats()
 end
 
 function Plugin:SaveMapStats()
-	local Map = Shared.GetMapName()
+	local Map = self:GetCurrentMap()
 
 	self.MapStats[ Map ] = ( self.MapStats[ Map ] or 0 ) + 1
 

--- a/lua/shine/extensions/mapvote/server.lua
+++ b/lua/shine/extensions/mapvote/server.lua
@@ -64,8 +64,8 @@ Plugin.DefaultConfig = {
 			-- Constraint on the number of voters needed to pass a map vote.
 			-- Percentage applies to the current server player count.
 			MinVotesRequired = {
-				Type = Plugin.ConstraintType.ABSOLUTE,
-				Value = 0
+				Type = Plugin.ConstraintType.PERCENT,
+				Value = 0.6
 			},
 			-- Constraint on the number of voters needed to end a map vote early.
 			-- Percentage applies to the current server player count.

--- a/lua/shine/extensions/mapvote/server.lua
+++ b/lua/shine/extensions/mapvote/server.lua
@@ -385,6 +385,7 @@ function Plugin:Initialise()
 
 	self:LoadLastMaps()
 	self:CreateCommands()
+	self:SetupEmptyCheckTimer()
 
 	self.Enabled = true
 

--- a/lua/shine/extensions/mapvote/server.lua
+++ b/lua/shine/extensions/mapvote/server.lua
@@ -97,6 +97,7 @@ Plugin.DefaultConfig = {
 	ChangeDelayInSeconds = 10, -- Time in seconds to wait before changing map after a vote (gives time for veto)
 	VoteDelayInMinutes = 10, -- Time to wait in minutes after map change/vote fail before voting can occur.
 	BlockAfterRoundTimeInMinutes = 0, -- Time in minutes after a round start to block starting map votes.
+	VoteTimeoutInSeconds = 60, -- Time after the last vote before the vote resets.
 
 	ShowVoteChoices = true, -- Show who votes for what map.
 	MaxOptions = 4, -- Max number of options to provide.
@@ -318,6 +319,7 @@ function Plugin:Initialise()
 
 	self.StartingVote = Shine:CreateVote( function() return self:GetVotesNeededToStart() end,
 		self:WrapCallback( function() self:StartVote() end ) )
+	self:SetupVoteTimeout( self.StartingVote, self.Config.VoteTimeoutInSeconds )
 	function self.StartingVote.OnReset()
 		self:ResetVoteCounters()
 	end

--- a/lua/shine/extensions/mapvote/server.lua
+++ b/lua/shine/extensions/mapvote/server.lua
@@ -23,6 +23,10 @@ Plugin.HasConfig = true
 Plugin.ConfigName = "MapVote.json"
 Plugin.PrintName = "Map Vote"
 
+Plugin.ConstraintType = table.AsEnum{
+	"PERCENT", "ABSOLUTE"
+}
+
 Plugin.DefaultConfig = {
 	GetMapsFromMapCycle = true, -- Get the valid votemaps directly from the mapcycle file.
 	Maps = { -- Valid votemaps if you do not wish to get them from the map cycle.
@@ -46,13 +50,13 @@ Plugin.DefaultConfig = {
 			-- Constraint on the number of voters needed to pass a start vote.
 			-- Percentage applies to the current server player count.
 			MinVotesRequired = {
-				Type = "PERCENT",
+				Type = Plugin.ConstraintType.PERCENT,
 				Value = 0.6
 			},
 			-- Constraint on the number of players needed to start a vote.
 			-- Percentage applies to the max player slot count.
 			MinPlayers = {
-				Type = "ABSOLUTE",
+				Type = Plugin.ConstraintType.ABSOLUTE,
 				Value = 10
 			}
 		},
@@ -60,13 +64,13 @@ Plugin.DefaultConfig = {
 			-- Constraint on the number of voters needed to pass a map vote.
 			-- Percentage applies to the current server player count.
 			MinVotesRequired = {
-				Type = "ABSOLUTE",
+				Type = Plugin.ConstraintType.ABSOLUTE,
 				Value = 0
 			},
 			-- Constraint on the number of voters needed to end a map vote early.
 			-- Percentage applies to the current server player count.
 			MinVotesToFinish = {
-				Type = "PERCENT",
+				Type = Plugin.ConstraintType.PERCENT,
 				Value = 0.8
 			}
 		},
@@ -74,13 +78,13 @@ Plugin.DefaultConfig = {
 			-- Constraint on the number of voters needed to pass a next map vote.
 			-- Percentage applies to the current server player count.
 			MinVotesRequired = {
-				Type = "ABSOLUTE",
+				Type = Plugin.ConstraintType.ABSOLUTE,
 				Value = 0
 			},
 			-- Constraint on the number of voters needed to end a next map vote early.
 			-- Percentage applies to the current server player count.
 			MinVotesToFinish = {
-				Type = "PERCENT",
+				Type = Plugin.ConstraintType.PERCENT,
 				-- Never finish early by default.
 				Value = 2
 			}
@@ -89,9 +93,9 @@ Plugin.DefaultConfig = {
 
 	MaxNominationsPerPlayer = 3, -- The maximum number of maps an individual player can nominate.
 
-	VoteLength = 1, -- Time in minutes a vote should last before failing.
-	ChangeDelay = 10, -- Time in seconds to wait before changing map after a vote (gives time for veto)
-	VoteDelay = 10, -- Time to wait in minutes after map change/vote fail before voting can occur.
+	VoteLengthInMinutes = 1, -- Time in minutes a vote should last before failing.
+	ChangeDelayInSeconds = 10, -- Time in seconds to wait before changing map after a vote (gives time for veto)
+	VoteDelayInMinutes = 10, -- Time to wait in minutes after map change/vote fail before voting can occur.
 	BlockAfterRoundTimeInMinutes = 0, -- Time in minutes after a round start to block starting map votes.
 
 	ShowVoteChoices = true, -- Show who votes for what map.
@@ -99,9 +103,12 @@ Plugin.DefaultConfig = {
 	ForceMenuOpenOnMapVote = false, -- Whether to force the map vote menu to show when a vote starts.
 
 	AllowExtend = true, -- Allow going to the same map to be an option.
-	ExtendTime = 15, -- Time in minutes to extend the map.
+	ExtendTimeInMinutes = 15, -- Time in minutes to extend the map.
 	MaxExtends = 1, -- Maximum number of map extensions.
 	AlwaysExtend = true, -- Always show an option to extend the map if not past the max extends.
+	-- Treat similarly named maps to the current map as extensions
+	-- (and thus prevent them from being an option when extension is denied)
+	ConsiderSimilarMapsAsExtension = false,
 
 	TieFails = false, -- A tie means the vote fails.
 	ChooseRandomOnTie = true, -- Choose randomly between the tied maps. If not, a revote is called.
@@ -110,10 +117,10 @@ Plugin.DefaultConfig = {
 	EnableRTV = true, -- Enables RTV voting.
 
 	EnableNextMapVote = true, -- Enables the vote to choose the next map.
-	NextMapVote = 1, -- How far into a game to begin a vote for the next map. Setting to 1 queues for the end of the map.
+	NextMapVoteMapTimeFraction = 1, -- How far into a game to begin a vote for the next map. Setting to 1 queues for the end of the map.
 	RoundLimit = 0, -- How many rounds should the map last for? This overrides time based cycling.
 
-	ForceChange = 60, -- How long left on the current map when a round ends that should force a change to the next map.
+	ForceChangeWhenSecondsLeft = 60, -- How long left on the current map when a round ends that should force a change to the next map.
 	CycleOnEmpty = false, -- Should the map cycle when the server's empty and it's past the map's time limit?
 	EmptyPlayerCount = 0, -- How many players defines 'empty'?
 
@@ -148,31 +155,31 @@ Plugin.ConfigMigrationSteps = {
 			Config.Constraints = {
 				StartVote = {
 					MinVotesRequired = {
-						Type = "PERCENT",
+						Type = Plugin.ConstraintType.PERCENT,
 						Value = tonumber( Config.PercentToStart ) or 0.6
 					},
 					MinPlayers = {
-						Type = "ABSOLUTE",
+						Type = Plugin.ConstraintType.ABSOLUTE,
 						Value = tonumber( Config.MinPlayers ) or 10
 					}
 				},
 				MapVote = {
 					MinVotesRequired = {
-						Type = "PERCENT",
+						Type = Plugin.ConstraintType.PERCENT,
 						Value = 0
 					},
 					MinVotesToFinish = {
-						Type = "PERCENT",
+						Type = Plugin.ConstraintType.PERCENT,
 						Value = tonumber( Config.PercentToFinish ) or 0.8
 					}
 				},
 				NextMapVote = {
 					MinVotesRequired = {
-						Type = "ABSOLUTE",
+						Type = Plugin.ConstraintType.ABSOLUTE,
 						Value = 0
 					},
 					MinVotesToFinish = {
-						Type = "PERCENT",
+						Type = Plugin.ConstraintType.PERCENT,
 						Value = 2
 					}
 				}
@@ -185,6 +192,15 @@ Plugin.ConfigMigrationSteps = {
 	{
 		VersionTo = "1.10",
 		Apply = function( Config )
+			Config.VoteLengthInMinutes = Config.VoteLength
+			Config.ChangeDelayInSeconds = Config.ChangeDelay
+			Config.VoteDelayInMinutes = Config.VoteDelay
+
+			Config.ExtendTimeInMinutes = Config.ExtendTime
+
+			Config.NextMapVoteMapTimeFraction = Config.NextMapVote
+			Config.ForceChangeWhenSecondsLeft = Config.ForceChange
+
 			if not IsType( Config.ExcludeLastMaps, "table" ) then return end
 
 			if Config.ExcludeLastMaps.UseStrictMatching == nil then
@@ -216,15 +232,14 @@ Shine.LoadPluginFile( "mapvote", "voting.lua" )
 
 do
 	local StringUpper = string.upper
-	Plugin.ConstraintType = table.AsEnum{
-		"PERCENT", "ABSOLUTE"
-	}
 
 	local Validator = Shine.Validator()
-	Validator:AddFieldRule( "ForceChange", Validator.Min( 0 ) )
+	Validator:AddFieldRule( "ForceChangeWhenSecondsLeft", Validator.Min( 0 ) )
 	Validator:AddFieldRule( "RoundLimit", Validator.Min( 0 ) )
-	Validator:AddFieldRule( "VoteLength", Validator.Min( 0.25 ) )
-	Validator:AddFieldRule( "VoteLength", Validator.Clamp( 0, 1 ) )
+	Validator:AddFieldRule( "ChangeDelayInSeconds", Validator.Min( 0 ) )
+	Validator:AddFieldRule( "VoteLengthInMinutes", Validator.Min( 0.25 ) )
+	Validator:AddFieldRule( "VoteLengthInMinutes", Validator.Clamp( 0, 1 ) )
+	Validator:AddFieldRule( "NextMapVoteMapTimeFraction", Validator.Clamp( 0, 1 ) )
 	Validator:AddFieldRule( "ExcludeLastMaps.Min", Validator.Min( 0 ) )
 	Validator:AddFieldRule( "ExcludeLastMaps.UseStrictMatching", Validator.IsType( "boolean", true ) )
 	Validator:AddRule( {
@@ -292,7 +307,7 @@ function Plugin:Initialise()
 	self.Round = 0
 
 	self.Vote = self.Vote or {}
-	self.Vote.NextVote = self.Vote.NextVote or ( SharedTime() + ( self.Config.VoteDelay * 60 ) )
+	self.Vote.NextVote = self.Vote.NextVote or ( SharedTime() + self:GetVoteDelay() )
 	self.Vote.Nominated = {} -- Table of nominated maps.
 	self.Vote.NominationTracker = {} -- Tracks the amount of times someone's nominated a map.
 	self.Vote.Votes = 0 -- Number of map votes that have taken place.
@@ -332,12 +347,12 @@ function Plugin:Initialise()
 	self.MapCycle.time = tonumber( self.MapCycle.time ) or 30
 
 	if self.Config.EnableNextMapVote and AllowVotes then
-		if self.Config.NextMapVote == 1 or self.Config.RoundLimit > 0 then
+		if self.Config.NextMapVoteMapTimeFraction >= 1 or self.Config.RoundLimit > 0 then
 			self.VoteOnEnd = true
 		else
 			local Time = SharedTime()
 			local CycleTime = Cycle and ( Cycle.time * 60 ) or 1800
-			self.NextMapVoteTime = Time + CycleTime * self.Config.NextMapVote
+			self.NextMapVoteTime = Time + CycleTime * self.Config.NextMapVoteMapTimeFraction
 		end
 	end
 
@@ -461,7 +476,7 @@ function Plugin:EndGame()
 			self:StartVote( true )
 		end
 
-		if TimeLeft <= self.Config.ForceChange then
+		if TimeLeft <= self.Config.ForceChangeWhenSecondsLeft then
 			if not self:VoteStarted() and not self.VoteOnEnd then
 				self:SendTranslatedNotify( nil, "MapCycling", {
 					MapName = self:GetNextMap()

--- a/lua/shine/extensions/mapvote/voting.lua
+++ b/lua/shine/extensions/mapvote/voting.lua
@@ -75,6 +75,8 @@ end
 function Plugin:SetGameState( Gamerules, State, OldState )
 	if State == kGameState.Started and self.Config.BlockAfterRoundTimeInMinutes > 0 then
 		self.VoteDisableTime = SharedTime() + self.Config.BlockAfterRoundTimeInMinutes * 60
+	else
+		self.VoteDisableTime = math.huge
 	end
 end
 

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -404,13 +404,8 @@ function Plugin:Initialise()
 		self:ApplyRandomSettings()
 	end
 
-	local function OnTimeout( Vote )
-		if Vote.LastVoted and SharedTime() - Vote.LastVoted > self.Config.VoteTimeout then
-			Vote:Reset()
-		end
-	end
-
-	self.Vote = Shine:CreateVote( GetVotesNeeded, self:WrapCallback( OnVotePassed ), OnTimeout )
+	self.Vote = Shine:CreateVote( GetVotesNeeded, self:WrapCallback( OnVotePassed ) )
+	self:SetupVoteTimeout( self.Vote, self.Config.VoteTimeout )
 	function self.Vote.OnReset()
 		self:ResetVoteCounters()
 	end
@@ -987,13 +982,6 @@ function Plugin:AddVote( Client )
 	end
 
 	return true
-end
-
---[[
-	Timeout the vote.
-]]
-function Plugin:Think()
-	self.Vote:Think()
 end
 
 Plugin.Stage = table.AsEnum{

--- a/lua/shine/extensions/votesurrender/server.lua
+++ b/lua/shine/extensions/votesurrender/server.lua
@@ -87,6 +87,13 @@ end
 	If a round has started, we set the next vote time to current time + delay.
 ]]
 function Plugin:SetGameState( Gamerules, State, OldState )
+	if State >= kGameState.Started then
+		-- Game has started/ended, reset the votes.
+		for i = 1, 2 do
+			self.Votes[ i ]:Reset()
+		end
+	end
+
 	if State == kGameState.Started then
 		self.NextVote = SharedTime() + ( self.Config.VoteDelay * 60 )
 	end
@@ -209,7 +216,7 @@ end
 ]]
 function Plugin:Surrender( Team )
 	local Gamerules = GetGamerules()
-	if not Gamerules then return end
+	if not Gamerules or Gamerules:GetGameState() ~= kGameState.Started then return end
 
 	for i = 1, 2 do
 		self.Votes[ i ]:Reset()

--- a/lua/shine/extensions/votesurrender/server.lua
+++ b/lua/shine/extensions/votesurrender/server.lua
@@ -211,6 +211,10 @@ function Plugin:Surrender( Team )
 	local Gamerules = GetGamerules()
 	if not Gamerules then return end
 
+	for i = 1, 2 do
+		self.Votes[ i ]:Reset()
+	end
+
 	Shine.SendNetworkMessage( "TeamConceded", { teamNumber = Team } )
 
 	local WinningTeam = Gamerules:GetTeam( Team == 1 and 2 or 1 )

--- a/lua/shine/extensions/votesurrender/server.lua
+++ b/lua/shine/extensions/votesurrender/server.lua
@@ -57,20 +57,16 @@ function Plugin:Initialise()
 	ClampConfigOption( "PercentNeededInEarlyGame", 0, 1 )
 	ClampConfigOption( "LastCommandStructureMinHealthPercent", 0, 1 )
 
-	local function VoteTimeout( Vote )
-		local LastVoted = Vote.LastVoted
-		if LastVoted and SharedTime() - LastVoted > self.Config.VoteTimeout then
-			Vote:Reset()
-		end
-	end
-
 	self.Votes = {
 		Shine:CreateVote( function() return self:GetVotesNeeded( 1 ) end,
-			self:WrapCallback( function() self:Surrender( 1 ) end ), VoteTimeout ),
+			self:WrapCallback( function() self:Surrender( 1 ) end ) ),
 
 		Shine:CreateVote( function() return self:GetVotesNeeded( 2 ) end,
-			self:WrapCallback( function() self:Surrender( 2 ) end ), VoteTimeout )
+			self:WrapCallback( function() self:Surrender( 2 ) end ) )
 	}
+	for i = 1, 2 do
+		self:SetupVoteTimeout( self.Votes[ i ], self.Config.VoteTimeout, "VoteTimeout"..i )
+	end
 
 	self.NextVote = 0
 	self.dt.ConcedeTime = self.Config.VoteDelay
@@ -175,15 +171,6 @@ function Plugin:AddVote( Client, Team )
 	if not Success then return false, Err end
 
 	return true
-end
-
---[[
-	Timeout the vote. 1 minute and no votes should reset it.
-]]
-function Plugin:Think()
-	for i = 1, 2 do
-		self.Votes[ i ]:Think()
-	end
 end
 
 --[[

--- a/lua/shine/init.lua
+++ b/lua/shine/init.lua
@@ -47,10 +47,4 @@ local OnLoadedFuncs = {
 
 Shine.LoadScripts( Scripts, OnLoadedFuncs )
 
-if Shine.Error then
-	Shared.Message( "Shine failed to start. Check the console for errors." )
-
-	return
-end
-
 Shine:Print( "Shine started up successfully." )

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -284,7 +284,7 @@ Hook.Add( "PlayerKeyPress", "SGUICtrlMonitor", function( Key, Down )
 	elseif SGUI.IsShiftKey( Key ) then
 		SGUI.SpecialKeyStates.Shift = Down or false
 	end
-end, -20 )
+end, Hook.MAX_PRIORITY )
 
 function SGUI.IsShiftKey( Key )
 	return Key == InputKey.LeftShift or Key == InputKey.RightShift

--- a/lua/shine/lib/gui/objects/panel.lua
+++ b/lua/shine/lib/gui/objects/panel.lua
@@ -368,6 +368,12 @@ function Panel:SetMaxHeight( Height, ForceInstantScroll )
 	end
 end
 
+function Panel:ScrollToBottom( Smoothly )
+	if not SGUI.IsValid( self.Scrollbar ) then return end
+
+	self.Scrollbar:ScrollToBottom( Smoothly )
+end
+
 function Panel:SetScrollbarPos( Pos )
 	self.ScrollPos = Pos
 

--- a/lua/shine/lib/objects/linked_list.lua
+++ b/lua/shine/lib/objects/linked_list.lua
@@ -1,0 +1,152 @@
+--[[
+	A doubly-linked list.
+]]
+
+local LinkedList = Shine.TypeDef()
+Shine.LinkedList = LinkedList
+
+function LinkedList:Init()
+	self.Size = 0
+
+	return self
+end
+
+local function MakeNode( Value )
+	return {
+		Value = Value
+	}
+end
+
+
+-- Adds a value to the end of the linked list.
+-- Returns the added node.
+function LinkedList:Add( Value )
+	local Node = MakeNode( Value )
+
+	if not self.First then
+		self.First = Node
+	end
+
+	if self.Last then
+		Node.Prev = self.Last
+		self.Last.Next = Node
+	end
+
+	self.Last = Node
+	self.Size = self.Size + 1
+
+	return Node
+end
+
+-- Inserts a value at the front of the list.
+-- Returns the added node.
+function LinkedList:InsertAtFront( Value )
+	local NewNode = MakeNode( Value )
+	if self.First then
+		NewNode.Next = self.First
+		self.First.Prev = NewNode
+	end
+
+	self.First = NewNode
+	self.Size = self.Size + 1
+
+	return NewNode
+end
+
+-- Inserts a value after the given node.
+-- Returns the added node.
+function LinkedList:InsertAfter( Node, Value )
+	if not Node then
+		return self:InsertAtFront( Value )
+	end
+
+	local NewNode = MakeNode( Value )
+
+	NewNode.Next = Node.Next
+	NewNode.Prev = Node
+
+	if Node.Next then
+		Node.Next.Prev = NewNode
+	else
+		self.Last = NewNode
+	end
+
+	Node.Next = NewNode
+
+	self.Size = self.Size + 1
+
+	return NewNode
+end
+
+-- Inserts the given value after the last value in the list that is
+-- considered less than or equal to the given value using the given comparator.
+function LinkedList:InsertByComparing( Value, Comparator )
+	for Node in self:IterateNodes() do
+		if Comparator( Value, Node.Value ) then
+			return self:InsertAfter( Node.Prev, Value )
+		end
+	end
+
+	return self:Add( Value )
+end
+
+-- Removes the given node from the linked list.
+-- This assumes the node is part of the list.
+function LinkedList:Remove( Node )
+	if self.First == Node then
+		self.First = Node.Next
+
+		if self.First then
+			self.First.Prev = nil
+		end
+	else
+		Node.Prev.Next = Node.Next
+		if Node.Next then
+			Node.Next.Prev = Node.Prev
+		end
+	end
+
+	if Node == self.Last then
+		self.Last = Node.Prev
+	end
+
+	self.Size = self.Size - 1
+end
+
+-- Clears all values from the linked list.
+function LinkedList:Clear()
+	self.First = nil
+	self.Last = nil
+	self.Size = 0
+end
+
+-- Gets the number of elements in the linked list.
+function LinkedList:GetCount()
+	return self.Size
+end
+
+local function Iterate( State )
+	local Next = State.Next and State.Next.Next
+	if not Next then return nil end
+
+	State.Next = Next
+
+	return Next.Value
+end
+
+-- Iterates the values in the linked list.
+function LinkedList:Iterate()
+	return Iterate, { Next = { Next = self.First } }
+end
+
+local function IterateNodes( List, PrevNode )
+	if not PrevNode then
+		return List.First
+	end
+	return PrevNode.Next
+end
+
+-- Iterates the nodes in the linked list.
+function LinkedList:IterateNodes()
+	return IterateNodes, self
+end

--- a/lua/shine/lib/objects/map.lua
+++ b/lua/shine/lib/objects/map.lua
@@ -7,6 +7,7 @@ local Clamp = math.Clamp
 local getmetatable = getmetatable
 local IsType = Shine.IsType
 local pairs = pairs
+local TableEmpty = table.Empty
 local TableRemove = table.remove
 
 local Map = Shine.TypeDef()
@@ -33,6 +34,14 @@ function Map:Init( InitialValues )
 	end
 
 	return self
+end
+
+function Map:Clear()
+	TableEmpty( self.Keys )
+	TableEmpty( self.MemberLookup )
+
+	self.Position = 0
+	self.NumMembers = 0
 end
 
 function Map:IsEmpty()
@@ -318,6 +327,11 @@ function Multimap:Init( Values )
 	end
 
 	return self
+end
+
+function Multimap:Clear()
+	Map.Clear( self )
+	self.Count = 0
 end
 
 --[[

--- a/lua/shine/lib/objects/votes.lua
+++ b/lua/shine/lib/objects/votes.lua
@@ -12,6 +12,7 @@ local Shine = Shine
 local Max = math.max
 local setmetatable = setmetatable
 local SharedTime = Shared.GetTime
+local StringFormat = string.format
 local TableEmpty = table.Empty
 
 local VoteMeta = {}
@@ -104,6 +105,10 @@ end
 
 function VoteMeta:GetVotes()
 	return self.Votes
+end
+
+function VoteMeta:__tostring()
+	return StringFormat( "Vote[%s / %s]", self.Votes, self.VotesNeeded() )
 end
 
 function Shine:CreateVote( VotesNeeded, OnSuccess, Timeout )

--- a/lua/shine/lib/objects/votes.lua
+++ b/lua/shine/lib/objects/votes.lua
@@ -35,10 +35,16 @@ function VoteMeta:SetTimeout( Func )
 	self.Timeout = Func
 end
 
+function VoteMeta:SetTimeoutDuration( DurationInSeconds )
+	self:SetTimeout( function( self )
+		if self.LastVoted and SharedTime() - self.LastVoted > DurationInSeconds then
+			self:Reset()
+		end
+	end )
+end
+
 function VoteMeta:Think()
-	if self.Timeout then
-		self:Timeout()
-	end
+	self:Timeout()
 end
 
 function VoteMeta:Reset()

--- a/lua/shine/lib/timer.lua
+++ b/lua/shine/lib/timer.lua
@@ -134,13 +134,7 @@ do
 	end
 end
 
-local Error
-local StackTrace
-
-local function OnError( Err )
-	Error = Err
-	StackTrace = Shine.Traceback( 2 )
-end
+local OnError = Shine.BuildErrorHandler( "Timer error" )
 
 local StringFormat = string.format
 local xpcall = xpcall
@@ -159,14 +153,6 @@ Shine.Hook.Add( "Think", "Timers", function( DeltaTime )
 
 			local Success = xpcall( Timer.Func, OnError, Timer )
 			if not Success then
-				Shine:DebugPrint( "Timer %s failed: %s.\n%s", true,
-					Name, Error, StackTrace )
-				Shine:AddErrorReport( StringFormat( "Timer %s failed: %s.",
-					Name, Error ), StackTrace )
-
-				Error = nil
-				StackTrace = nil
-
 				Timer:Destroy()
 			else
 				if Timer.Reps == 0 then

--- a/lua/shine/lib/utf8.lua
+++ b/lua/shine/lib/utf8.lua
@@ -15,7 +15,6 @@ local select = select
 local StringByte = string.byte
 local StringChar = string.char
 local StringFormat = string.format
-local StringLen = string.len
 local StringSub = string.sub
 local TableConcat = table.concat
 local TableReverse = table.Reverse
@@ -1890,47 +1889,27 @@ local function TypeCheck( Arg, Type, ArgNumber, FuncName )
 	end
 end
 
-local ByteRules = {
-	{
-		{ 1, 127 }
-	},
-	{
-		{ 194, 223 },
-		{ 128, 191 }
-	},
-	{
-		{ 224, 239 },
-		{ 128, 191 },
-		{ 128, 191 },
-		EdgeCases = function( Bytes )
-			if Bytes[ 1 ] == 224 and ( Bytes[ 2 ] < 160 or Bytes[ 2 ] > 191 ) then
-				return false
-			end
-			if Bytes[ 1 ] == 237 and ( Bytes[ 2 ] < 128 or Bytes[ 2 ] > 159 ) then
-				return false
-			end
+local function IdentityValid( Bytes ) return Bytes end
 
-			return true
-		end
-	},
-	{
-		{ 240, 244 },
-		{ 128, 191 },
-		{ 128, 191 },
-		{ 128, 191 },
-		EdgeCases = function( Bytes )
-			if Bytes[ 1 ] == 240 and ( Bytes[ 2 ] < 144 or Bytes[ 2 ] > 191 ) then
-				return false
-			end
-			if Bytes[ 1 ] == 244 and ( Bytes[ 2 ] < 128 or Bytes[ 2 ] > 143 ) then
-				return false
-			end
+local function IsValidContinuationByte( Byte )
+	-- Leftmost 2 bits must be 10
+	return Byte and BitBand( Byte, 0xC0 ) == 0x80
+end
 
-			return true
-		end
-	}
-}
-local NumRules = #ByteRules
+local function GetNumContinuationBytes( FirstByte )
+	return FirstByte >= 0xF0 and 3 or FirstByte >= 0xE0 and 2 or 1
+end
+
+local ValidityChecks = {}
+for i = 0xC2, 0xF4 do
+	ValidityChecks[ i ] = IdentityValid
+end
+-- Check for overlong encoding.
+ValidityChecks[ 0xE0 ] = function( Bytes ) return Bytes[ 2 ] >= 0xA0 and Bytes or nil end
+ValidityChecks[ 0xF0 ] = function( Bytes ) return Bytes[ 2 ] >= 0x90 and Bytes or nil end
+ValidityChecks[ 0xF4 ] = function( Bytes ) return Bytes[ 2 ] <= 0x8F and Bytes or nil end
+-- Check for UTF-16 surrogate halves (0xD800 - 0xDFFF).
+ValidityChecks[ 0xED ] = function( Bytes ) return Bytes[ 2 ] <= 0x9F and Bytes or nil end
 
 --[[
 	Returns the bytes used by the UTF-8 character.
@@ -1947,38 +1926,29 @@ local function GetUTF8Bytes( String, Index )
 	local FirstByte = StringByte( String, Index )
 	if not FirstByte then return nil end
 
-	for i = 1, NumRules do
-		local Rule = ByteRules[ i ]
-		local FirstInterval = Rule[ 1 ]
-
-		if FirstByte >= FirstInterval[ 1 ] and FirstByte <= FirstInterval[ 2 ] then
-			local Matches = true
-			local Bytes = { FirstByte }
-
-			for j = 2, i do
-				local Interval = Rule[ j ]
-				local CurByte = StringByte( String, Index + j - 1 )
-
-				if not CurByte or ( CurByte < Interval[ 1 ] or CurByte > Interval[ 2 ] ) then
-					Matches = false
-					break
-				end
-
-				Bytes[ j ] = CurByte
-			end
-
-			if Matches then
-				local EdgeCases = Rule.EdgeCases
-				if not EdgeCases or EdgeCases( Bytes ) then
-					return Bytes
-				end
-			end
-
-			break
-		end
+	if FirstByte < 0x80 then
+		-- Trivial case, no continuation bytes.
+		return { FirstByte }
 	end
 
-	return nil
+	if FirstByte < 0xC2 or FirstByte > 0xF4 then
+		-- Byte is invalid, or a continuation byte.
+		return nil
+	end
+
+	local NumContinuationBytes = GetNumContinuationBytes( FirstByte )
+	local Bytes = { FirstByte }
+	for i = 1, NumContinuationBytes do
+		local Byte = StringByte( String, Index + i )
+		if not IsValidContinuationByte( Byte ) then
+			-- Every continuation byte must have the same 10xxxxxx structure.
+			return nil
+		end
+
+		Bytes[ i + 1 ] = Byte
+	end
+
+	return ValidityChecks[ FirstByte ]( Bytes )
 end
 
 --[[
@@ -2061,7 +2031,7 @@ do
 	local function GetMask( Bits )
 		local Mask = 1
 		for i = 1, Bits do
-			Mask = Mask + 2 ^ i
+			Mask = Mask + BitLShift( 1, i )
 		end
 		return Mask
 	end
@@ -2100,12 +2070,13 @@ do
 	end
 end
 
+local REPLACEMENT_CHAR = UTF8Char( 0xFFFD )
 --[[
 	Encodes a string into valid UTF-8, returning a table of UTF-8 characters.
 ]]
 local function UTF8Encode( String )
 	local CurByte = 1
-	local Bytes = StringLen( String )
+	local Bytes = #String
 	local Count = 0
 	local Chars = {}
 
@@ -2115,7 +2086,7 @@ local function UTF8Encode( String )
 
 		if not CharBytes then
 			CharBytes = 1
-			Char = UTF8Char( 0xFFFD )
+			Char = REPLACEMENT_CHAR
 		else
 			Char = StringSub( String, CurByte, CurByte + CharBytes - 1 )
 		end

--- a/lua/shine/lib/utf8.lua
+++ b/lua/shine/lib/utf8.lua
@@ -1920,9 +1920,6 @@ ValidityChecks[ 0xED ] = function( Bytes ) return Bytes[ 2 ] <= 0x9F and Bytes o
 local function GetUTF8Bytes( String, Index )
 	Index = Index or 1
 
-	TypeCheck( String, "string", 1, "GetUTF8Bytes" )
-	TypeCheck( Index, "number", 2, "GetUTF8Bytes" )
-
 	local FirstByte = StringByte( String, Index )
 	if not FirstByte then return nil end
 
@@ -1973,6 +1970,11 @@ end
 	Output: True if valid, false otherwise.
 ]]
 function string.IsValidUTF8( String, Index )
+	TypeCheck( String, "string", 1, "IsValidUTF8" )
+	if Index then
+		TypeCheck( Index, "number", 2, "IsValidUTF8" )
+	end
+
 	return GetUTF8Bytes( String, Index ) ~= nil
 end
 
@@ -1983,6 +1985,11 @@ end
 	Output: Up to 4 bytes of data. Returns nil if the character is invalid UTF8.
 ]]
 function string.GetUTF8Bytes( String, Index )
+	TypeCheck( String, "string", 1, "GetUTF8Bytes" )
+	if Index then
+		TypeCheck( Index, "number", 2, "GetUTF8Bytes" )
+	end
+
 	local Bytes = GetUTF8Bytes( String, Index )
 	if Bytes then
 		return unpack( Bytes )
@@ -1994,36 +2001,34 @@ end
 ]]
 local function UTF8Char( Char )
 	if Char < 0 or Char > 0x10FFFF then
-		error( "bad argument #1 to UTF8Char (out of range)", 2 )
+		error( "bad argument #1 to 'UTF8Char' (out of range)", 2 )
 	end
-
-	local Byte1, Byte2, Byte3, Byte4
 
 	if Char < 0x80 then
 		return StringChar( Char )
 	end
 
 	if Char < 0x800 then
-		Byte1 = BitBor( 0xC0, BitBand( BitRShift( Char, 6 ), 0x1F ) )
-		Byte2 = BitBor( 0x80, BitBand( Char, 0x3F ) )
-
-		return StringChar( Byte1, Byte2 )
+		return StringChar(
+			BitBor( 0xC0, BitBand( BitRShift( Char, 6 ), 0x1F ) ),
+			BitBor( 0x80, BitBand( Char, 0x3F ) )
+		)
 	end
 
 	if Char < 0x10000 then
-		Byte1 = BitBor( 0xE0, BitBand( BitRShift( Char, 12 ), 0x0F ) )
-		Byte2 = BitBor( 0x80, BitBand( BitRShift( Char, 6 ), 0x3F ) )
-		Byte3 = BitBor( 0x80, BitBand( Char, 0x3F ) )
-
-		return StringChar( Byte1, Byte2, Byte3 )
+		return StringChar(
+			BitBor( 0xE0, BitBand( BitRShift( Char, 12 ), 0x0F ) ),
+			BitBor( 0x80, BitBand( BitRShift( Char, 6 ), 0x3F ) ),
+			BitBor( 0x80, BitBand( Char, 0x3F ) )
+		)
 	end
 
-	Byte1 = BitBor( 0xF0, BitBand( BitRShift( Char, 18 ), 0x07 ) )
-	Byte2 = BitBor( 0x80, BitBand( BitRShift( Char, 12 ), 0x3F ) )
-	Byte3 = BitBor( 0x80, BitBand( BitRShift( Char, 6 ), 0x3F ) )
-	Byte4 = BitBor( 0x80, BitBand( Char, 0x3F ) )
-
-	return StringChar( Byte1, Byte2, Byte3, Byte4 )
+	return StringChar(
+		BitBor( 0xF0, BitBand( BitRShift( Char, 18 ), 0x07 ) ),
+		BitBor( 0x80, BitBand( BitRShift( Char, 12 ), 0x3F ) ),
+		BitBor( 0x80, BitBand( BitRShift( Char, 6 ), 0x3F ) ),
+		BitBor( 0x80, BitBand( Char, 0x3F ) )
+	)
 end
 string.UTF8Char = UTF8Char
 

--- a/lua/shine/modules/sh_vote.lua
+++ b/lua/shine/modules/sh_vote.lua
@@ -51,13 +51,8 @@ if Server then
 				self:OnVotePassed()
 			end
 
-			local function OnTimeout( Vote )
-				if Vote.LastVoted and SharedTime() - Vote.LastVoted > self.Config.VoteTimeoutInSeconds then
-					Vote:Reset()
-				end
-			end
-
-			self.Vote = Shine:CreateVote( GetVotesNeeded, self:WrapCallback( OnVotePassed ), OnTimeout )
+			self.Vote = Shine:CreateVote( GetVotesNeeded, self:WrapCallback( OnVotePassed ) )
+			self:SetupVoteTimeout( self.Vote, self.Config.VoteTimeoutInSeconds )
 			function self.Vote.OnReset()
 				self:ResetVoteCounters()
 			end
@@ -65,10 +60,6 @@ if Server then
 			self:CreateCommands()
 
 			return true
-		end
-
-		function Module:Think()
-			self.Vote:Think()
 		end
 
 		function Module:GetVotesNeeded()

--- a/lua/shine/modules/vote.lua
+++ b/lua/shine/modules/vote.lua
@@ -18,6 +18,13 @@ if not Plugin.HandlesVoteConfig then
 	}
 end
 
+function Module:SetupVoteTimeout( Vote, TimeoutInSeconds, TimerName )
+	Vote:SetTimeoutDuration( TimeoutInSeconds )
+	self:CreateTimer( TimerName or "VoteTimeout", 1, -1, function()
+		Vote:Think()
+	end )
+end
+
 local function IsNotBot( Client )
 	return Client.GetIsVirtual and not Client:GetIsVirtual()
 end

--- a/lua/shine/startup.lua
+++ b/lua/shine/startup.lua
@@ -17,14 +17,6 @@ function Shine.LoadScripts( Scripts, OnLoadedFuncs )
 	for i = 1, #Scripts do
 		include( "lua/shine/"..Scripts[ i ] )
 
-		if Shine.Error then
-			if Shine.Hook then
-				Shine.Hook.Disabled = true
-			end
-
-			break
-		end
-
 		if OnLoadedFuncs[ Scripts[ i ] ] then
 			OnLoadedFuncs[ Scripts[ i ] ]()
 		end

--- a/test/core/shared/hook.lua
+++ b/test/core/shared/hook.lua
@@ -1,0 +1,70 @@
+--[[
+	Hook system tests.
+]]
+
+local UnitTest = Shine.UnitTest
+local Hook = Shine.Hook
+
+UnitTest:Test( "Hook integration test", function( Assert )
+	local Called = {}
+	Hook.Add( "Test", "Normal1", function()
+		Called[ #Called + 1 ] = "Normal1"
+	end )
+	Hook.Add( "Test", "Normal2", function()
+		Hook.Remove( "Test", "Normal1" )
+		Hook.Remove( "Test", "LowPriority" )
+		Hook.Remove( "Test", "Normal2" )
+		Called[ #Called + 1 ] = "Normal2"
+	end )
+	Hook.Add( "Test", "Normal3", function()
+		Called[ #Called + 1 ] = "Normal3"
+	end )
+	Hook.Add( "Test", "CalledFirst", function()
+		Called[ #Called + 1 ] = "CalledFirst"
+	end, Hook.MAX_PRIORITY )
+	Hook.Add( "Test", "CalledLast", function()
+		Called[ #Called + 1 ] = "CalledLast"
+	end, Hook.MIN_PRIORITY )
+	Hook.Add( "Test", "LowPriority", function()
+		Called[ #Called + 1 ] = "LowPriority"
+	end, Hook.DEFAULT_PRIORITY + 5 )
+
+	local function AssertCallOrder( Expected )
+		Hook.Call( "Test" )
+
+		Assert.ArrayEquals( "Unexpected hook calls", Expected, Called )
+
+		Called = {}
+	end
+
+	-- Call in priority order, with equal priority using insertion order.
+	-- Normal2 will remove itself, the low priority hook and the hook before it.
+	AssertCallOrder{
+		"CalledFirst", "Normal1", "Normal2", "Normal3", "CalledLast"
+	}
+	-- This results in a second call omitting the removed callbacks.
+	AssertCallOrder{ "CalledFirst", "Normal3", "CalledLast" }
+
+	-- When a hook adds more hooks, they should be called if ordered later.
+	Hook.Add( "Test", "Normal1", function()
+		Hook.Add( "Test", "Normal2", function()
+			Called[ #Called + 1 ] = "Normal2"
+		end )
+		Hook.Add( "Test", "CalledSecond", function()
+			Called[ #Called + 1 ] = "CalledSecond"
+		end, Hook.MAX_PRIORITY + 1 )
+		Called[ #Called + 1 ] = "Normal1"
+	end )
+
+	-- Normal3 exists from before, Normal1 adds a few new callbacks (of which only Normal2 is after it).
+	AssertCallOrder{ "CalledFirst", "Normal3", "Normal1", "Normal2", "CalledLast" }
+	-- The final call will include the -10 priority callback but keep the same hooks as the identifiers are equal.
+	AssertCallOrder{ "CalledFirst", "CalledSecond", "Normal3", "Normal1", "Normal2", "CalledLast" }
+
+	Hook.Clear( "Test" )
+
+	-- Nothing should be called after clearing.
+	AssertCallOrder{}
+end )
+
+Hook.Clear( "Test" )

--- a/test/extensions/mapvote.lua
+++ b/test/extensions/mapvote.lua
@@ -85,7 +85,8 @@ end )
 MapVote.Config.MaxOptions = 5
 MapVote.Config.ExcludeLastMaps = {
 	Min = 0,
-	Max = 0
+	Max = 0,
+	UseStrictMatching = true
 }
 MapVote.LastMapData = {
 	"ns2_refinery", "ns2_veil", "ns2_summit", "ns2_kodiak"
@@ -120,7 +121,8 @@ UnitTest:Test( "RemoveLastMaps - Min and max == 0", function( Assert )
 end )
 
 MapVote.Config.ExcludeLastMaps = {
-	Min = 3
+	Min = 3,
+	UseStrictMatching = true
 }
 
 UnitTest:Test( "RemoveLastMaps - Min == auto and no max", function( Assert )
@@ -173,7 +175,8 @@ end )
 
 MapVote.Config.ExcludeLastMaps = {
 	Min = 2,
-	Max = 2
+	Max = 2,
+	UseStrictMatching = true
 }
 
 UnitTest:Test( "RemoveLastMaps - Min and max equal", function( Assert )
@@ -204,7 +207,8 @@ end )
 
 MapVote.Config.ExcludeLastMaps = {
 	Min = 1,
-	Max = 2
+	Max = 2,
+	UseStrictMatching = true
 }
 
 UnitTest:Test( "RemoveLastMaps - Min and max not equal", function( Assert )
@@ -235,7 +239,8 @@ end )
 
 MapVote.Config.ExcludeLastMaps = {
 	Min = 2,
-	Max = 4
+	Max = 4,
+	UseStrictMatching = true
 }
 
 UnitTest:Test( "RemoveLastMaps - Min and max not equal, max larger than auto", function( Assert )
@@ -260,6 +265,76 @@ UnitTest:Test( "RemoveLastMaps - Min and max not equal, max larger than auto", f
 		ns2_refinery = true,
 		ns2_descent = true,
 		ns2_biodome = true
+	} ), PotentialMaps )
+end )
+
+MapVote.Config.ExcludeLastMaps = {
+	Min = 2,
+	Max = 4,
+	UseStrictMatching = false
+}
+
+MapVote.LastMapData = {
+	"ns2_refinery", "ns2_veil", "ns2_tram_nextstop", "ns2_kodiak"
+}
+
+UnitTest:Test( "RemoveLastMaps - Non-strict matching removes similar maps", function( Assert )
+	local PotentialMaps = Shine.Set( {
+		ns2_tram = true,
+		ns2_derelict = true,
+		ns2_veil_five = true,
+		ns2_summit = true,
+		ns2_kodiak = true,
+		ns2_refinery = true,
+		ns2_descent = true,
+		ns2_biodome = true
+	} )
+	local FinalChoices = Shine.Set()
+
+	MapVote:RemoveLastMaps( PotentialMaps, FinalChoices )
+
+	-- Should remove the last 3 maps, matching ns2_veil vs. ns2_veil_five
+	-- and ns2_tram vs. ns2_tram_nextstop.
+	Assert:Equals( Shine.Set( {
+		ns2_summit = true,
+		ns2_derelict = true,
+		ns2_refinery = true,
+		ns2_descent = true,
+		ns2_biodome = true
+	} ), PotentialMaps )
+end )
+
+MapVote.Config.ExcludeLastMaps = {
+	Min = 2,
+	Max = 4,
+	UseStrictMatching = true
+}
+
+UnitTest:Test( "RemoveLastMaps - Strict matching removes only exactly matching maps", function( Assert )
+	local PotentialMaps = Shine.Set( {
+		ns2_tram = true,
+		ns2_derelict = true,
+		ns2_veil_five = true,
+		ns2_summit = true,
+		ns2_kodiak = true,
+		ns2_refinery = true,
+		ns2_descent = true,
+		ns2_biodome = true
+	} )
+	local FinalChoices = Shine.Set()
+
+	MapVote:RemoveLastMaps( PotentialMaps, FinalChoices )
+
+	-- Should remove only ns2_kodiak as it's the only one with an exact match in the
+	-- last 3 maps.
+	Assert:Equals( Shine.Set( {
+		ns2_summit = true,
+		ns2_derelict = true,
+		ns2_refinery = true,
+		ns2_descent = true,
+		ns2_biodome = true,
+		ns2_tram = true,
+		ns2_veil_five = true
 	} ), PotentialMaps )
 end )
 

--- a/test/extensions/mapvote.lua
+++ b/test/extensions/mapvote.lua
@@ -338,6 +338,110 @@ UnitTest:Test( "RemoveLastMaps - Strict matching removes only exactly matching m
 	} ), PotentialMaps )
 end )
 
+function MapVote:GetCurrentMap()
+	return "ns2_derelict"
+end
+
+MapVote.Config.ConsiderSimilarMapsAsExtension = true
+function MapVote:CanExtend() return false end
+
+UnitTest:Test( "AddCurrentMap - ConsiderSimilarMapsAsExtension excludes similar maps when enabled", function( Assert )
+	local PotentialMaps = Shine.Set( {
+		ns2_tram = true,
+		ns2_derelict = true,
+		ns2_derelict_awesomeedition = true,
+		ns2_veil_five = true,
+		ns2_summit = true,
+		ns2_kodiak = true,
+		ns2_refinery = true,
+		ns2_descent = true,
+		ns2_biodome = true
+	} )
+	local FinalChoices = Shine.Set()
+
+	MapVote:AddCurrentMap( PotentialMaps, FinalChoices )
+
+	-- Should remove both maps that are akin to ns2_derelict.
+	Assert:Equals( Shine.Set( {
+		ns2_tram = true,
+		ns2_veil_five = true,
+		ns2_summit = true,
+		ns2_kodiak = true,
+		ns2_refinery = true,
+		ns2_descent = true,
+		ns2_biodome = true
+	} ), PotentialMaps )
+end )
+
+MapVote.Config.ConsiderSimilarMapsAsExtension = false
+
+UnitTest:Test( "AddCurrentMap - ConsiderSimilarMapsAsExtension includes similar maps when disabled", function( Assert )
+	local PotentialMaps = Shine.Set( {
+		ns2_tram = true,
+		ns2_derelict = true,
+		ns2_derelict_awesomeedition = true,
+		ns2_veil_five = true,
+		ns2_summit = true,
+		ns2_kodiak = true,
+		ns2_refinery = true,
+		ns2_descent = true,
+		ns2_biodome = true
+	} )
+	local FinalChoices = Shine.Set()
+
+	MapVote:AddCurrentMap( PotentialMaps, FinalChoices )
+
+	-- Should remove only ns2_derelict.
+	Assert:Equals( Shine.Set( {
+		ns2_tram = true,
+		ns2_derelict_awesomeedition = true,
+		ns2_veil_five = true,
+		ns2_summit = true,
+		ns2_kodiak = true,
+		ns2_refinery = true,
+		ns2_descent = true,
+		ns2_biodome = true
+	} ), PotentialMaps )
+end )
+
+function MapVote:CanExtend() return true end
+MapVote.Config.AlwaysExtend = true
+
+UnitTest:Test( "AddCurrentMap - AlwaysExtend adds map to final choices", function( Assert )
+	local PotentialMaps = Shine.Set( {
+		ns2_tram = true,
+		ns2_derelict = true,
+		ns2_derelict_awesomeedition = true,
+		ns2_veil_five = true,
+		ns2_summit = true,
+		ns2_kodiak = true,
+		ns2_refinery = true,
+		ns2_descent = true,
+		ns2_biodome = true
+	} )
+	local FinalChoices = Shine.Set()
+
+	MapVote:AddCurrentMap( PotentialMaps, FinalChoices )
+
+	-- Should remove the current map from the potential set, and add it to the final choices.
+	Assert:Equals( Shine.Set( {
+		ns2_tram = true,
+		ns2_derelict_awesomeedition = true,
+		ns2_veil_five = true,
+		ns2_summit = true,
+		ns2_kodiak = true,
+		ns2_refinery = true,
+		ns2_descent = true,
+		ns2_biodome = true
+	} ), PotentialMaps )
+	Assert.Equals( "Set of final choices does not include current map!", Shine.Set( {
+		ns2_derelict = true
+	} ), FinalChoices )
+end )
+
+MapVote.CanExtend = nil
+MapVote.Config.AlwaysExtend = false
+
 MapVote.Config.Maps = {
 	ns2_tram = true,
 	ns2_derelict = true,

--- a/test/lib/objects/linked_list.lua
+++ b/test/lib/objects/linked_list.lua
@@ -218,6 +218,25 @@ UnitTest:Test( "Iterate", function( Assert )
 	Assert.Equals( "Iteration didn't iterate all values", 5, i )
 end )
 
+UnitTest:Test( "Iterate and remove", function( Assert )
+	local List = Shine.LinkedList()
+	local Nodes = {}
+	for i = 1, 5 do
+		Nodes[ i ] = List:Add( i )
+	end
+
+	local i = 0
+	for Value in List:Iterate() do
+		i = i + 1
+		Assert:Equals( i, Value )
+		-- Node still points at next node, so iteration should be unaffected.
+		List:Remove( Nodes[ i ] )
+	end
+
+	Assert.Equals( "Iteration didn't iterate all values", 5, i )
+	Assert.Equals( "List should be empty after iteration", 0, List:GetCount() )
+end )
+
 UnitTest:Test( "IterateNodes", function( Assert )
 	local List = Shine.LinkedList()
 	local Nodes = {}

--- a/test/lib/objects/linked_list.lua
+++ b/test/lib/objects/linked_list.lua
@@ -1,0 +1,234 @@
+--[[
+	Linked list unit tests.
+]]
+
+local UnitTest = Shine.UnitTest
+
+UnitTest:Test( "Add", function( Assert )
+	local List = Shine.LinkedList()
+	local Node = List:Add( 1 )
+
+	Assert.Equals( "Node should have correct value", 1, Node.Value )
+	Assert.Nil( "Node should have no next node", Node.Next )
+	Assert.Nil( "Node should have no previous node", Node.Prev )
+	Assert.Equals( "Node should be the first", List.First, Node )
+	Assert.Equals( "Node should be the last", List.Last, Node )
+	Assert.Equals( "List should have size 1", 1, List:GetCount() )
+
+	local SecondNode = List:Add( 2 )
+
+	Assert.Equals( "Second node should have correct value", 2, SecondNode.Value )
+	Assert.Equals( "First node should be behind second", Node, SecondNode.Prev )
+	Assert.Equals( "Second node should be in front of first", SecondNode, Node.Next )
+	Assert.Equals( "First node should be first", Node, List.First )
+	Assert.Equals( "Second node should be last", SecondNode, List.Last )
+	Assert.Nil( "Second node should have no next node", SecondNode.Next )
+	Assert.Nil( "First node should have no previous node", Node.Prev )
+	Assert.Equals( "List should have size 2", 2, List:GetCount() )
+end )
+
+UnitTest:Test( "InsertAtFront", function( Assert )
+	local List = Shine.LinkedList()
+	local Nodes = {}
+	for i = 1, 5 do
+		Nodes[ i ] = List:Add( i )
+	end
+
+	local Node = List:InsertAtFront( 0 )
+	Assert.Equals( "Node should have correct value", 0, Node.Value )
+	Assert.Equals( "Node's next node should be the previous first", Nodes[ 1 ], Node.Next )
+	Assert.Equals( "Previous first node should have new node as previous", Node, Nodes[ 1 ].Prev )
+	Assert.Equals( "Node should be first", Node, List.First )
+	Assert.Nil( "Node should have no previous node", Node.Prev )
+end )
+
+UnitTest:Test( "InsertAfter mid-list", function( Assert )
+	local List = Shine.LinkedList()
+	local Nodes = {}
+	for i = 1, 5 do
+		Nodes[ i ] = List:Add( i )
+	end
+
+	Assert.Equals( "List should have size 5", 5, List:GetCount() )
+
+	local Node = List:InsertAfter( Nodes[ 2 ], 0 )
+	Assert.Equals( "Node should have correct value", 0, Node.Value )
+	Assert.Equals( "Node's next node should be the previous third", Nodes[ 3 ], Node.Next )
+	Assert.Equals( "Node's previous node should be the previous second", Nodes[ 2 ], Node.Prev )
+	Assert.Equals( "Node should be behind the third node", Node, Nodes[ 3 ].Prev )
+	Assert.Equals( "Node should be in front of the second node", Node, Nodes[ 2 ].Next )
+	Assert.Equals( "Last node should be unchanged", Nodes[ 5 ], List.Last )
+	Assert.Equals( "List should have size 6", 6, List:GetCount() )
+end )
+
+UnitTest:Test( "InsertAfter at end of list", function( Assert )
+	local List = Shine.LinkedList()
+	local Nodes = {}
+	for i = 1, 5 do
+		Nodes[ i ] = List:Add( i )
+	end
+
+	Assert.Equals( "List should have size 5", 5, List:GetCount() )
+
+	local Node = List:InsertAfter( Nodes[ 5 ], 0 )
+	Assert.Equals( "Node should have correct value", 0, Node.Value )
+	Assert.Equals( "Node 5's next node be the new node", Node, Nodes[ 5 ].Next )
+	Assert.Equals( "Node's previous node should be the fifth", Nodes[ 5 ], Node.Prev )
+	Assert.Nil( "Node should have no next node", Node.Next )
+	Assert.Equals( "Last node should be the new node", Node, List.Last )
+	Assert.Equals( "List should have size 6", 6, List:GetCount() )
+end )
+
+UnitTest:Test( "InsertByComparing - start of list", function( Assert )
+	local List = Shine.LinkedList()
+	local Nodes = {}
+	for i = 1, 5 do
+		Nodes[ i ] = List:Add( i )
+	end
+
+	Assert.Equals( "List should have size 5", 5, List:GetCount() )
+
+	local Node = List:InsertByComparing( 0, function( A, B ) return A < B end )
+	Assert.Equals( "Node should have correct value", 0, Node.Value )
+	Assert.Equals( "Node's next node should be the previous first", Nodes[ 1 ], Node.Next )
+	Assert.Nil( "Node should have no previous node", Node.Prev )
+	Assert.Equals( "Node should be behind the first node", Node, Nodes[ 1 ].Prev )
+	Assert.Equals( "Node should be the new first node", Node, List.First )
+	Assert.Equals( "Last node should be unchanged", Nodes[ 5 ], List.Last )
+	Assert.Equals( "List should have size 6", 6, List:GetCount() )
+end )
+
+UnitTest:Test( "InsertByComparing - mid-list", function( Assert )
+	local List = Shine.LinkedList()
+	local Nodes = {}
+	for i = 1, 5 do
+		Nodes[ i ] = List:Add( i )
+	end
+
+	Assert.Equals( "List should have size 5", 5, List:GetCount() )
+
+	local Node = List:InsertByComparing( 3, function( A, B ) return A < B end )
+	Assert.Equals( "Node should have correct value", 3, Node.Value )
+	Assert.Equals( "Node's next node should be the previous fourth", Nodes[ 4 ], Node.Next )
+	Assert.Equals( "Node's previous node should be the previous third", Nodes[ 3 ], Node.Prev )
+	Assert.Equals( "Node should be behind the fourth node", Node, Nodes[ 4 ].Prev )
+	Assert.Equals( "Node should be in front of the third node", Node, Nodes[ 3 ].Next )
+	Assert.Equals( "First node should be unchanged", Nodes[ 1 ], List.First )
+	Assert.Equals( "Last node should be unchanged", Nodes[ 5 ], List.Last )
+	Assert.Equals( "List should have size 6", 6, List:GetCount() )
+end )
+
+UnitTest:Test( "InsertByComparing - end of list", function( Assert )
+	local List = Shine.LinkedList()
+	local Nodes = {}
+	for i = 1, 5 do
+		Nodes[ i ] = List:Add( i )
+	end
+
+	Assert.Equals( "List should have size 5", 5, List:GetCount() )
+
+	local Node = List:InsertByComparing( 6, function( A, B ) return A < B end )
+	Assert.Equals( "Node should have correct value", 6, Node.Value )
+	Assert.Equals( "Node 5's next node be the new node", Node, Nodes[ 5 ].Next )
+	Assert.Equals( "Node's previous node should be the fifth", Nodes[ 5 ], Node.Prev )
+	Assert.Nil( "Node should have no next node", Node.Next )
+	Assert.Equals( "First node should be unchanged", Nodes[ 1 ], List.First )
+	Assert.Equals( "Last node should be the new node", Node, List.Last )
+	Assert.Equals( "List should have size 6", 6, List:GetCount() )
+end )
+
+UnitTest:Test( "Remove only element", function( Assert )
+	local List = Shine.LinkedList()
+	local Node = List:Add( 1 )
+
+	Assert.Equals( "List should have size 1", 1, List:GetCount() )
+
+	List:Remove( Node )
+
+	Assert.Nil( "List should have no first node", List.First )
+	Assert.Nil( "List should have no last node", List.Last )
+
+	Assert.Equals( "List should have size 0", 0, List:GetCount() )
+end )
+
+UnitTest:Test( "Remove start of list", function( Assert )
+	local List = Shine.LinkedList()
+	local Nodes = {}
+	for i = 1, 5 do
+		Nodes[ i ] = List:Add( i )
+	end
+
+	Assert.Equals( "List should have size 5", 5, List:GetCount() )
+
+	List:Remove( Nodes[ 1 ] )
+
+	Assert.Equals( "Second node should now be first", Nodes[ 2 ], List.First )
+	Assert.Equals( "Fifth node should still be last", Nodes[ 5 ], List.Last )
+	Assert.Nil( "Second node should have no previous node", Nodes[ 2 ].Prev )
+	Assert.Equals( "List should have size 4", 4, List:GetCount() )
+end )
+
+UnitTest:Test( "Remove mid-list", function( Assert )
+	local List = Shine.LinkedList()
+	local Nodes = {}
+	for i = 1, 5 do
+		Nodes[ i ] = List:Add( i )
+	end
+
+	Assert.Equals( "List should have size 5", 5, List:GetCount() )
+
+	List:Remove( Nodes[ 3 ] )
+
+	Assert.Equals( "First node should still be first", Nodes[ 1 ], List.First )
+	Assert.Equals( "Fifth node should still be last", Nodes[ 5 ], List.Last )
+	Assert.Equals( "Second node should have fourth as next node", Nodes[ 4 ], Nodes[ 2 ].Next )
+	Assert.Equals( "Fourth node should have second as previous ndoe", Nodes[ 2 ], Nodes[ 4 ].Prev )
+	Assert.Equals( "List should have size 4", 4, List:GetCount() )
+end )
+
+UnitTest:Test( "Clear", function( Assert )
+	local List = Shine.LinkedList()
+	local Nodes = {}
+	for i = 1, 5 do
+		Nodes[ i ] = List:Add( i )
+	end
+
+	Assert.Equals( "List should have size 5", 5, List:GetCount() )
+
+	List:Clear()
+
+	Assert.Nil( "List should have no first node", List.First )
+	Assert.Nil( "List should have no last node", List.Last )
+
+	Assert.Equals( "List should have size 0", 0, List:GetCount() )
+end )
+
+UnitTest:Test( "Iterate", function( Assert )
+	local List = Shine.LinkedList()
+	local Nodes = {}
+	for i = 1, 5 do
+		Nodes[ i ] = List:Add( i )
+	end
+
+	local i = 0
+	for Value in List:Iterate() do
+		i = i + 1
+		Assert:Equals( i, Value )
+	end
+	Assert.Equals( "Iteration didn't iterate all values", 5, i )
+end )
+
+UnitTest:Test( "IterateNodes", function( Assert )
+	local List = Shine.LinkedList()
+	local Nodes = {}
+	for i = 1, 5 do
+		Nodes[ i ] = List:Add( i )
+	end
+
+	local i = 0
+	for Node in List:IterateNodes() do
+		i = i + 1
+		Assert:Equals( i, Node.Value )
+	end
+	Assert.Equals( "Iteration didn't iterate all values", 5, i )
+end )

--- a/test/lib/objects/map.lua
+++ b/test/lib/objects/map.lua
@@ -49,6 +49,24 @@ UnitTest:Test( "RemovalOfFalse", function( Assert )
 	Assert.Nil( "Map didn't remove false!", Map:Get( 1 ) )
 end )
 
+UnitTest:Test( "Clear", function( Assert )
+	local Map = Map()
+	for i = 1, 30 do
+		Map:Add( i, i )
+	end
+
+	Assert:Equals( 30, Map:GetCount() )
+
+	Map:Clear()
+
+	for i = 1, 30 do
+		Assert:Nil( Map:Get( i ) )
+	end
+
+	Assert.True( "Map was not empty after clearing", Map:IsEmpty() )
+	Assert.Equals( "Map was not empty after clearing", 0, Map:GetCount() )
+end )
+
 UnitTest:Test( "IterationRemoval", function( Assert )
 	local Map = Map()
 
@@ -203,6 +221,23 @@ UnitTest:Test( "Multimap:RemoveKeyValue()", function( Assert )
 	Map:RemoveKeyValue( 1, 2 )
 	Assert:ArrayEquals( { 1, 3 }, Map:Get( 1 ) )
 	Assert:Equals( 2, Map:GetCount() )
+end )
+
+UnitTest:Test( "Multimap:Clear()", function( Assert )
+	local Map = Multimap()
+	for i = 1, 30 do
+		Map:Add( i % 2, i )
+	end
+
+	Assert:Equals( 30, Map:GetCount() )
+
+	Map:Clear()
+
+	Assert:Nil( Map:Get( 0 ) )
+	Assert:Nil( Map:Get( 1 ) )
+
+	Assert.True( "Map was not empty after clearing", Map:IsEmpty() )
+	Assert.Equals( "Map was not empty after clearing", 0, Map:GetCount() )
 end )
 
 UnitTest:Test( "Multimap from table", function( Assert )

--- a/test/lib/objects/queue.lua
+++ b/test/lib/objects/queue.lua
@@ -8,22 +8,17 @@ UnitTest:Test( "Add", function( Assert )
 	local Queue = Shine.Queue()
 	Queue:Add( 1 )
 
-	local FirstNode = Queue.FirstNode
-	Assert:NotNil( FirstNode )
-	Assert:Nil( FirstNode.Previous )
-	Assert:Nil( FirstNode.Next )
-	Assert:Equals( FirstNode, Queue.LastNode )
-	Assert:Equals( 1, FirstNode.Value )
-	Assert:Equals( 1, Queue:GetCount() )
+	Assert.Equals( "Value at index 1 should equal 1", 1, Queue.Elements[ 1 ] )
+	Assert.Equals( "First index should be 1", 1, Queue.First )
+	Assert.Equals( "Last index should be 1", 1, Queue.Last )
+	Assert.Equals( "Size should be 1", 1, Queue:GetCount() )
 
 	Queue:Add( 2 )
-	Assert:Equals( FirstNode, Queue.FirstNode )
-	Assert:NotNil( FirstNode.Next )
-	Assert:Equals( FirstNode.Next.Previous, FirstNode )
-	Assert:Nil( FirstNode.Next.Next )
-	Assert:Equals( FirstNode.Next, Queue.LastNode )
-	Assert:Equals( 2, FirstNode.Next.Value )
-	Assert:Equals( 2, Queue:GetCount() )
+	Assert.Equals( "Value at index 1 should equal 1", 1, Queue.Elements[ 1 ] )
+	Assert.Equals( "Value at index 1 should equal 2", 2, Queue.Elements[ 2 ] )
+	Assert.Equals( "First index should be 1", 1, Queue.First )
+	Assert.Equals( "Last index should be 2", 2, Queue.Last )
+	Assert.Equals( "Size should be 2", 2, Queue:GetCount() )
 end )
 
 UnitTest:Test( "Pop", function( Assert )
@@ -35,16 +30,26 @@ UnitTest:Test( "Pop", function( Assert )
 	for i = 1, 4 do
 		Queue:Pop()
 
-		local FirstNode = Queue.FirstNode
-		Assert:NotNil( FirstNode )
-		Assert:Nil( FirstNode.Previous )
-		Assert:Equals( i + 1, FirstNode.Value )
+		local FirstValue = Queue:Peek()
+		Assert:Equals( i + 1, FirstValue )
 		Assert:Equals( 5 - i, Queue:GetCount() )
 	end
 
 	Queue:Pop()
-	Assert:Nil( Queue.FirstNode )
-	Assert:Nil( Queue.LastNode )
+	Assert:Nil( Queue:Peek() )
+	Assert:Equals( 0, Queue:GetCount() )
+end )
+
+UnitTest:Test( "Clear", function( Assert )
+	local Queue = Shine.Queue()
+	for i = 1, 5 do
+		Queue:Add( i )
+	end
+
+	Assert:Equals( 5, Queue:GetCount() )
+
+	Queue:Clear()
+	Assert:Nil( Queue:Peek() )
 	Assert:Equals( 0, Queue:GetCount() )
 end )
 
@@ -78,17 +83,13 @@ UnitTest:Test( "Add, then pop, then add", function( Assert )
 
 	Queue:Add( Data )
 	Assert:Equals( 1, Queue:GetCount() )
-	Assert:Equals( Data, Queue.FirstNode.Value )
-	Assert:Equals( Data, Queue.LastNode.Value )
+	Assert:Equals( Data, Queue:Peek() )
 
-	-- Popping should clear both the first and last node on the last pop.
 	Queue:Pop()
 	Assert:Equals( 0, Queue:GetCount() )
-	Assert:Nil( Queue.FirstNode )
-	Assert:Nil( Queue.LastNode )
+	Assert:Nil( Queue:Peek() )
 
 	Queue:Add( Data )
 	Assert:Equals( 1, Queue:GetCount() )
-	Assert:Equals( Data, Queue.FirstNode.Value )
-	Assert:Equals( Data, Queue.LastNode.Value )
+	Assert:Equals( Data, Queue:Peek() )
 end )

--- a/test/lib/objects/votes.lua
+++ b/test/lib/objects/votes.lua
@@ -1,0 +1,101 @@
+--[[
+	Vote object tests.
+]]
+
+local UnitTest = Shine.UnitTest
+
+UnitTest:Test( "Adding votes", function( Assert )
+	local Success = false
+	local Vote = Shine:CreateVote(
+		function() return 2 end,
+		function() Success = true end
+	)
+
+	Assert.True( "Expected new vote to be added successfully", Vote:AddVote( 1 ) )
+
+	Assert.True( "Client 1 should have voted", Vote:GetHasClientVoted( 1 ) )
+	Assert.Equals( "Expected one vote", 1, Vote:GetVotes() )
+	Assert.Equals( "Expected one more vote required to pass", 1, Vote:GetVotesNeeded() )
+	Assert.False( "Vote should not have passed yet", Success )
+
+	Assert.False( "Expected vote from same client to be rejected", Vote:AddVote( 1 ) )
+	Assert.False( "Vote should not have passed yet", Success )
+
+	Assert.True( "Expected second vote to be added successfully", Vote:AddVote( 2 ) )
+	Assert.True( "Expected vote to pass", Success )
+	Assert.True( "Expected vote to be marked as successful due to the last vote",
+		Vote:HasSucceededOnLastVote() )
+	Assert.Equals( "Expected vote count to be reset", 0, Vote:GetVotes() )
+	Assert.Equals( "Expected two more vote required to pass", 2, Vote:GetVotesNeeded() )
+end )
+
+UnitTest:Test( "Removing votes", function( Assert )
+	local Success = false
+	local Vote = Shine:CreateVote(
+		function() return 2 end,
+		function() Success = true end
+	)
+
+	Assert.True( "Expected new vote to be added successfully", Vote:AddVote( 1 ) )
+
+	Assert.True( "Client 1 should have voted", Vote:GetHasClientVoted( 1 ) )
+	Assert.Equals( "Expected one vote", 1, Vote:GetVotes() )
+	Assert.Equals( "Expected one more vote required to pass", 1, Vote:GetVotesNeeded() )
+	Assert.False( "Vote should not have passed yet", Success )
+
+	Vote:RemoveVote( 1 )
+
+	Assert.False( "Client 1 should not have voted", Vote:GetHasClientVoted( 1 ) )
+	Assert.Equals( "Expected vote count to be reset", 0, Vote:GetVotes() )
+	Assert.Equals( "Expected two more vote required to pass", 2, Vote:GetVotesNeeded() )
+	Assert.False( "Vote should not have passed yet", Success )
+
+	-- Removing the vote again should do nothing.
+	Vote:RemoveVote( 1 )
+
+	Assert.Equals( "Expected vote count to be reset", 0, Vote:GetVotes() )
+	Assert.Equals( "Expected two more vote required to pass", 2, Vote:GetVotesNeeded() )
+	Assert.False( "Vote should not have passed yet", Success )
+end )
+
+UnitTest:Test( "Resetting", function( Assert )
+	local Success = false
+	local Vote = Shine:CreateVote(
+		function() return 2 end,
+		function() Success = true end
+	)
+
+	Assert.True( "Expected new vote to be added successfully", Vote:AddVote( 1 ) )
+
+	Assert.True( "Client 1 should have voted", Vote:GetHasClientVoted( 1 ) )
+	Assert.Equals( "Expected one vote", 1, Vote:GetVotes() )
+	Assert.Equals( "Expected one more vote required to pass", 1, Vote:GetVotesNeeded() )
+	Assert.False( "Vote should not have passed yet", Success )
+
+	Vote:Reset()
+
+	Assert.False( "Client 1 should not have voted", Vote:GetHasClientVoted( 1 ) )
+	Assert.Equals( "Expected vote count to be reset", 0, Vote:GetVotes() )
+	Assert.Equals( "Expected two more vote required to pass", 2, Vote:GetVotesNeeded() )
+	Assert.False( "Vote should not have passed yet", Success )
+end )
+
+UnitTest:Test( "Timeout duration", function( Assert )
+	local Success = false
+	local Vote = Shine:CreateVote(
+		function() return 2 end,
+		function() Success = true end
+	)
+
+	Vote:SetTimeoutDuration( 5 )
+	Vote:AddVote( 1 )
+	Vote:Think()
+
+	Assert.Equals( "Expected one vote", 1, Vote:GetVotes() )
+	Assert.False( "Vote should not have passed yet", Success )
+
+	Vote.LastVoted = Shared.GetTime() - 6
+
+	Vote:Think()
+	Assert.Equals( "Expected vote count to be reset", 0, Vote:GetVotes() )
+end )


### PR DESCRIPTION
#### AFK Kick
* Removed Steam overlay checking due to the game not always seeing the correct Steam overlay state.
* Improved performance by sampling move commands rather than checking them all. Use the `SampleIntervalInSeconds` to set how frequently to sample move commands.

#### Chatbox
* Added option to always scroll to the bottom when opening the chatbox.

#### Map Vote
* Added `BlockAfterRoundTimeInMinutes` option to block map votes after a given number of minutes in a round have passed.
* Added `ExcludeLastMaps.UseStrictMatching` option to determine whether to strictly match previous map names when removing them from vote options. If `false`, then maps such as `ns2_veil` and `ns2_veil_five` are considered equal and thus if either were previously played they will exclude each other.
* Added `ConsiderSimilarMapsAsExtension` option to determine if maps named similarly to the current map should be blocked from being vote options when extension of the current map is denied.
* Added `VoteTimeoutInSeconds` option to allow votes to initiate a map vote to time-out if players stop voting to change the map.

#### Vote Surrender
* Fixed votes not being reset correctly.
* Prevented multiple surrender votes from passing simultaneously.

#### General
* Improved performance of the hook system.
* Improved performance of UTF-8 parsing.
* Removed some unnecessary `Think` hooks in `basecommands` and `mapvote`.
* Added `LinkedList` type, and changed `Queue` to use a more simplified approach.
