### PR TITLE
Add shuffle vote constraints, fix minor issues

### DIFF
--- a/locale/shine/extensions/voterandom/enGB.json
+++ b/locale/shine/extensions/voterandom/enGB.json
@@ -119,5 +119,7 @@
 	"AUTO_SHUFFLE_ENABLED_HIVE_BASED": "Automatic Hive skill based teams have been enabled.",
 	"AUTO_SHUFFLE_ENABLED_KDR_BASED": "Automatic KDR based teams have been enabled.",
 	"AUTO_SHUFFLE_ENABLED_RANDOM_BASED": "Automatic score based teams have been enabled.",
-	"AUTO_SHUFFLE_ENABLED_SCORE_BASED": "Automatic random teams have been enabled."
+	"AUTO_SHUFFLE_ENABLED_SCORE_BASED": "Automatic random teams have been enabled.",
+
+	"ERROR_CONSTRAINTS": "Teams are already sufficiently balanced."
 }

--- a/lua/shine/extensions/ban/server.lua
+++ b/lua/shine/extensions/ban/server.lua
@@ -70,10 +70,11 @@ function Plugin:Initialise()
 	self.Retries = {}
 
 	if self.Config.GetBansFromWeb then
-		--Load bans list after everything else.
+		-- Load bans list after everything else.
 		self:SimpleTimer( 1, function()
 			self:LoadBansFromWeb()
 		end )
+		self:BuildInitialNetworkData()
 	else
 		self:MergeNS2IntoShine()
 	end
@@ -82,7 +83,7 @@ function Plugin:Initialise()
 	self:CheckBans()
 
 	if not Hooked then
-		--Hook into the default banning commands.
+		-- Hook into the default banning commands.
 		Event.Hook( "Console_sv_ban", function( Client, ... )
 			Shine:RunCommand( Client, "sh_ban", false, ... )
 		end )
@@ -91,7 +92,7 @@ function Plugin:Initialise()
 			Shine:RunCommand( Client, "sh_unban", false, ... )
 		end )
 
-		--Override the bans list function (have to do it after everything's loaded).
+		-- Override the bans list function (have to do it after everything's loaded).
 		self:SimpleTimer( 1, function()
 			function GetBannedPlayersList()
 				local Bans = self.Config.Banned

--- a/lua/shine/extensions/ban/shared.lua
+++ b/lua/shine/extensions/ban/shared.lua
@@ -323,7 +323,9 @@ function Plugin:SetupAdminMenu()
 			Window:Destroy()
 			Window = nil
 
-			self:RequestBanPage( self.CurrentPage )
+			if self.BanMenuOpen then
+				self:RequestBanPage( self.CurrentPage )
+			end
 		end
 	end
 

--- a/lua/shine/extensions/basecommands/shared.lua
+++ b/lua/shine/extensions/basecommands/shared.lua
@@ -706,6 +706,17 @@ function Plugin:UpdateAllTalk( State )
 		-- Hide the text if the inventory HUD is visible (avoids the text overlapping it).
 		-- There's no easy way to determine its visibility, so this awkward polling will have to do.
 		function self.TextObj:Think()
+			-- Allow other mods to influence the position and visiblity of the text if they have
+			-- extra HUD elements. Should return whether the text is visible, and its new position.
+			local Visible, X, Y = Hook.Call( "OnUpdateAllTalkText", self:GetIsVisible(), self.x, self.y )
+			if Visible ~= nil then
+				self:SetIsVisible( Visible )
+				if X and self.x ~= X or Y and self.y ~= Y then
+					self:SetScaledPos( X or self.x, Y or self.y )
+				end
+				return
+			end
+
 			local HUD = ClientUI.GetScript( "Hud/Marine/GUIMarineHUD" ) or ClientUI.GetScript( "GUIAlienHUD" )
 			local Inventory = HUD and HUD.inventoryDisplay
 			local InventoryIsVisible = Inventory and Inventory.background and Inventory.background:GetIsVisible()

--- a/lua/shine/extensions/mapvote/cycle.lua
+++ b/lua/shine/extensions/mapvote/cycle.lua
@@ -81,7 +81,7 @@ function Plugin:SetupMaps( Cycle )
 			end
 		end
 
-		if Cycle.maps then
+		if Cycle and Cycle.maps then
 			for i = 1, #Cycle.maps do
 				local Map = Cycle.maps[ i ]
 

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -193,10 +193,18 @@ Plugin.ConfigMigrationSteps = {
 
 do
 	local Validator = Shine.Validator()
+
+	Validator:AddFieldRule( "VoteConstraints.MinPlayerFractionToConstrain",
+		Validator.IsType( "number", Plugin.DefaultConfig.VoteConstraints.MinPlayerFractionToConstrain ) )
+	Validator:AddFieldRules( {
+		"VoteConstraints.MinAverageDiffToAllowShuffle",
+		"VoteConstraints.MinStandardDeviationDiffToAllowShuffle"
+	}, Validator.IsType( "number", 0 ) )
+
 	Validator:AddFieldRule( "VotePassActions.PreGame", Validator.IsType( "table",
-		Plugin.DefaultConfig.PreGame ) )
+		Plugin.DefaultConfig.VotePassActions.PreGame ) )
 	Validator:AddFieldRule( "VotePassActions.InGame", Validator.IsType( "table",
-		Plugin.DefaultConfig.InGame ) )
+		Plugin.DefaultConfig.VotePassActions.InGame ) )
 	Validator:AddFieldRules( {
 		"VotePassActions.PreGame.ShufflePolicy",
 		"VotePassActions.InGame.ShufflePolicy"

--- a/lua/shine/extensions/voterandom/team_balance.lua
+++ b/lua/shine/extensions/voterandom/team_balance.lua
@@ -740,21 +740,23 @@ do
 		return Sqrt( Sum / RealCount )
 	end
 
-	function BalanceModule:GetAverageSkill( Players, TeamNumber )
-		return GetAverageSkillFunc( Players, self.SkillGetters.GetHiveSkill, TeamNumber )
+	function BalanceModule:GetAverageSkill( Players, TeamNumber, RankFunc )
+		return GetAverageSkillFunc( Players, RankFunc or self.SkillGetters.GetHiveSkill, TeamNumber )
 	end
 
-	function BalanceModule:GetTeamStats()
+	function BalanceModule:GetTeamStats( RankFunc )
 		local Marines = GetEntitiesForTeam( "Player", 1 )
 		local Aliens = GetEntitiesForTeam( "Player", 2 )
 
+		RankFunc = RankFunc or self.SkillGetters.GetHiveSkill
+
 		local MarineSkill = self:GetAverageSkill( Marines, 1 )
 		MarineSkill.StandardDeviation = GetStandardDeviation( Marines, MarineSkill.Average,
-			self.SkillGetters.GetHiveSkill, 1 )
+			RankFunc, 1 )
 
 		local AlienSkill = self:GetAverageSkill( Aliens, 2 )
 		AlienSkill.StandardDeviation = GetStandardDeviation( Aliens, AlienSkill.Average,
-			self.SkillGetters.GetHiveSkill, 2 )
+			RankFunc, 2 )
 
 		if self.LastShuffleTeamLookup then
 			local NumMatchingTeams = 0

--- a/lua/shine/extensions/voterandom/team_balance.lua
+++ b/lua/shine/extensions/voterandom/team_balance.lua
@@ -102,12 +102,14 @@ local DebugMode = false
 -- TeamNumber parameter currently unused, but ready for Hive 2.0
 BalanceModule.SkillGetters = {
 	GetHiveSkill = function( Ply, TeamNumber )
-		if DebugMode then
-			local Client = GetOwner( Ply )
-			if Client and Client:GetIsVirtual() then
+		local Client = GetOwner( Ply )
+		if Client and Client:GetIsVirtual() then
+			if DebugMode then
 				Client.Skill = Client.Skill or Random( 0, 2500 )
 				return Client.Skill
 			end
+			-- Bots are all equal so there's no reason to consider them.
+			return nil
 		end
 
 		if Ply.GetPlayerSkill then

--- a/lua/shine/extensions/voterandom/team_optimiser.lua
+++ b/lua/shine/extensions/voterandom/team_optimiser.lua
@@ -73,17 +73,17 @@ function TeamOptimiser:Init( TeamMembers, TeamSkills, RankFunc, Comparator )
 
 	do
 		local RankCache = {}
-		self.RankFunc = function( Ply, TeamMember )
+		self.RankFunc = function( Ply, TeamNumber )
 			local Cached = RankCache[ Ply ]
-			if Cached and Cached[ TeamMember ] then
-				return Cached[ TeamMember ]
+			if Cached and Cached[ TeamNumber ] then
+				return Cached[ TeamNumber ]
 			end
 
-			local Value = RankFunc( Ply, TeamMember )
+			local Value = RankFunc( Ply, TeamNumber )
 			if not Cached then
 				Cached = {}
 			end
-			Cached[ TeamMember ] = Value
+			Cached[ TeamNumber ] = Value
 			RankCache[ Ply ] = Cached
 
 			return Value

--- a/test/extensions/voterandom/voterandom.lua
+++ b/test/extensions/voterandom/voterandom.lua
@@ -322,6 +322,67 @@ function( Assert )
 	Assert:True( VoteShuffle:ShouldOptimiseHappiness( TeamMembers ) )
 end )
 
+VoteShuffle.Config.VoteConstraints.MinPlayerFractionToConstrain = 0.9
+
+UnitTest:Test( "EvaluateConstraints - Number of players too low", function( Assert )
+	Assert.True( "Should allow voting as only 2/10 players are on teams",
+		VoteShuffle:EvaluateConstraints( 10, {
+			{ Skills = { 1000 } },
+			{ Skills = { 1000 } }
+		} )
+	)
+end )
+
+UnitTest:Test( "EvaluateConstraints - Teams imbalanced", function( Assert )
+	Assert.True( "Should allow voting as teams are imbalanced",
+		VoteShuffle:EvaluateConstraints( 4, {
+			{ Skills = { 1000, 2000, 2000 } },
+			{ Skills = { 1000 } }
+		} )
+	)
+end )
+
+VoteShuffle.Config.VoteConstraints.MinAverageDiffToAllowShuffle = 100
+VoteShuffle.Config.VoteConstraints.MinStandardDeviationDiffToAllowShuffle = 0
+
+UnitTest:Test( "EvaluateConstraints - Average diff is high enough", function( Assert )
+	Assert.True( "Should allow voting as averages are too far apart",
+		VoteShuffle:EvaluateConstraints( 4, {
+			{ Skills = { 1000, 2000 }, Average = 1500 },
+			{ Skills = { 1000, 4000 }, Average = 2500 }
+		} )
+	)
+end )
+
+UnitTest:Test( "EvaluateConstraints - Min standard deviation difference = 0 is ignored", function( Assert )
+	Assert.False( "Should ignore standard deviation as min is 0",
+		VoteShuffle:EvaluateConstraints( 4, {
+			{ Skills = { 1500, 1500 }, Average = 1500, StandardDeviation = 0 },
+			{ Skills = { 1000, 2000 }, Average = 1500, StandardDeviation = 500 }
+		} )
+	)
+end )
+
+VoteShuffle.Config.VoteConstraints.MinStandardDeviationDiffToAllowShuffle = 200
+
+UnitTest:Test( "EvaluateConstraints - Standard deviation diff is high enough", function( Assert )
+	Assert.True( "Should allow voting as standard deviations are too far apart",
+		VoteShuffle:EvaluateConstraints( 4, {
+			{ Skills = { 1500, 1500 }, Average = 1500, StandardDeviation = 0 },
+			{ Skills = { 1000, 2000 }, Average = 1500, StandardDeviation = 500 }
+		} )
+	)
+end )
+
+UnitTest:Test( "EvaluateConstraints - Teams are balanced", function( Assert )
+	Assert.False( "Should deny voting when teams are sufficiently balanced",
+		VoteShuffle:EvaluateConstraints( 4, {
+			{ Skills = { 1500, 1500 }, Average = 1500, StandardDeviation = 0 },
+			{ Skills = { 1500, 1500 }, Average = 1500, StandardDeviation = 0 }
+		} )
+	)
+end )
+
 VoteShuffle.Config.IgnoreCommanders = false
 
 VoteShuffle.SaveHappinessHistory = BalanceModule.SaveHappinessHistory


### PR DESCRIPTION
#### Admin Menu
* Fixed script error when the bans tab has never been opened and a ban is being added through the commands tab.

#### Base Commands
* Added a hook for other mods/plugins to change the position and visibility of the "All talk is enabled" text to better fit extra HUD elements.

#### Vote Shuffle
* Added `VoteConstraints` configuration options to constrain when a vote can occur based on the current difference in average skill and optionally standard deviation of skill.
* Fixed bots showing up in `sh_teamstats`.