### PR TITLE
Apply rate limits to commands, update AFK kick

### DIFF
--- a/locale/shine/extensions/afkkick/enGB.json
+++ b/locale/shine/extensions/afkkick/enGB.json
@@ -1,4 +1,5 @@
 {
 	"NOTIFY_PREFIX": "[AFKKick]",
-	"WARN_KICK_ON_CONNECT": "You have been AFK for over {AFKTime:Duration}. You may be kicked when new players attempt to connect."
+	"WARN_KICK_ON_CONNECT": "You have been AFK for over {AFKTime:Duration}. You may be kicked when new players attempt to connect.",
+	"WARN_NOTIFY": "You have been AFK for over {AFKTime:Duration}. You will be kicked if you are AFK for {KickTime:Duration} and the player count reaches {MinPlayers}."
 }

--- a/lua/shine/core/server/config.lua
+++ b/lua/shine/core/server/config.lua
@@ -77,6 +77,7 @@ local DefaultConfig = {
 	NotifyAdminAnonymous = false, -- Should we hide to players with greater-equal immunity who performed it?
 	ChatName = "Admin", -- The name to use for anonymous output.
 	ConsoleName = "Admin", -- The name to use for console running a command.
+	MaxCommandsPerSecond = 3, -- The maximum number of (server-side) commands that can be executed in a second by a given client.
 
 	SilentChatCommands = true, -- Defines whether to silence all chat commands, or only those starting with "/".
 

--- a/lua/shine/extensions/afkkick/shared.lua
+++ b/lua/shine/extensions/afkkick/shared.lua
@@ -10,6 +10,11 @@ function Plugin:SetupDataTable()
 	self:AddTranslatedNotify( "WARN_KICK_ON_CONNECT", {
 		AFKTime = "integer"
 	} )
+	self:AddTranslatedNotify( "WARN_NOTIFY", {
+		AFKTime = "integer",
+		KickTime = "integer",
+		MinPlayers = "integer"
+	} )
 end
 
 Shine:RegisterExtension( "afkkick", Plugin )

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -698,6 +698,7 @@ function Plugin:ShuffleTeams( ResetScores, ForceMode )
 		end
 	end
 	self.LastShuffleTeamLookup = TeamLookup
+	self:ClearStatsCache()
 end
 
 function Plugin:GetOptimalTeamForPlayer( Player, Team1Players, Team2Players, SkillGetter )

--- a/lua/shine/lib/objects/rate_limiter.lua
+++ b/lua/shine/lib/objects/rate_limiter.lua
@@ -1,0 +1,76 @@
+--[[
+	Provides rate limiting functionality.
+]]
+
+local RateLimiter = Shine.TypeDef()
+Shine.RateLimiter = RateLimiter
+
+-- Provides exponentially growing backoff every time the limit is hit.
+RateLimiter.ExponentialBackoff = function( Interval ) return Interval * 2 end
+
+-- Generates a backoff function that increases the interval by the given value
+-- every time the limit is hit.
+RateLimiter.LinearBackoff = function( IntervalGrowthRate )
+	return function( Interval )
+		return Interval + IntervalGrowthRate
+	end
+end
+
+-- Provides no backoff at all (the default).
+RateLimiter.NullBackoff = function( Interval ) return Interval end
+
+function RateLimiter:Init( MaxPerInterval, Interval, Clock, BackoffFunc )
+	self.MaxPerInterval = MaxPerInterval
+	self.DefaultInterval = Interval
+	self.Clock = Clock
+	self.BackoffFunc = BackoffFunc or RateLimiter.NullBackoff
+
+	self.CurrentInterval = Interval
+	self.Value = MaxPerInterval
+	self.NextReset = Clock() + Interval
+
+	return self
+end
+
+function RateLimiter:GetRemainingAmount()
+	return self.Value
+end
+
+-- Consumes the given amount from the limiter. If the amount exceeds the remaining
+-- allocation, the method will return false. Otherwise the value is updated and backoff
+-- is applied when reaching 0 allocation.
+function RateLimiter:Consume( Amount )
+	local Time = self.Clock()
+	if Time >= self.NextReset then
+		local IntervalsPassed = ( Time - self.NextReset ) / self.CurrentInterval
+		if self.Value == self.MaxPerInterval or IntervalsPassed >= 1 then
+			-- If the limiter wasn't hit at all last interval, reset back to
+			-- normal, removing any backoff.
+			self.CurrentInterval = self.DefaultInterval
+		end
+
+		self.Value = self.MaxPerInterval
+		self.NextReset = Time + self.CurrentInterval
+
+		self:OnReset()
+	end
+
+	local NewValue = self.Value - Amount
+	if NewValue < 0 then
+		return false
+	end
+
+	self.Value = NewValue
+
+	if NewValue == 0 then
+		-- The entire allocation for this interval was used, so apply
+		-- any backoff to the interval.
+		self.CurrentInterval = self.BackoffFunc( self.CurrentInterval )
+	end
+
+	return true
+end
+
+function RateLimiter:OnReset()
+
+end

--- a/test/extensions/voterandom/voterandom.lua
+++ b/test/extensions/voterandom/voterandom.lua
@@ -383,6 +383,18 @@ UnitTest:Test( "EvaluateConstraints - Teams are balanced", function( Assert )
 	)
 end )
 
+UnitTest:Test( "GetTeamStats - Uses cached data if available", function( Assert )
+	local RankFunc = function() end
+	local Stats = {}
+
+	VoteShuffle.TeamStatsCache[ RankFunc ] = Stats
+	local ComputedStats = VoteShuffle:GetTeamStats( RankFunc )
+
+	Assert.Equals( "Expected GetTeamStats to return cached data when available",
+		Stats, ComputedStats )
+end )
+
+VoteShuffle:ClearStatsCache()
 VoteShuffle.Config.IgnoreCommanders = false
 
 VoteShuffle.SaveHappinessHistory = BalanceModule.SaveHappinessHistory

--- a/test/lib/objects/rate_limiter.lua
+++ b/test/lib/objects/rate_limiter.lua
@@ -1,0 +1,44 @@
+--[[
+	Rate limiter unit tests.
+]]
+
+local UnitTest = Shine.UnitTest
+
+local TIME = 0
+local function Clock()
+	return TIME
+end
+
+UnitTest:Before( function()
+	TIME = 0
+end )
+
+UnitTest:Test( "Consumption is denied when too large", function( Assert )
+	local RateLimiter = Shine.RateLimiter( 10, 1, Clock )
+	Assert.False( "Consumption should be denied when larger than current value", RateLimiter:Consume( 11 ) )
+	Assert.Equals( "Nothing should have been consumed", 10, RateLimiter:GetRemainingAmount() )
+end )
+
+UnitTest:Test( "Consumption is permitted when smaller than current value", function( Assert )
+	local RateLimiter = Shine.RateLimiter( 10, 1, Clock )
+	Assert.True( "Consumption should be permitted when small enough", RateLimiter:Consume( 1 ) )
+	Assert.Equals( "Should have consumed 1", 9, RateLimiter:GetRemainingAmount() )
+end )
+
+UnitTest:Test( "Backoff is applied when all is consumed", function( Assert )
+	local RateLimiter = Shine.RateLimiter( 10, 1, Clock, Shine.RateLimiter.ExponentialBackoff )
+	Assert.True( "Consumption should be permitted", RateLimiter:Consume( 10 ) )
+	Assert.Equals( "Should have consumed 10", 0, RateLimiter:GetRemainingAmount() )
+	Assert.Equals( "Should have doubled the interval", 2, RateLimiter.CurrentInterval )
+
+	TIME = 1
+	Assert.True( "Should permit consumption after reset time", RateLimiter:Consume( 1 ) )
+	Assert.Equals( "Should have applied doubled interval to next reset time", 3, RateLimiter.NextReset )
+	Assert.Equals( "Should have consumed 1", 9, RateLimiter:GetRemainingAmount() )
+
+	-- Jump forward 2 intervals, should consider the previous interval empty.
+	TIME = 5
+	Assert.True( "Should permit consumption after reset time", RateLimiter:Consume( 1 ) )
+	Assert.Equals( "Should have reset interval due to 0 consumption in previous interval", 6, RateLimiter.NextReset )
+	Assert.Equals( "Should have consumed 1", 9, RateLimiter:GetRemainingAmount() )
+end )


### PR DESCRIPTION
#### AFK Kick
* Improved the message displayed when a player is warned and the server has less than `MinPlayers` connected. It will now inform them that they will be kicked only if they exceed `KickTime` and the number of players reaches `MinPlayers`.
* The plugin now overrides the vanilla AFK timer to ensure infantry portals know when players are AFK.

#### Vote Shuffle
* Team statistics for `sh_teamstats` and vote constraints are now cached to improve performance in certain cases.

#### Other
* Added a rate limit to command execution. This can be changed with the `MaxCommandsPerSecond` option in the base config.