### PR TITLE
Add system time based advert triggers, alter chat command matching

### DIFF
--- a/lua/shine/core/server/commands.lua
+++ b/lua/shine/core/server/commands.lua
@@ -899,7 +899,7 @@ Shine.Hook.Add( "PlayerSay", "CommandExecute", function( Client, Message )
 	if not FirstWord then return end
 
 	-- They've done !, / or some other special character first.
-	if StringFind( StringSub( FirstWord, 1, 1 ), "[^%w]" ) then
+	if StringFind( StringSub( FirstWord, 1, 1 ), "[!/]" ) then
 		Directive = StringSub( FirstWord, 1, 1 )
 		Exploded[ 1 ] = StringSub( FirstWord, 2 )
 	end

--- a/lua/shine/lib/string.lua
+++ b/lua/shine/lib/string.lua
@@ -241,6 +241,57 @@ do
 end
 
 do
+	local OSDate = os.date
+	local OSTime = os.time
+	local StringMatch = string.match
+	local tonumber = tonumber
+
+	local LOCAL_DATE_TIME = "^(%d+)%-(%d+)%-(%d+)[T ](%d+):(%d+):?(%d*)$"
+	local LOCAL_TIME = "^T?(%d+):(%d+):?(%d*)$"
+
+	--[[
+		Parses the given string into a timestamp.
+
+		Format should be one of (where seconds are optional):
+		YYYY-MM-ddTHH:mm:ss
+		YYYY-MM-dd HH:mm:ss
+		THH:mm:ss
+		HH:mm:ss
+
+		If the string is a full date-time, the timestamp will use the given year/month/day,
+		otherwise, it will use the current local time's date.
+	]]
+	function string.ParseLocalDateTime( Time, FallbackDate )
+		FallbackDate = FallbackDate or OSDate( "*t" )
+
+		local IsDateTime = true
+		local Year, Month, Day, Hour, Minute, Second = StringMatch( Time, LOCAL_DATE_TIME )
+		if not Year then
+			IsDateTime = false
+
+			Year = FallbackDate.year
+			Month = FallbackDate.month
+			Day = FallbackDate.day
+
+			Hour, Minute, Second = StringMatch( Time, LOCAL_TIME )
+		end
+
+		if not Hour then
+			return nil, "invalid date/time format"
+		end
+
+		return OSTime( {
+			year = tonumber( Year ),
+			month = tonumber( Month ),
+			day = tonumber( Day ),
+			hour = tonumber( Hour ),
+			min = tonumber( Minute ),
+			sec = tonumber( Second ) or 0
+		} ), IsDateTime
+	end
+end
+
+do
 	local StringExplode = string.Explode
 	local StringGSub = string.gsub
 	local StringMatch = string.match

--- a/test/lib/string.lua
+++ b/test/lib/string.lua
@@ -20,6 +20,34 @@ UnitTest:Test( "PatternSafe", function( Assert )
 	Assert.True( "Should be able to search without error", pcall( string.find, ".*+-?()[]%^$", Pattern ) )
 end )
 
+UnitTest:Test( "ParseLocalDateTime - Date and time with seconds", function( Assert )
+	local Timestamp, IsDateTime = string.ParseLocalDateTime( "2018-01-01T00:00:05" )
+
+	Assert.True( "Should be parsed as a date-time", IsDateTime )
+	Assert.Equals( "Should match expected timestamp", 1514764805, Timestamp )
+end )
+
+UnitTest:Test( "ParseLocalDateTime - Date and time without seconds", function( Assert )
+	local Timestamp, IsDateTime = string.ParseLocalDateTime( "2018-01-01T00:00" )
+
+	Assert.True( "Should be parsed as a date-time", IsDateTime )
+	Assert.Equals( "Should match expected timestamp", 1514764800, Timestamp )
+end )
+
+UnitTest:Test( "ParseLocalDateTime - Time with seconds", function( Assert )
+	local Timestamp, IsDateTime = string.ParseLocalDateTime( "T00:00:05", { year = 2018, month = 1, day = 1 } )
+
+	Assert.False( "Should be parsed as a time", IsDateTime )
+	Assert.Equals( "Should match expected timestamp", 1514764805, Timestamp )
+end )
+
+UnitTest:Test( "ParseLocalDateTime - Time without seconds", function( Assert )
+	local Timestamp, IsDateTime = string.ParseLocalDateTime( "T00:00", { year = 2018, month = 1, day = 1 } )
+
+	Assert.False( "Should be parsed as a time", IsDateTime )
+	Assert.Equals( "Should match expected timestamp", 1514764800, Timestamp )
+end )
+
 do
 	local InterpolationTests = {
 		{


### PR DESCRIPTION
#### Adverts
* Advert cycles can now be [started/stopped at specific system times/dates](https://github.com/Person8880/Shine/issues/698#issuecomment-406803808) using the `SYSTEM_TIME` trigger type.

#### Misc
* Fixed chat commands accepting too many possible characters to be triggered. They can now only be triggered by either `!` or `/`.