### PR TITLE
Forced badges, vote permissions, commander adverts, eject vote customisation and fixes

### DIFF
--- a/locale/shine/extensions/chatbox/enGB.json
+++ b/locale/shine/extensions/chatbox/enGB.json
@@ -6,6 +6,7 @@
 	"AUTO_DELETE": "Auto delete on close.",
 	"SMOOTH_SCROLL": "Use smooth scrolling.",
 	"SCROLL_TO_BOTTOM": "Scroll to bottom on open.",
+	"MOVE_VANILLA_CHAT": "Move outer messages.",
 	"MESSAGE_MEMORY": "Message memory",
 	"OPACITY": "Opacity (%)",
 	"SCALE": "Scale (will re-open chatbox)",

--- a/locale/shine/extensions/mapvote/enGB.json
+++ b/locale/shine/extensions/mapvote/enGB.json
@@ -44,6 +44,7 @@
 	"RECENTLY_PLAYED": "{MapName} was recently played and cannot be voted for yet.",
 	"NOMINATIONS_FULL": "Nominations are full.",
 	"NOMINATED_MAP": "{TargetName} nominated {MapName} for a map vote.",
+	"NOMINATED_MAP_CONDITIONALLY": "NOTE: {MapName} has conditions that may prevent it from being an option when the map vote starts.",
 	"RTV_DISABLED": "RTV has been disabled.",
 	"RTV_VOTED": "{TargetName} voted to change the map ({VotesNeeded} more {VotesNeeded:Pluralise:vote|votes} needed).",
 	"PLAYER_VOTED": "{TargetName} {Revote:BoolToPhrase:revoted|voted} for {MapName} ({Votes} {Votes:Pluralise:vote|votes} for this, {TotalVotes} total)",

--- a/lua/shine/core/shared/base_plugin.lua
+++ b/lua/shine/core/shared/base_plugin.lua
@@ -13,6 +13,10 @@ Shine.BasePlugin = PluginMeta
 -- Modules are static mixins that are applied to the base plugin.
 PluginMeta.Modules = {}
 
+function PluginMeta:GetName()
+	return self.__Name
+end
+
 --[[
 	Base initialise, just enables the plugin, nothing more.
 	Override to add to it.

--- a/lua/shine/core/shared/config.lua
+++ b/lua/shine/core/shared/config.lua
@@ -269,6 +269,31 @@ do
 		end
 	end
 
+	function Validator.ValidateField( Name, Predicate, FixFunc, MessageFunc )
+		return function( Value )
+			if not IsType( Value, "table" ) then return true end
+			return Predicate( Value[ Name ] )
+		end,
+		function( Value )
+			if not IsType( Value, "table" ) then
+				local Fixed = FixFunc( nil )
+				if Fixed ~= nil then
+					return {
+						[ Name ] = Fixed
+					}
+				end
+				return nil
+			end
+
+			Value[ Name ] = FixFunc( Value[ Name ] )
+
+			return Value
+		end,
+		function()
+			return StringFormat( "Field %s on %s", Name, MessageFunc() )
+		end
+	end
+
 	function Validator.InEnum( PossibleValues, DefaultValue )
 		return function( Value )
 			return not IsType( Value, "string" ) or PossibleValues[ StringUpper( Value ) ] == nil, StringUpper( Value )

--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -632,6 +632,7 @@ Add( "Think", "ReplaceMethods", function()
 
 	if not Shine.IsNS2Combat then
 		SetupClassHook( "CommandStructure", "LoginPlayer", "CommLoginPlayer", "PassivePre" )
+		SetupClassHook( "CommandStructure", "OnCommanderLogin", "OnCommanderLogin", "PassivePre" )
 		SetupClassHook( "CommandStructure", "Logout", "CommLogout", "PassivePre" )
 		SetupClassHook( "CommandStructure", "OnUse", "CheckCommLogin", "ActivePre" )
 
@@ -642,6 +643,9 @@ Add( "Think", "ReplaceMethods", function()
 			"PassivePre" )
 		SetupClassHook( "Commander", "TriggerNotification", "OnCommanderNotify", "PassivePre" )
 		SetupClassHook( "Commander", "Eject", "OnCommanderEjected", "PassivePre" )
+
+		SetupClassHook( "PlayingTeam", "VoteToEjectCommander", "OnVoteToEjectCommander", "PassivePost" )
+		SetupClassHook( "PlayingTeam", "VoteToGiveUp", "OnVoteToConcede", "PassivePost" )
 	end
 
 	SetupClassHook( "ConstructMixin", "OnInitialized", "OnConstructInit", "PassivePre" )

--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -641,6 +641,7 @@ Add( "Think", "ReplaceMethods", function()
 		SetupClassHook( "Commander", "ProcessTechTreeActionForEntity", "OnCommanderTechTreeAction",
 			"PassivePre" )
 		SetupClassHook( "Commander", "TriggerNotification", "OnCommanderNotify", "PassivePre" )
+		SetupClassHook( "Commander", "Eject", "OnCommanderEjected", "PassivePre" )
 	end
 
 	SetupClassHook( "ConstructMixin", "OnInitialized", "OnConstructInit", "PassivePre" )

--- a/lua/shine/extensions/badges.lua
+++ b/lua/shine/extensions/badges.lua
@@ -4,6 +4,7 @@
 
 local pairs = pairs
 local pcall = pcall
+local rawget = rawget
 local tonumber = tonumber
 local tostring = tostring
 local IsType = Shine.IsType
@@ -14,12 +15,14 @@ Plugin.Version = "2.1"
 
 function Plugin:Initialise()
 	self.AssignedGuests = {}
+
 	self.Enabled = true
 
 	return true
 end
 
 function Plugin:OnFirstThink()
+	Shine.Hook.SetupGlobalHook( "Badges_OnClientBadgeRequest", "OnClientBadgeRequest", "ActivePre" )
 	self:Setup()
 end
 
@@ -162,6 +165,42 @@ function Plugin:AssignBadgesToID( ID, Entry, MasterBadgeTable, OwnerName )
 			end
 		end
 	end
+
+	local ForcedBadges = Entry.ForcedBadges
+	if IsType( ForcedBadges, "table" ) then
+		for i = 1, MaxBadgeRows do
+			local Badge = ForcedBadges[ i ] or ForcedBadges[ tostring( i ) ]
+			if IsType( Badge, "string" ) then
+				self:ForceBadgeForIDIfNotAlready( ID, Badge, i )
+			end
+		end
+	end
+end
+
+--[[
+	Forces the given player to have the given badge on the given column,
+	regardless of the badge they have chosen.
+
+	If there is already a forced badge for the given column, it will be left
+	unchanged.
+]]
+function Plugin:ForceBadgeForIDIfNotAlready( ID, Badge, Column )
+	local ForcedBadges = self.ForcedBadges[ ID ]
+	if ForcedBadges and ForcedBadges[ Column ] then return end
+
+	self:ForceBadgeForID( ID, Badge, Column )
+end
+
+--[[
+	Forces the given player to have the given badge on the given column,
+	regardless of the badge they have chosen.
+]]
+function Plugin:ForceBadgeForID( ID, Badge, Column )
+	if not AssignBadge( ID, Badge, Column ) then return end
+
+	local ForcedBadges = self.ForcedBadges[ ID ] or {}
+	ForcedBadges[ Column ] = Badge
+	self.ForcedBadges[ ID ] = ForcedBadges
 end
 
 function Plugin:Setup()
@@ -175,6 +214,9 @@ function Plugin:Setup()
 	if not UserData or not UserData.Groups or not UserData.Users then return end
 
 	local MasterBadgeTable = self:GetMasterBadgeLookup( UserData.Badges )
+
+	-- Remember badges that are forced per NS2ID.
+	self.ForcedBadges = {}
 
 	for ID, User in pairs( UserData.Users ) do
 		ID = tonumber( ID )
@@ -192,10 +234,17 @@ end
 function Plugin:OnUserReload()
 	self.AssignedGuests = {}
 	self:Setup()
+
+	-- Re-assign default group badges.
+	local DefaultGroup = Shine:GetDefaultGroup()
+	if not DefaultGroup then return end
+
+	for Client in Shine.GameIDs:Iterate() do
+		self:AssignGuestBadge( Client, DefaultGroup )
+	end
 end
 
-function Plugin:ClientConnect( Client )
-	local DefaultGroup = Shine:GetDefaultGroup()
+function Plugin:AssignGuestBadge( Client, DefaultGroup )
 	if not DefaultGroup then return end
 
 	local ID = Client:GetUserId()
@@ -205,6 +254,35 @@ function Plugin:ClientConnect( Client )
 	self.AssignedGuests[ ID ] = true
 	self:AssignGroupBadge( ID, nil, DefaultGroup, {},
 		self:GetMasterBadgeLookup( Shine.UserData.Badges ) )
+end
+
+function Plugin:AssignForcedBadges( Client )
+	local ForcedBadges = self.ForcedBadges[ Client:GetUserId() ]
+	if not ForcedBadges then return end
+
+	for Column, BadgeName in pairs( ForcedBadges ) do
+		local BadgeID = rawget( gBadges, BadgeName )
+		if BadgeID then
+			Badges_SetBadge( Client:GetId(), BadgeID, Column )
+		end
+	end
+end
+
+function Plugin:ClientConnect( Client )
+	self:AssignGuestBadge( Client, Shine:GetDefaultGroup() )
+	self:AssignForcedBadges( Client )
+end
+
+function Plugin:OnClientBadgeRequest( ClientID, Message )
+	local Client = ClientID and Server.GetClientById( ClientID )
+	if not Client then return end
+
+	local ForcedBadges = self.ForcedBadges[ Client:GetUserId() ]
+	if not ForcedBadges then return end
+
+	-- Prevent the user changing their badge if it's been forced
+	-- for the given column.
+	if ForcedBadges[ Message.column ] then return false end
 end
 
 Shine:RegisterExtension( "badges", Plugin )

--- a/lua/shine/extensions/basecommands/gamerules.lua
+++ b/lua/shine/extensions/basecommands/gamerules.lua
@@ -1,0 +1,301 @@
+--[[
+	Gamerules overrides.
+]]
+
+local Max = math.max
+local Min = math.min
+local Round = math.Round
+local SharedTime = Shared.GetTime
+local TableEmpty = table.Empty
+
+local Plugin = Plugin
+
+function Plugin:SetGameState( Gamerules, NewState, OldState )
+	self.dt.Gamestate = NewState
+	self:AttemptToConfigureGamerules( Gamerules )
+
+	if NewState == kGameState.Started then
+		local Time = SharedTime()
+		for i = 1, 2 do
+			local Commander = self:GetCommanderForTeam( i )
+			if Commander then
+				-- Start the commander time tracking, and ensure their duration
+				-- is reset from previous rounds.
+				self:MarkCommanderLoginTime( Commander, Time, true )
+			end
+		end
+	elseif self.CommanderLogins then
+		-- Forget all commander logins when not in a round.
+		TableEmpty( self.CommanderLogins )
+	end
+end
+
+function Plugin:GetCommanderForTeam( TeamNumber )
+	return GetEntitiesForTeam( "Commander", TeamNumber )[ 1 ]
+end
+
+local function EnsureVotesNeededLargeEnough( VotesNeeded, TotalPlayerCount )
+	return Min( Max( Round( VotesNeeded ), 2 ), Max( 1, TotalPlayerCount ) )
+end
+
+local function GetEjectVotesNeededFromVoteInterval( VoteInterval, TotalPlayerCount )
+	local Fraction = VoteInterval.FractionOfTeamToPass
+	return EnsureVotesNeededLargeEnough( Fraction * TotalPlayerCount, TotalPlayerCount )
+end
+
+function Plugin:MarkCommanderLoginTime( Commander, Time, ResetDuration )
+	if not self.CommanderLogins then return end
+
+	local Client = Commander:GetClient()
+	if not Client then return end
+
+	if not Time then
+		-- Remove any entry if removing login time.
+		self.CommanderLogins[ Client ] = nil
+		return
+	end
+
+	-- Remember when the commander logged in via their client.
+	local Login = self.CommanderLogins[ Client ]
+	if not Login then
+		Login = {}
+		self.CommanderLogins[ Client ] = Login
+	end
+
+	Login.LoginTime = Time
+	if ResetDuration then
+		Login.Duration = 0
+	end
+
+	if Time then
+		self.Logger:Debug( "%s logged in at %s", Shine.GetClientInfo( Client ), Time )
+	end
+end
+
+function Plugin:MarkCommanderExitTime( Commander, Time )
+	if not self.CommanderLogins then return end
+
+	local Client = Commander:GetClient()
+	local Login = self.CommanderLogins[ Client ]
+	if not Client or not Login or not Login.LoginTime then return end
+
+	-- When a commander logs out, store the duration they were in the chair so the eject vote
+	-- can be based on their total time commanding.
+	local ExistingDuration = Login.Duration or 0
+	Login.Duration = ExistingDuration + ( Time - Login.LoginTime )
+	Login.LoginTime = nil
+
+	self.Logger:Debug( "%s logged out with %s seconds as a commander.",
+		Shine.GetClientInfo( Client ), Login.Duration )
+end
+
+function Plugin:GetCommanderDuration( Commander )
+	local Client = Commander:GetClient()
+	local Login = self.CommanderLogins[ Client ]
+	if not Client or not Login or not Login.LoginTime then return nil end
+
+	return SharedTime() - Login.LoginTime + ( Login.Duration or 0 )
+end
+
+local function LogCommander( Logger, Message, Commander, ... )
+	Logger:Debug( Message, Shine.GetClientInfo( Commander:GetClient() ), ... )
+end
+
+function Plugin:GetEjectVotesNeeded( VoteManager, TeamNumber )
+	local Commander = self:GetCommanderForTeam( TeamNumber )
+	local VoteIntervals = self.Config.EjectVotesNeeded
+	local TotalPlayerCount = VoteManager.numPlayers
+
+	if not Commander then
+		-- Use the first entry if no commander is present.
+		local VotesNeeded = GetEjectVotesNeededFromVoteInterval( VoteIntervals[ 1 ], TotalPlayerCount )
+		self.Logger:Debug( "No commander present, votes needed: %s", VotesNeeded )
+		return VotesNeeded
+	end
+
+	-- Time in chair is the time since last login plus any previous time in the chair.
+	local TimeInChair = self:GetCommanderDuration( Commander )
+	if not TimeInChair then
+		-- Round has not yet started, use the lowest value.
+		local VotesNeeded = GetEjectVotesNeededFromVoteInterval( VoteIntervals[ 1 ], TotalPlayerCount )
+
+		self.Logger:IfDebugEnabled( LogCommander, "No time in chair recorded for %s, votes needed: %s",
+			Commander, VotesNeeded )
+
+		return VotesNeeded
+	end
+
+	-- Assume intervals are sorted already (validator ensures they are).
+	for i = 1, #VoteIntervals do
+		local VoteInterval = VoteIntervals[ i ]
+		if not VoteInterval.MaxSecondsAsCommander or TimeInChair <= VoteInterval.MaxSecondsAsCommander then
+			local VotesNeeded = GetEjectVotesNeededFromVoteInterval( VoteInterval, TotalPlayerCount )
+
+			self.Logger:IfDebugEnabled( LogCommander,
+				"%s has been in the chair for %s seconds, votes needed: %s",
+				Commander, TimeInChair, VotesNeeded )
+
+			return VotesNeeded
+		end
+	end
+
+	-- Shouldn't ever reach this point.
+	local VotesNeeded = GetEjectVotesNeededFromVoteInterval( VoteIntervals[ #VoteIntervals ], TotalPlayerCount )
+
+	self.Logger:IfDebugEnabled( LogCommander,
+		"%s has been in the chair for %s seconds, votes needed (no matching entry): %s",
+		Commander, TimeInChair, VotesNeeded )
+
+	return VotesNeeded
+end
+
+function Plugin:OnCommanderLogin( Chair, Commander, Forced )
+	local Gamerules = GetGamerules()
+	if not Gamerules or not Gamerules:GetGameStarted() then
+		-- Do not track time outside of a round.
+		self:MarkCommanderLoginTime( Commander, nil, true )
+		return
+	end
+
+	self:MarkCommanderLoginTime( Commander, SharedTime() )
+end
+
+function Plugin:CommLogout( Chair )
+	local Commander = Chair:GetCommander()
+	if not Commander then return end
+
+	self:MarkCommanderExitTime( Commander, SharedTime() )
+end
+
+function Plugin:AttemptToConfigureGamerules( Gamerules )
+	if not Gamerules or self.ConfiguredGamerules then return end
+	if not Gamerules.team1 or not Gamerules.team2 then return end
+	if not Gamerules.team1.ejectCommVoteManager or not Gamerules.team2.ejectCommVoteManager then return end
+
+	self.ConfiguredGamerules = true
+
+	Gamerules.kStartGameVoteDelay = self.Config.CommanderBotVoteDelayInSeconds
+
+	if #self.Config.EjectVotesNeeded == 1 then
+		-- If there's just one interval, set the percentage on the vote and leave the
+		-- team object alone.
+		local VotesNeeded = self.Config.EjectVotesNeeded[ 1 ].FractionOfTeamToPass
+		Gamerules.team1.ejectCommVoteManager:SetTeamPercentNeeded( VotesNeeded )
+		Gamerules.team2.ejectCommVoteManager:SetTeamPercentNeeded( VotesNeeded )
+		self.HasOverriddenTeamVotes = false
+		return
+	end
+
+	-- Remember when commanders login.
+	self.CommanderLogins = {}
+	self.HasOverriddenTeamVotes = true
+
+	-- Otherwise, replace the GetNumVotesNeeded method to compute based on interval,
+	-- and alter the way votes are checked to avoid running it every tick.
+	local function ReplaceGetNumVotesNeeded( VoteManager, TeamNumber )
+		VoteManager.GetNumVotesNeeded = function( VoteManager )
+			return self:GetEjectVotesNeeded( VoteManager, TeamNumber )
+		end
+	end
+
+	ReplaceGetNumVotesNeeded( Gamerules.team1.ejectCommVoteManager, 1 )
+	ReplaceGetNumVotesNeeded( Gamerules.team2.ejectCommVoteManager, 2 )
+
+	local function FixVoteChecking( Team )
+		function Team:UpdateVotes()
+			-- Only poll resetting here, not vote passing.
+			-- This avoids GetNumVotesNeeded() being called every tick.
+			if self.ejectCommVoteManager:GetVoteElapsed( SharedTime() ) then
+				self.ejectCommVoteManager:Reset()
+			end
+			if self.concedeVoteManager:GetVoteElapsed( SharedTime() ) then
+				self.concedeVoteManager:Reset()
+			end
+		end
+	end
+
+	FixVoteChecking( Gamerules.team1 )
+	FixVoteChecking( Gamerules.team2 )
+end
+
+local function UpdateVotePlayerCounts( PlayingTeam, Vote )
+	local NumPlayers, _, NumBots = PlayingTeam:GetNumPlayers()
+	Vote:SetNumPlayers( NumPlayers - NumBots )
+end
+
+function Plugin:EvaluateEjectVote( PlayingTeam )
+	local EjectVote = PlayingTeam.ejectCommVoteManager
+	if not EjectVote then return end
+
+	UpdateVotePlayerCounts( PlayingTeam, EjectVote )
+
+	if EjectVote:GetVotePassed() then
+		local TargetCommander = GetPlayerFromUserId( EjectVote:GetTarget() )
+		EjectVote:Reset()
+
+		if TargetCommander and TargetCommander.Eject then
+			TargetCommander:Eject()
+		end
+	end
+end
+
+function Plugin:OnVoteToEjectCommander( PlayingTeam, Player, Commander )
+	if not self.HasOverriddenTeamVotes then return end
+
+	self:EvaluateEjectVote( PlayingTeam )
+end
+
+function Plugin:EvaluateConcedeVote( PlayingTeam )
+	local ConcedeVote = PlayingTeam.concedeVoteManager
+	if not ConcedeVote then return end
+
+	UpdateVotePlayerCounts( PlayingTeam, ConcedeVote )
+
+	if ConcedeVote:GetVotePassed() then
+		ConcedeVote:Reset()
+		PlayingTeam.conceded = true
+		Shine.SendNetworkMessage( "TeamConceded", { teamNumber = PlayingTeam:GetTeamNumber() } )
+	end
+end
+
+function Plugin:OnVoteToConcede( PlayingTeam, Player )
+	if not self.HasOverriddenTeamVotes then return end
+
+	self:EvaluateConcedeVote( PlayingTeam )
+end
+
+function Plugin:EvaluateVotesForTeam( PlayingTeam )
+	if not PlayingTeam then return end
+
+	self:EvaluateEjectVote( PlayingTeam )
+	self:EvaluateConcedeVote( PlayingTeam )
+end
+
+function Plugin:PostJoinTeam( Gamerules, Player, OldTeam, NewTeam, Force )
+	if not self.HasOverriddenTeamVotes then return end
+
+	if OldTeam == 1 or OldTeam == 2 then
+		local Team = Gamerules:GetTeam( OldTeam )
+		-- Player has left team, check the concede/eject totals again.
+		self:EvaluateVotesForTeam( Team )
+	end
+
+	local Client = Player:GetClient()
+	if not Client then return end
+
+	-- Forget any commander login time for the player if they swap teams.
+	self.CommanderLogins[ Client ] = nil
+end
+
+function Plugin:UpdateVotesOnDisconnect()
+	if not self.HasOverriddenTeamVotes then return end
+
+	local Gamerules = GetGamerules()
+	if not Gamerules then return end
+
+	-- Player has left game entirely, check both team's votes.
+	for i = 1, 2 do
+		local Team = Gamerules:GetTeam( i )
+		self:EvaluateVotesForTeam( Team )
+	end
+end

--- a/lua/shine/extensions/chatbox/client.lua
+++ b/lua/shine/extensions/chatbox/client.lua
@@ -68,6 +68,8 @@ function Plugin:HookChat( ChatElement )
 		-- Alter the offset value by reference directly to avoid having to
 		-- reposition elements constantly in the Update method.
 		local CurrentOffset = GetOffset()
+		if not CurrentOffset then return end
+
 		local InverseScale = 1 / GUIScale( 1 )
 		CurrentOffset.x = Offset.x * InverseScale
 		CurrentOffset.y = Offset.y * InverseScale
@@ -121,7 +123,7 @@ function Plugin:HookChat( ChatElement )
 
 		Plugin:AddMessage( PlayerColour, PlayerName, MessageColour, MessageName, Tags )
 
-		if Plugin.Visible and IsType( JustAdded, "table" ) then
+		if Plugin.Visible and JustAdded.Background then
 			JustAdded.Background:SetIsVisible( false )
 		end
 	end

--- a/lua/shine/extensions/mapvote/cycle.lua
+++ b/lua/shine/extensions/mapvote/cycle.lua
@@ -124,6 +124,15 @@ do
 	end
 end
 
+function Plugin:IsConditionalMap( Map )
+	if not IsType( Map, "table" ) or not IsType( Map.map, "string" ) then
+		return false
+	end
+
+	return IsType( Map.min, "number" ) or IsType( Map.max, "number" )
+		or ( self.TrackMapStats and IsType( Map.percent or Map.Percent, "number" ) )
+end
+
 --[[
 	Checks various restrictions to see if the map should be available.
 ]]

--- a/lua/shine/extensions/mapvote/server.lua
+++ b/lua/shine/extensions/mapvote/server.lua
@@ -623,6 +623,8 @@ function Plugin:CreateCommands()
 			return
 		end
 
+		local IsConditional = self:IsConditionalMap( self.MapOptions[ Map ] )
+
 		self.Vote.NominationTracker[ SteamID ] = NominationCount + 1
 
 		Nominated[ Count + 1 ] = Map
@@ -631,6 +633,16 @@ function Plugin:CreateCommands()
 			TargetName = PlayerName,
 			MapName = Map
 		} )
+		if IsConditional then
+			-- Make it clear that the map may not show up if there are any conditions on it.
+			if Client then
+				self:SendTranslatedNotify( Client, "NOMINATED_MAP_CONDITIONALLY", {
+					MapName = Map
+				} )
+			else
+				Notify( StringFormat( "%s has conditions that may prevent it from being an option when the map vote starts.", Map ) )
+			end
+		end
 	end
 	local NominateCommand = self:BindCommand( "sh_nominate", "nominate", Nominate, true )
 	NominateCommand:AddParam{ Type = "string", Error = "Please specify a map name to nominate.", Help = "mapname" }

--- a/lua/shine/extensions/mapvote/shared.lua
+++ b/lua/shine/extensions/mapvote/shared.lua
@@ -102,7 +102,7 @@ function Plugin:SetupDataTable()
 		[ MessageTypes.MapName ] = {
 			"MapCycling", "WINNER_NEXT_MAP", "WINNER_CYCLING",
 			"CHOOSING_RANDOM_MAP", "NextMapCommand",
-			"MAP_CYCLING"
+			"MAP_CYCLING", "NOMINATED_MAP_CONDITIONALLY"
 		},
 		[ MessageTypes.MapVotes ] = {
 			"WINNER_VOTES"

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -280,7 +280,10 @@ function EnforcementPolicy:JoinTeam( Plugin, Gamerules, Player, NewTeam, Force )
 		return false
 	end
 
-	if not self.Policies[ Plugin.EnforcementPolicyType.ASSIGN_PLAYERS ] then return end
+	if not self.Policies[ Plugin.EnforcementPolicyType.ASSIGN_PLAYERS ] or ( NumTeam1 == 0 and NumTeam2 == 0 ) then
+		-- Skip if not auto-assigning or if both playing teams are empty.
+		return
+	end
 
 	if not Player.ShineRandomised then
 		-- They're going from the ready room/spectate to a team.

--- a/lua/shine/lib/gui/layout/units/default.lua
+++ b/lua/shine/lib/gui/layout/units/default.lua
@@ -89,6 +89,8 @@ end
 	Spacing type, handles padding and margins.
 ]]
 do
+	local rawget = rawget
+
 	local Spacing = NewType( "Spacing" )
 
 	function Spacing:Init( L, U, R, D )
@@ -107,7 +109,7 @@ do
 		Down = 4
 	}
 	function Spacing:__index( Key )
-		return Spacing[ Key ] or self[ KeyMap[ Key ] ]
+		return Spacing[ Key ] or rawget( self, KeyMap[ Key ] )
 	end
 
 	function Spacing:WithLeft( Left )

--- a/lua/shine/lib/gui/objects/slider.lua
+++ b/lua/shine/lib/gui/objects/slider.lua
@@ -11,14 +11,14 @@ local type = type
 
 local Slider = {}
 
-local DefaultHandleSize = Vector( 10, 32, 0 )
-local DefaultLineSize = Vector( 250, 5, 0 )
-local DefaultUnfilledLineSize = Vector( 0, 5, 0 )
-local DefaultSize = Vector( 250, 32, 0 )
-local Padding = Vector( 20, 0, 0 )
+local DefaultHandleSize = Vector2( 10, 32 )
+local DefaultLineSize = Vector2( 250, 5 )
+local DefaultUnfilledLineSize = Vector2( 0, 5 )
+local DefaultSize = Vector2( 250, 32 )
+local Padding = Vector2( 20, 0 )
 
-local LinePos = Vector( 0, -2.5, 0 )
-local UnfilledLinePos = Vector( 250, -2.5, 0 )
+local LinePos = Vector2( 0, -2.5 )
+local UnfilledLinePos = Vector2( 250, -2.5 )
 
 local Clear = Colour( 0, 0, 0, 0 )
 
@@ -75,12 +75,13 @@ function Slider:Initialise()
 	self.Range = 100
 	self.Value = 0
 	self.Decimals = 0
+	self.LineHeightMultiplier = 0.25
 
-	self.HandleSize = Vector( 10, 32, 0 )
-	self.HandlePos = Vector( 0, 0, 0 )
-	self.LineSize = Vector( 250, 5, 0 )
-	self.DarkLineSize = Vector( 0, 5, 0 )
-	self.DarkLinePos = Vector( 250, -2.5, 0 )
+	self.HandleSize = Vector2( 10, 32 )
+	self.HandlePos = Vector2( 0, 0 )
+	self.LineSize = Vector2( 250, 5 )
+	self.DarkLineSize = Vector2( 0, 5 )
+	self.DarkLinePos = Vector2( 250, -2.5 )
 end
 
 function Slider:SetupStencil()
@@ -97,15 +98,31 @@ function Slider:SizeLines()
 
 	local LineWidth = self.Width * self.Fraction
 	self.LineSize.x = LineWidth
+	self.LineSize.y = self.Height * self.LineHeightMultiplier
 	self.Line:SetSize( self.LineSize )
 
+	local CurrentLinePos = Vector2( 0, -self.LineSize.y * 0.5 )
+	self.Line:SetPosition( CurrentLinePos )
+
 	self.DarkLinePos.x = LineWidth
+	self.DarkLinePos.y = CurrentLinePos.y
 	self.DarkLine:SetPosition( self.DarkLinePos )
 
 	self.DarkLineSize.x = self.Width * ( 1 - self.Fraction )
+	self.DarkLineSize.y = self.LineSize.y
 	self.DarkLine:SetSize( self.DarkLineSize )
 
 	self.HandleSize.y = self.Height
+	self.Handle:SetSize( self.HandleSize )
+end
+
+function Slider:SetLineHeightMultiplier( Multiplier )
+	self.LineHeightMultiplier = Multiplier
+	self:SizeLines()
+end
+
+function Slider:SetHandleWidth( Width )
+	self.HandleSize.x = Width
 	self.Handle:SetSize( self.HandleSize )
 end
 
@@ -126,7 +143,7 @@ SGUI.AddBoundProperty( Slider, "LineColour", "Line:SetColor" )
 SGUI.AddBoundProperty( Slider, "DarkLineColour", "DarkLine:SetColor" )
 
 function Slider:SetPadding( Value )
-	self.Label:SetPos( Vector( Value, 0, 0 ) )
+	self.Label:SetPos( Vector2( Value, 0 ) )
 end
 
 --[[
@@ -205,7 +222,7 @@ function Slider:PlayerKeyPress( Key, Down )
 end
 
 local GetCursorPos
-local LineMult = Vector( 1, 0.5, 0 )
+local LineMult = Vector2( 1, 0.5 )
 
 function Slider:OnMouseDown( Key )
 	if Key ~= InputKey.MouseButton0 then return end
@@ -228,7 +245,7 @@ function Slider:OnMouseDown( Key )
 	self.DragStart = X
 	self.StartingPos = self.Handle:GetPosition()
 
-	self.CurPos = Vector( self.StartingPos.x, 0, 0 )
+	self.CurPos = Vector2( self.StartingPos.x, 0 )
 
 	return true, self
 end

--- a/test/core/server/permissions.lua
+++ b/test/core/server/permissions.lua
@@ -185,6 +185,26 @@ UnitTest:Test( "GetGroupAccess", function( Assert )
 	Assert:Falsy( Shine:GetGroupAccess( GroupName, GroupTable, "sh_help" ) )
 end )
 
+UnitTest:Test( "GetGroupAccess when allowed by default", function( Assert )
+	local GroupName = "Member"
+	local GroupTable = Shine:GetGroupData( GroupName )
+
+	-- Allowed in whitelist
+	Assert:Truthy( Shine:GetGroupAccess( GroupName, GroupTable, "sh_kick", true ) )
+	-- Allowed by default (not denied in whitelist)
+	Assert:Truthy( Shine:GetGroupAccess( GroupName, GroupTable, "sh_ns2_votereset", true ) )
+	-- Explicitly denied in a whitelist, so should not have access.
+	Assert:Falsy( Shine:GetGroupAccess( GroupName, GroupTable, "sh_help", true ) )
+
+	GroupName = "SuperAdmin"
+	GroupTable = Shine:GetGroupData( GroupName )
+
+	-- Explicitly denied in a blacklist, so should not have access.
+	Assert:Falsy( Shine:GetGroupAccess( GroupName, GroupTable, "sh_randomimmune", true ) )
+	-- Not denied in blacklist.
+	Assert:Truthy( Shine:GetGroupAccess( GroupName, GroupTable, "sh_kick", true ) )
+end )
+
 ---- USER PERMISSION TESTS ----
 UnitTest:Test( "Default group targeting", function( Assert )
 	Assert:Truthy( Shine:CanTarget( 999, 998 ) )

--- a/test/core/shared/config.lua
+++ b/test/core/shared/config.lua
@@ -36,6 +36,13 @@ UnitTest:Test( "Validator", function( Assert )
 	Validator:AddFieldRules( { "SingleEnum", "AnotherEnum" }, Validator.InEnum( Enum, Enum.B ) )
 	Validator:AddFieldRule( "SingleEnum", Validator.IsType( "string", 1 ) )
 
+	Validator:AddFieldRule( "ListOfTables", Validator.Each(
+		Validator.ValidateField( "ShouldBeNumber", Validator.IsType( "number", 1 ) )
+	) )
+	Validator:AddFieldRule( "ListOfTables", Validator.Each(
+		Validator.ValidateField( "CanBeNilOrNumber", Validator.IsAnyType( { "number", "nil" }, 0 ) )
+	) )
+
 	local Config = {
 		TooSmallNumber = 5,
 		BigEnoughNumber = 11,
@@ -44,7 +51,11 @@ UnitTest:Test( "Validator", function( Assert )
 		},
 		ListOfEnums = { "A", "C", "b" },
 		SingleEnum = "a",
-		AnotherEnum = "C"
+		AnotherEnum = "C",
+		ListOfTables = {
+			{ ShouldBeNumber = 0 },
+			{ ShouldBeNumber = "1", CanBeNilOrNumber = true }
+		}
 	}
 	Assert:True( Validator:Validate( Config ) )
 	Assert:True( Config.Fixed )
@@ -64,6 +75,11 @@ UnitTest:Test( "Validator", function( Assert )
 	Assert:Equals( "A", Config.SingleEnum )
 	-- Should replace the invalid enum.
 	Assert:Equals( "B", Config.AnotherEnum )
+
+	Assert:DeepEquals( {
+		{ ShouldBeNumber = 0 },
+		{ ShouldBeNumber = 1, CanBeNilOrNumber = 0 }
+	}, Config.ListOfTables )
 end )
 
 UnitTest:Test( "TypeCheckConfig", function( Assert )

--- a/test/extensions/badges.lua
+++ b/test/extensions/badges.lua
@@ -6,6 +6,8 @@ local UnitTest = Shine.UnitTest
 local Badges = UnitTest:LoadExtension( "badges" )
 if not Badges then return end
 
+Badges = UnitTest.MockOf( Badges )
+
 local TableInsertUnique = table.InsertUnique
 
 local Assigned = {}
@@ -121,9 +123,9 @@ UnitTest:Test( "AssignBadgesToID", function( Assert )
 	Assert:Contains( Assigned[ ID ][ 1 ], "ranoutofcake" )
 	Assert:NotNil( Assigned[ ID ][ 8 ] )
 	Assert:Contains( Assigned[ ID ][ 8 ], "ohwell" )
-end, function()
-	Assigned = {}
 end )
+
+Assigned = {}
 
 UnitTest:Test( "AssignGroupBadge", function( Assert )
 	local ID = 123456
@@ -138,6 +140,27 @@ UnitTest:Test( "AssignGroupBadge", function( Assert )
 	Assert:NotNil( Assigned[ ID ][ Badges.DefaultRow ] )
 	Assert:ArrayEquals( { "cake", "morecake", "somuchcake", "test" },
 		Assigned[ ID ][ Badges.DefaultRow ] )
+end )
+
+Assigned = {}
+
+UnitTest:Test( "Assign forced badges", function( Assert )
+	local ID = 123456
+	local Entry = {
+		ForcedBadges = { "cake", "morecake" }
+	}
+
+	Badges:AssignBadgesToID( ID, Entry )
+
+	Assert:NotNil( Assigned[ ID ] )
+	Assert:ArrayEquals( { "cake" }, Assigned[ ID ][ 1 ] )
+	Assert:ArrayEquals( { "morecake" }, Assigned[ ID ][ 2 ] )
+
+	Assert:DeepEquals( Badges.ForcedBadges, {
+		[ ID ] = {
+			"cake", "morecake"
+		}
+	} )
 end )
 
 GiveBadge = OldGiveBadge

--- a/test/extensions/basecommands.lua
+++ b/test/extensions/basecommands.lua
@@ -1,0 +1,173 @@
+--[[
+	Base commands plugin unit test.
+]]
+
+local UnitTest = Shine.UnitTest
+local Plugin = UnitTest:LoadExtension( "basecommands" )
+if not Plugin then return end
+
+Plugin = UnitTest.MockOf( Plugin )
+
+Plugin.Config = {
+	EjectVotesNeeded = {
+		{ FractionOfTeamToPass = 0.25, MaxSecondsAsCommander = 10 },
+		{ FractionOfTeamToPass = 0.4, MaxSecondsAsCommander = 60 },
+		{ FractionOfTeamToPass = 0.75 }
+	}
+}
+
+Plugin.CommanderLogins = {}
+
+local COMMANDER
+local CLIENT = {
+	GetControllingPlayer = function() return COMMANDER end,
+	GetUserId = function() return 0 end
+}
+local function MockCommander()
+	return {
+		GetClient = function() return CLIENT end,
+		GetName = function() return "TestCommander" end
+	}
+end
+function Plugin:GetCommanderForTeam()
+	return COMMANDER
+end
+
+local function SetCommanderTime( Time, Duration )
+	if not Time then
+		Plugin.CommanderLogins[ CLIENT ] = nil
+		return
+	end
+	Plugin.CommanderLogins[ CLIENT ] = {
+		LoginTime = Time,
+		Duration = Duration
+	}
+end
+
+local function GetLoginTime()
+	local Login = Plugin.CommanderLogins[ CLIENT ]
+	return Login and Login.LoginTime
+end
+
+local function GetDuration()
+	local Login = Plugin.CommanderLogins[ CLIENT ]
+	return Login and Login.Duration
+end
+
+local VoteManager = {
+	numPlayers = 1
+}
+
+UnitTest:Test( "GetEjectVotesNeeded - Should have minimum value of 1", function( Assert )
+	local VotesNeeded = Plugin:GetEjectVotesNeeded( VoteManager, 1 )
+	Assert.Equals( "Should always return at least 1 for GetEjectVotesNeeded", 1, VotesNeeded )
+end )
+
+VoteManager.numPlayers = 2
+
+UnitTest:Test( "GetEjectVotesNeeded - Should return 2 when 2 players present", function( Assert )
+	local VotesNeeded = Plugin:GetEjectVotesNeeded( VoteManager, 1 )
+	Assert.Equals( "Should always return 2 for GetEjectVotesNeeded with 2 players present", 2, VotesNeeded )
+end )
+
+VoteManager.numPlayers = 10
+
+UnitTest:Test( "GetEjectVotesNeeded - No commander found returns first value", function( Assert )
+	local VotesNeeded = Plugin:GetEjectVotesNeeded( VoteManager, 1 )
+	Assert.Equals( "Should use the first interval when no valid commander is found", 3, VotesNeeded )
+end )
+
+COMMANDER = MockCommander()
+
+UnitTest:Test( "GetEjectVotesNeeded - Commander with no login time returns first value", function( Assert )
+	local VotesNeeded = Plugin:GetEjectVotesNeeded( VoteManager, 1 )
+	Assert.Equals( "Should use the first interval when no valid commander is found", 3, VotesNeeded )
+end )
+
+UnitTest:Test( "GetEjectVotesNeeded - First value chosen when time low enough", function( Assert )
+	SetCommanderTime( Shared.GetTime() )
+
+	local VotesNeeded = Plugin:GetEjectVotesNeeded( VoteManager, 1 )
+	Assert.Equals( "Should use the first interval when time is low enough", 3, VotesNeeded )
+end )
+
+UnitTest:Test( "GetEjectVotesNeeded - Second value chosen when time is larger than first but smaller than last", function( Assert )
+	SetCommanderTime( Shared.GetTime() - 20 )
+
+	local VotesNeeded = Plugin:GetEjectVotesNeeded( VoteManager, 1 )
+	Assert.Equals( "Should use the second interval when time is between first and third", 4, VotesNeeded )
+end )
+
+UnitTest:Test( "GetEjectVotesNeeded - Last value chosen when time is high enough", function( Assert )
+	SetCommanderTime( Shared.GetTime() - 61 )
+
+	local VotesNeeded = Plugin:GetEjectVotesNeeded( VoteManager, 1 )
+	Assert.Equals( "Should use the last interval when time is after first and second", 8, VotesNeeded )
+end )
+
+UnitTest:Test( "MarkCommanderLoginTime - Marks with given time", function( Assert )
+	SetCommanderTime()
+
+	Plugin:MarkCommanderLoginTime( COMMANDER, 0 )
+
+	Assert.Equals( "Login time should be set to given value", 0, GetLoginTime() )
+	Assert.Nil( "Duration should be unchanged when not reset", GetDuration() )
+end )
+
+UnitTest:Test( "MarkCommanderLoginTime - Marks with given time and resets", function( Assert )
+	SetCommanderTime()
+
+	Plugin:MarkCommanderLoginTime( COMMANDER, 0, true )
+
+	Assert.Equals( "Login time should be set to given value", 0, GetLoginTime() )
+	Assert.Equals( "Duration should be reset", 0, GetDuration() )
+end )
+
+UnitTest:Test( "MarkCommanderExitTime - Does not mark when no login time present", function( Assert )
+	SetCommanderTime()
+
+	Plugin:MarkCommanderExitTime( COMMANDER, 0 )
+
+	Assert.Nil( "Duration should be unchanged when no login time is set", GetDuration() )
+end )
+
+UnitTest:Test( "MarkCommanderExitTime - Sets duration when none is present", function( Assert )
+	SetCommanderTime( 0 )
+
+	Plugin:MarkCommanderExitTime( COMMANDER, 120 )
+
+	Assert.Equals( "Duration should be set to difference between now and login time",
+		120, GetDuration() )
+	Assert.Nil( "Login time should be reset", GetLoginTime() )
+end )
+
+UnitTest:Test( "MarkCommanderExitTime - Updates duration when it is present", function( Assert )
+	SetCommanderTime( 0, 120 )
+
+	Plugin:MarkCommanderExitTime( COMMANDER, 120 )
+
+	Assert.Equals( "Duration should be added to the existing duration",
+		240, GetDuration() )
+	Assert.Nil( "Login time should be reset", GetLoginTime() )
+end )
+
+UnitTest:Test( "GetCommanderDuration - Returns nil when no login time stored", function( Assert )
+	SetCommanderTime()
+
+	Assert.Nil( "Total time should be nil when no login time is stored",
+		Plugin:GetCommanderDuration( COMMANDER ) )
+end )
+
+UnitTest:Test( "GetCommanderDuration - Uses login time only when no duration present", function( Assert )
+	SetCommanderTime( Shared.GetTime() - 30 )
+
+	Assert.Equals( "Total time should equal time since last login",
+		30, Plugin:GetCommanderDuration( COMMANDER ) )
+end )
+
+UnitTest:Test( "GetCommanderDuration - Uses duration when present", function( Assert )
+	SetCommanderTime( Shared.GetTime() - 30, 30 )
+
+	Assert.Equals( "Total time should equal duration plus time since last login",
+		60, Plugin:GetCommanderDuration( COMMANDER ) )
+end )


### PR DESCRIPTION
#### Adverts
* Added new advert triggers:
  * `COMMANDER_LOGGED_IN`
  * `MARINE_COMMANDER_LOGGED_IN`
  * `ALIEN_COMMANDER_LOGGED_IN`
  * `COMMANDER_LOGGED_OUT`
  * `MARINE_COMMANDER_LOGGED_OUT`
  * `ALIEN_COMMANDER_LOGGED_OUT`
  * `COMMANDER_EJECTED`
  * `MARINE_COMMANDER_EJECTED`
  * `ALIEN_COMMANDER_EJECTED`
* Each of the new triggers may be formatted with the commander's name using `{CommanderName}`.

#### Badges
* Badges can [now be forced](https://github.com/Person8880/Shine/wiki/Badges#forcing-badges) by adding a `ForcedBadges` entry to either a user or group.

#### Base Commands
* Eject votes [can now have different percentages](https://github.com/Person8880/Shine/issues/709#issuecomment-414123447) of the team required depending on how long a commander has commanded in the current round.

#### Chatbox
* Added an option to make the outer chat follow the chatbox when moved.

#### Map Vote
* Players nominating a map that has conditions that may mean it does not appear are now informed that conditions exist.

#### Vote Shuffle
* Players will no longer be auto-assigned to a team when both playing teams are empty.

#### Other
* NS2 votes can now be blocked for users/groups by assigning permissions of the form `sh_ns2_<votename>`. See [the wiki for a list](https://github.com/Person8880/Shine/wiki/Configuring-Users#special-access-commands).