### PR TITLE
Various bug fixes and improvements

### DIFF
--- a/locale/shine/extensions/afkkick/enGB.json
+++ b/locale/shine/extensions/afkkick/enGB.json
@@ -1,5 +1,6 @@
 {
 	"NOTIFY_PREFIX": "[AFKKick]",
 	"WARN_KICK_ON_CONNECT": "You have been AFK for over {AFKTime:Duration}. You may be kicked when new players attempt to connect.",
-	"WARN_NOTIFY": "You have been AFK for over {AFKTime:Duration}. You will be kicked if you are AFK for {KickTime:Duration} and the player count reaches {MinPlayers}."
+	"WARN_NOTIFY": "You have been AFK for over {AFKTime:Duration}. You will be kicked if you are AFK for {KickTime:Duration} and the player count reaches {MinPlayers}.",
+	"WARN_WILL_BE_KICKED": "You have been AFK for over {AFKTime:Duration}. You will be kicked if you are AFK for {KickTime:Duration}."
 }

--- a/lua/shine/core/server/permissions.lua
+++ b/lua/shine/core/server/permissions.lua
@@ -120,47 +120,49 @@ local function ConvertData( Data, DontSave )
 end
 
 function Shine:RequestUsers( Reload )
-	local function UsersResponse( Response )
-		if not Response and not Reload then
-			self:LoadUsers()
+	local Callbacks = {
+		OnSuccess = function( Response )
+			if not Response then
+				self:Print( "Got no response from server when loading users. Using local file instead." )
+				return
+			end
 
-			return
-		end
+			local UserData, Pos, Err = Decode( Response )
+			if not IsType( UserData, "table" ) or not next( UserData ) then
+				if Reload then -- Don't replace with a blank table if request failed when reloading.
+					self:AdminPrint( nil,
+						"Reloading from the web failed. User data has not been changed. Error: %s", true, Err )
 
-		local UserData, Pos, Err = Decode( Response )
+					return
+				end
 
-		if not IsType( UserData, "table" ) or not next( UserData ) then
-			if Reload then --Don't replace with a blank table if request failed when reloading.
-				self:AdminPrint( nil,
-					"Reloading from the web failed. User data has not been changed. Error: %s", true, Err )
+				self:Print( "Loading from the web failed. Using local file instead. Error: %s", true, Err )
 
 				return
 			end
 
-			self:Print( "Loading from the web failed. Using local file instead. Error: %s", true, Err )
-			self:LoadUsers()
+			self.UserData = UserData
 
-			return
+			ConvertData( self.UserData, true )
+
+			-- Cache the current user data, so if we fail to load it on
+			-- a later map we still have something to load.
+			self:SaveUsers( true )
+			self:Print( Reload and "Shine reloaded users from the web."
+				or "Shine loaded users from web." )
+
+			self.Hook.Call( "OnUserReload" )
+		end,
+		OnFailure = function()
+			self:Print( "All attempts to load users from the web failed. Using local file instead." )
 		end
-
-		self.UserData = UserData
-
-		ConvertData( self.UserData, true )
-
-		--Cache the current user data, so if we fail to load it on
-		--a later map we still have something to load.
-		self:SaveUsers( true )
-		self:Print( Reload and "Shine reloaded users from the web."
-			or "Shine loaded users from web." )
-
-		self.Hook.Call( "OnUserReload" )
-	end
+	}
 
 	if self.Config.GetUsersWithPOST then
-		Shared.SendHTTPRequest( self.Config.UsersURL, "POST",
-			self.Config.UserRetrieveArguments, UsersResponse )
+		self.HTTPRequestWithRetry( self.Config.UsersURL, "POST",
+			self.Config.UserRetrieveArguments, Callbacks )
 	else
-		Shared.SendHTTPRequest( self.Config.UsersURL, "GET", UsersResponse )
+		self.HTTPRequestWithRetry( self.Config.UsersURL, "GET", Callbacks )
 	end
 end
 
@@ -174,23 +176,26 @@ function Shine:LoadUsers( Web, Reload )
 		if Reload then
 			self:RequestUsers( true )
 		else
+			-- Load the local data upfront.
+			self:LoadUsers()
+			-- Queue loading the up-to-date data.
 			self.Hook.Add( "ClientConnect", "LoadUsers", function( Client )
-				self:RequestUsers()
 				self.Hook.Remove( "ClientConnect", "LoadUsers" )
+				self:RequestUsers()
 			end, self.Hook.MAX_PRIORITY )
 		end
 
 		return
 	end
 
-	--Check the default path.
+	-- Check the default path.
 	local UserFile, Pos, Err = self.LoadJSONFile( UserPath )
 
 	if UserFile == false then
-		UserFile, Pos, Err = self.LoadJSONFile( BackupPath ) --Check the secondary path.
+		UserFile, Pos, Err = self.LoadJSONFile( BackupPath ) -- Check the secondary path.
 
 		if UserFile == false then
-			UserFile, Pos, Err = self.LoadJSONFile( DefaultUsers ) --Check the default NS2 users file.
+			UserFile, Pos, Err = self.LoadJSONFile( DefaultUsers ) -- Check the default NS2 users file.
 
 			if not UserFile then
 				self:GenerateDefaultUsers( true )
@@ -206,7 +211,7 @@ function Shine:LoadUsers( Web, Reload )
 		Notify( StringFormat( "The user data file is not valid JSON, unable to load user data. Error: %s",
 			Err ) )
 
-		--Dummy data to avoid errors.
+		-- Dummy data to avoid errors.
 		if not Reload then
 			self.UserData = { Groups = {}, Users = {} }
 		end

--- a/lua/shine/core/shared/config.lua
+++ b/lua/shine/core/shared/config.lua
@@ -233,6 +233,7 @@ end
 
 do
 	local Clamp = math.Clamp
+	local Floor = math.floor
 	local StringExplode = string.Explode
 	local StringUpper = string.upper
 	local TableBuild = table.Build
@@ -246,6 +247,20 @@ do
 
 	function Validator.Constant( Value )
 		return function() return Value end
+	end
+
+	function Validator.Integer( Rounder )
+		Rounder = Rounder or Floor
+
+		return function( Value )
+			return ( tonumber( Value ) or 0 ) % 1 ~= 0
+		end,
+		function( Value )
+			return Rounder( tonumber( Value ) )
+		end,
+		function()
+			return "%s must be an integer"
+		end
 	end
 
 	function Validator.Min( MinValue )

--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -634,7 +634,7 @@ Add( "Think", "ReplaceMethods", function()
 		SetupClassHook( "CommandStructure", "LoginPlayer", "CommLoginPlayer", "PassivePre" )
 		SetupClassHook( "CommandStructure", "OnCommanderLogin", "OnCommanderLogin", "PassivePre" )
 		SetupClassHook( "CommandStructure", "Logout", "CommLogout", "PassivePre" )
-		SetupClassHook( "CommandStructure", "OnUse", "CheckCommLogin", "ActivePre" )
+		SetupClassHook( Gamerules, "OnCommanderLogin", "ValidateCommanderLogin", "ActivePre" )
 
 		SetupClassHook( "RecycleMixin", "OnResearch", "OnRecycle", "PassivePre" )
 		SetupClassHook( "RecycleMixin", "OnResearchComplete", "OnBuildingRecycled", "PassivePre" )

--- a/lua/shine/extensions/adverts/advert_stream.lua
+++ b/lua/shine/extensions/adverts/advert_stream.lua
@@ -199,6 +199,25 @@ for i = 1, #kGameState do
 	SafeGameStateLookup[ kGameState[ i ] ] = i
 end
 
+local function IsGameState( GameStateName, GameState )
+	return SafeGameStateLookup[ GameStateName ] == GameState
+end
+
+function AdvertStream.IsValidForGameState( Advert, GameState )
+	if not Advert.GameState then return true end
+
+	if IsType( Advert.GameState, "table" ) then
+		for i = 1, #Advert.GameState do
+			if IsGameState( Advert.GameState[ i ], GameState ) then
+				return true
+			end
+		end
+	end
+
+	return IsGameState( Advert.GameState, GameState )
+end
+
+local IsValidForGameState = AdvertStream.IsValidForGameState
 --[[
 	Filters the current advert list to those that are valid for the given
 	game state.
@@ -207,28 +226,10 @@ end
 	out.
 ]]
 function AdvertStream.FilterAdvertListForState( Adverts, CurrentAdverts, GameState )
-	local function IsGameState( GameStateName )
-		return SafeGameStateLookup[ GameStateName ] == GameState
-	end
-
-	local function IsValidForGameState( Advert )
-		if not Advert.GameState then return true end
-
-		if IsType( Advert.GameState, "table" ) then
-			for i = 1, #Advert.GameState do
-				if IsGameState( Advert.GameState[ i ] ) then
-					return true
-				end
-			end
-		end
-
-		return IsGameState( Advert.GameState )
-	end
-
 	local OutputAdverts = {}
 	local HasChanged = false
 	for i = 1, #Adverts do
-		if IsValidForGameState( Adverts[ i ] ) then
+		if IsValidForGameState( Adverts[ i ], GameState ) then
 			local Index = #OutputAdverts + 1
 			OutputAdverts[ Index ] = Adverts[ i ]
 			if OutputAdverts[ Index ] ~= CurrentAdverts[ Index ] then

--- a/lua/shine/extensions/adverts/server.lua
+++ b/lua/shine/extensions/adverts/server.lua
@@ -593,7 +593,7 @@ function Plugin:ParseAdverts()
 					if self.TriggerHandlers[ TriggerName ] then
 						local Source = StringFormat( "%s[ %d ]", AdvertList, Index )
 						self.TriggerHandlers[ TriggerName ]( self, Source, Advert, function()
-							self:DisplayAdvert( Advert )
+							self:TriggerAdvert( Advert, nil, self:GetGameState() )
 						end )
 					else
 						TriggeredAdvertsByTrigger:Add( TriggerName, Advert )
@@ -603,6 +603,11 @@ function Plugin:ParseAdverts()
 	end
 
 	self.TriggeredAdvertsByTrigger = TriggeredAdvertsByTrigger
+end
+
+function Plugin:GetGameState()
+	local Gamerules = GetGamerules()
+	return Gamerules and Gamerules:GetGameState()
 end
 
 function Plugin:StartStreams()
@@ -696,6 +701,15 @@ function Plugin:DisplayAdvert( Advert, EventData )
 	end
 end
 
+function Plugin:TriggerAdvert( Advert, EventData, GameState )
+	if GameState and not AdvertStream.IsValidForGameState( Advert, GameState ) then
+		return
+	end
+
+	-- Only trigger adverts that are valid for the current gamestate.
+	self:DisplayAdvert( Advert, EventData )
+end
+
 --[[
 	Triggers all adverts for the given trigger name with the given data.
 ]]
@@ -710,9 +724,10 @@ function Plugin:TriggerAdverts( TriggerName, EventData )
 
 	local Adverts = self.TriggeredAdvertsByTrigger:Get( TriggerName )
 	if Adverts then
+		local GameState = self:GetGameState()
 		-- Trigger individual adverts.
 		for j = 1, #Adverts do
-			self:DisplayAdvert( Adverts[ j ], EventData )
+			self:TriggerAdvert( Adverts[ j ], EventData, GameState )
 		end
 	end
 end

--- a/lua/shine/extensions/afkkick/server.lua
+++ b/lua/shine/extensions/afkkick/server.lua
@@ -443,10 +443,10 @@ function Plugin:EvaluatePlayer( Client, DataTable, Params )
 					local AFKTime = Time - DataTable.LastMove
 
 					if WillKickWhenTimeReached then
-						Shine.SendNetworkMessage( Client, "AFKWarning", {
-							timeAFK = AFKTime,
-							maxAFKTime = KickTime
-						}, true )
+						self:SendTranslatedNotify( Client, "WARN_WILL_BE_KICKED", {
+							AFKTime = Floor( WarnTime ),
+							KickTime = KickTime
+						} )
 					else
 						-- Not going to kick them yet, but tell them they may be kicked later.
 						self:SendTranslatedNotify( Client, "WARN_NOTIFY", {

--- a/lua/shine/extensions/afkkick/shared.lua
+++ b/lua/shine/extensions/afkkick/shared.lua
@@ -10,6 +10,10 @@ function Plugin:SetupDataTable()
 	self:AddTranslatedNotify( "WARN_KICK_ON_CONNECT", {
 		AFKTime = "integer"
 	} )
+	self:AddTranslatedNotify( "WARN_WILL_BE_KICKED", {
+		AFKTime = "integer",
+		KickTime = "integer"
+	} )
 	self:AddTranslatedNotify( "WARN_NOTIFY", {
 		AFKTime = "integer",
 		KickTime = "integer",

--- a/lua/shine/extensions/badges.lua
+++ b/lua/shine/extensions/badges.lua
@@ -242,6 +242,8 @@ function Plugin:Setup()
 				MasterBadgeTable )
 		end
 	end
+
+	self.Logger:Info( "Setup badges successfully." )
 end
 
 function Plugin:OnUserReload()

--- a/lua/shine/extensions/badges.lua
+++ b/lua/shine/extensions/badges.lua
@@ -23,6 +23,7 @@ function Plugin:Initialise()
 	self:BroadcastModuleEvent( "Initialise" )
 
 	self.AssignedGuests = {}
+	self.ForcedBadges = {}
 	self.Enabled = true
 
 	return true
@@ -214,6 +215,9 @@ function Plugin:ForceBadgeForID( ID, Badge, Column )
 end
 
 function Plugin:Setup()
+	self.AssignedGuests = {}
+	self.ForcedBadges = {}
+
 	if not GiveBadge then
 		self.Logger:Error( "Badge system unavailable, cannot load badges." )
 		Shine:UnloadExtension( self:GetName() )
@@ -221,13 +225,12 @@ function Plugin:Setup()
 	end
 
 	local UserData = Shine.UserData
-	if not UserData or not UserData.Groups or not UserData.Users then return end
+	if not UserData or not UserData.Groups or not UserData.Users then
+		self.Logger:Error( "User data is missing groups and/or users, unable to setup badges." )
+		return
+	end
 
 	local MasterBadgeTable = self:GetMasterBadgeLookup( UserData.Badges )
-
-	-- Remember badges that are forced per NS2ID.
-	self.ForcedBadges = {}
-
 	for ID, User in pairs( UserData.Users ) do
 		ID = tonumber( ID )
 
@@ -242,7 +245,6 @@ function Plugin:Setup()
 end
 
 function Plugin:OnUserReload()
-	self.AssignedGuests = {}
 	self:Setup()
 
 	-- Re-assign default group badges.

--- a/lua/shine/extensions/ban/server.lua
+++ b/lua/shine/extensions/ban/server.lua
@@ -41,6 +41,9 @@ Plugin.MAX_BAN_PER_NETMESSAGE = 15
 -- Permission required to receive the ban list.
 Plugin.ListPermission = "sh_unban"
 
+Plugin.OnBannedHookName = "OnPlayerBanned"
+Plugin.OnUnbannedHookName = "OnPlayerUnbanned"
+
 local Hooked
 
 Plugin.DefaultConfig = {
@@ -410,7 +413,9 @@ function Plugin:AddBan( ID, Name, Duration, BannedBy, BanningID, Reason )
 		BanSharer( self:CheckFamilySharing( ID, false, BanSharer ) )
 	end
 
-	Hook.Call( "OnPlayerBanned", ID, Name, Duration, BannedBy, Reason )
+	if self.OnBannedHookName then
+		Hook.Call( self.OnBannedHookName, ID, Name, Duration, BannedBy, Reason )
+	end
 
 	return true
 end
@@ -443,7 +448,9 @@ function Plugin:RemoveBan( ID, DontSave, UnbannerID )
 		end )
 	end
 
-	Hook.Call( "OnPlayerUnbanned", ID )
+	if self.OnUnbannedHookName then
+		Hook.Call( self.OnUnbannedHookName, ID )
+	end
 
 	if DontSave then return end
 

--- a/lua/shine/extensions/basecommands/rates.lua
+++ b/lua/shine/extensions/basecommands/rates.lua
@@ -1,0 +1,149 @@
+--[[
+	Server rates configuration.
+]]
+
+local IsType = Shine.IsType
+local Notify = Shared.Message
+local StringFormat = string.format
+
+local RatesModule = {}
+RatesModule.DefaultConfig = {
+	Rates = {
+		-- Whether to enforce these rate settings or leave the defaults as-is.
+		ApplyRates = true,
+		BWLimit = 50,
+		Interp = 100,
+		MoveRate = 26,
+		SendRate = 20,
+		TickRate = 30
+	}
+}
+
+local Rates = {
+	{
+		Key = "MoveRate",
+		Min = 5,
+		Integer = true,
+		Default = 26,
+		Command = "mr %s"
+	},
+	{
+		Key = "TickRate",
+		Min = 5,
+		Integer = true,
+		Default = function() return Server.GetTickrate() end,
+		Command = "tickrate %s"
+	},
+	{
+		Key = "SendRate",
+		Integer = true,
+		Min = 5,
+		Default = function() return Server.GetSendrate() end,
+		Command = "sendrate %s"
+	},
+	{
+		Key = "Interp",
+		Min = 0,
+		Default = 100,
+		Command = function( Value ) return StringFormat( "interp %s", Value * 0.001 ) end
+	},
+	{
+		Key = "BWLimit",
+		Min = 5,
+		Transformer = function( Value ) return Value * 1024 end,
+		Default = function() return Server.GetBwLimit() / 1024 end,
+		Command = "bwlimit %s",
+		WarnIfBelow = 50
+	}
+}
+
+local Validator = Shine.Validator()
+Validator:AddFieldRule( "Rates.ApplyRates", Validator.IsType( "boolean", true ) )
+for i = 1, #Rates do
+	local Rate = Rates[ i ]
+	local Default = IsType( Rate.Default, "function" ) and Rate.Default() or Rate.Default
+	local FieldName = "Rates."..Rate.Key
+
+	Validator:AddFieldRule( FieldName, Validator.IsType( "number", Default ) )
+	Validator:AddFieldRule( FieldName, Validator.Min( Rate.Min ) )
+	if Rate.Integer then
+		Validator:AddFieldRule( FieldName, Validator.Integer() )
+	end
+end
+
+Validator:AddRule( {
+	Matches = function( self, Config )
+		return Config.Rates.MoveRate > Config.Rates.TickRate
+	end,
+	Fix = function( self, Config )
+		Config.Rates.MoveRate = Config.Rates.TickRate
+		Notify( "Move rate cannot be more than tick rate. Clamping to tick rate." )
+	end
+} )
+Validator:AddRule( {
+	Matches = function( self, Config )
+		return Config.Rates.SendRate > Config.Rates.TickRate
+	end,
+	Fix = function( self, Config )
+		Config.Rates.SendRate = Config.Rates.TickRate
+		Notify( "Send rate cannot be more than tick rate. Clamping to tick rate." )
+	end
+} )
+Validator:AddRule( {
+	Matches = function( self, Config )
+		return Config.Rates.SendRate > Config.Rates.MoveRate
+	end,
+	Fix = function( self, Config )
+		Config.Rates.SendRate = Config.Rates.MoveRate
+		Notify( "Send rate cannot be more than move rate. Clamping to move rate." )
+	end
+} )
+Validator:AddRule( {
+	Matches = function( self, Config )
+		local MinInterp = 2 / Config.Rates.SendRate * 1000
+
+		if Config.Rates.Interp < MinInterp then
+			Config.Rates.Interp = MinInterp
+			Notify( StringFormat( "Interp cannot be less than %.2fms, clamping...",
+				MinInterp ) )
+			return true
+		end
+
+		return false
+	end
+} )
+RatesModule.ConfigValidator = Validator
+
+function RatesModule:Initialise()
+	self:CheckRateValues()
+end
+
+local function Transform( Rate, Value )
+	return Rate.Transformer and Rate.Transformer( Value ) or Value
+end
+
+function RatesModule:CheckRateValues()
+	if not self.Config.Rates.ApplyRates then return end
+
+	for i = 1, #Rates do
+		local Rate = Rates[ i ]
+		local ConfigValue = self.Config.Rates[ Rate.Key ]
+
+		-- Only skip applying values where we can get the current value. Any rates that
+		-- have no getter should always be applied in case they've been changed elsewhere.
+		local Default = IsType( Rate.Default, "function" ) and Rate.Default() or nil
+		if ConfigValue ~= Default then
+			local ActualValue = Transform( Rate, ConfigValue )
+			local Command = IsType( Rate.Command, "function" ) and Rate.Command( ActualValue )
+				or StringFormat( Rate.Command, ActualValue )
+
+			Shared.ConsoleCommand( Command )
+		end
+
+		if Rate.WarnIfBelow and ConfigValue < Rate.WarnIfBelow then
+			Notify( StringFormat( "WARNING: %s is below the default of %s", Rate.Key, Rate.WarnIfBelow ) )
+		end
+	end
+end
+
+Plugin:AddModule( RatesModule )

--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -59,7 +59,6 @@ Plugin.HandlesVoteConfig = true
 Shine.LoadPluginModule( "vote.lua", Plugin )
 Shine.LoadPluginModule( "logger.lua", Plugin )
 Shine.LoadPluginFile( "basecommands", "gamerules.lua" )
-Shine.LoadPluginFile( "basecommands", "rates.lua" )
 
 Plugin.ConfigMigrationSteps = {
 	{
@@ -249,6 +248,9 @@ do
 		end
 	} )
 	Plugin.ConfigValidator = Validator
+
+	-- Load after default validator to ensure validators merge.
+	Shine.LoadPluginFile( "basecommands", "rates.lua" )
 end
 
 function Plugin:Initialise()

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -9,10 +9,12 @@ local Notify = Shared.Message
 local Abs = math.abs
 local Ceil = math.ceil
 local Clamp = math.Clamp
+local DebugGetInfo = debug.getinfo
 local Floor = math.floor
 local GetAllPlayers = Shine.GetAllPlayers
 local GetNumPlayers = Shine.GetHumanPlayerCount
 local GetOwner = Server.GetOwner
+local IsType = Shine.IsType
 local Max = math.max
 local Random = math.random
 local SharedTime = Shared.GetTime
@@ -533,6 +535,13 @@ do
 		local IsRookieMode = Gamerules.gameInfo and Gamerules.gameInfo:GetRookieMode()
 		local IsEnforcingTeams = self.EnforcementPolicy:IsActive( self )
 
+		local function AddTeamPreference( Player, Client, Preference )
+			TeamMembers.TeamPreferences[ Player ] = Preference
+			-- Track against thier client too as their player object will be changed
+			-- if their team is changed.
+			TeamMembers.TeamPreferences[ Client ] = Preference
+		end
+
 		local function SortPlayer( Player, Client, Commander, Pass )
 			-- Do not shuffle clients that are in a spectator slot.
 			if Client:GetIsSpectator() then return end
@@ -565,7 +574,7 @@ do
 					-- Either they have a set preference, or they joined the team they want.
 					Preference = Preference or ( IsPlayingTeam and Team )
 					-- Even without a preference, don't move them around if it can be helped.
-					TeamMembers.TeamPreferences[ Player ] = Preference or true
+					AddTeamPreference( Player, Client, Preference or true )
 				end
 
 				return
@@ -581,15 +590,15 @@ do
 				if not IsEnforcingTeams then
 					-- If we're not enforcing teams, their preference is either the one they've set
 					-- or otherwise the team they decided to join.
-					TeamMembers.TeamPreferences[ Player ] = Preference or Team
+					AddTeamPreference( Player, Client, Preference or Team )
 				else
 					-- If we are enforcing teams, then the only assumption about preference we have
 					-- is their configured choice, as they've been locked to a team.
-					TeamMembers.TeamPreferences[ Player ] = Preference
+					AddTeamPreference( Player, Client, Preference )
 				end
 			else
 				Targets[ #Targets + 1 ] = Player
-				TeamMembers.TeamPreferences[ Player ] = Preference
+				AddTeamPreference( Player, Client, Preference )
 			end
 		end
 
@@ -682,7 +691,11 @@ function Plugin:ShuffleTeams( ResetScores, ForceMode )
 	self.ReconnectingClients = {}
 
 	local Mode = ForceMode or self.Config.BalanceMode
-	self.ShufflingModes[ Mode ]( self, Gamerules, Targets, TeamMembers )
+	local ModeFunction = self.ShufflingModes[ Mode ]
+	ModeFunction( self, Gamerules, Targets, TeamMembers )
+
+	local FunctionSource = DebugGetInfo( ModeFunction, "S" ).source
+	local IsExpectedFunction = FunctionSource == "@lua/shine/extensions/voterandom/team_balance.lua"
 
 	self.OptimisingTeams = false
 	self.HasShuffledThisRound = true
@@ -690,6 +703,8 @@ function Plugin:ShuffleTeams( ResetScores, ForceMode )
 	-- Remember who was on what team at the point of shuffling, so we can work out
 	-- how close to the shuffled teams we are later.
 	local TeamLookup = {}
+	local NumPreferencesHeld = 0
+	local NumPreferencesTotal = 0
 	for i = 1, 2 do
 		for j = 1, #TeamMembers[ i ] do
 			local Player = TeamMembers[ i ][ j ]
@@ -697,9 +712,24 @@ function Plugin:ShuffleTeams( ResetScores, ForceMode )
 				local Client = Player:GetClient()
 				local SteamID = Client:GetUserId()
 				TeamLookup[ SteamID ] = i
+
+				-- Remember how many players got the team they wanted.
+				local Preference = TeamMembers.TeamPreferences[ Client ]
+				if IsType( Preference, "number" ) then
+					NumPreferencesTotal = NumPreferencesTotal + 1
+					if Preference == i then
+						NumPreferencesHeld = NumPreferencesHeld + 1
+					end
+				end
 			end
 		end
 	end
+
+	TeamLookup.NumPreferencesHeld = NumPreferencesHeld
+	TeamLookup.NumPreferencesTotal = NumPreferencesTotal
+	-- If another mod has overridden the balance algorithm, tell players.
+	TeamLookup.IsFunctionChanged = not IsExpectedFunction
+
 	self.LastShuffleTeamLookup = TeamLookup
 	self:ClearStatsCache()
 end
@@ -1317,10 +1347,19 @@ function Plugin:CreateCommands()
 			self.Config.StandardDeviationTolerance, self.Config.AverageValueTolerance )
 		if self.LastShuffleTime then
 			Message[ #Message + 1 ] = StringFormat(
-				"Last shuffle was %s ago. %i/%i players match their team from the last shuffle.",
+				"Last shuffle was %s ago. %d/%d player(s) match their team from the last shuffle.",
 				string.TimeToString( SharedTime() - self.LastShuffleTime ),
 				TeamStats.NumMatchingTeams or 0,
 				TeamStats.TotalPlayers or 0 )
+			Message[ #Message + 1 ] = StringFormat( "%d/%d player(s) were placed on their preferred team.",
+				TeamStats.NumPreferencesHeld or 0,
+				TeamStats.NumPreferencesTotal or 0 )
+			if TeamStats.IsFunctionChanged then
+				-- If you're altering the algorithm, please don't try to suppress this.
+				-- It's important for players to know when the shuffle algorithm is different so
+				-- it's clear who to report problems to.
+				Message[ #Message + 1 ] = "Another mod has altered the shuffle algorithm, results may be different to other servers."
+			end
 		else
 			Message[ #Message + 1 ] = "Teams have not yet been shuffled."
 		end

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -79,34 +79,33 @@ local ModeStrings = {
 Plugin.ModeStrings = ModeStrings
 
 Plugin.DefaultConfig = {
-	MinPlayers = 10, --Minimum number of players on the server to enable voting.
-	PercentNeeded = 0.75, --Percentage of the server population needing to vote for it to succeed.
+	MinPlayers = 10, -- Minimum number of players on the server to enable voting.
+	PercentNeeded = 0.75, -- Percentage of the server population needing to vote for it to succeed.
 
 	VoteCooldownInMinutes = 15, -- Cooldown time before another vote can be made.
-	BlockAfterTime = 0, --Time after round start to block the vote. 0 to disable blocking.
-	VoteTimeout = 60, --Time after the last vote before the vote resets.
-	NotifyOnVote = true, -- Should all players be told through the chat when a vote is cast?
-	ApplyToBots = false, -- Should bots be shuffled, or removed?
+	BlockAfterTime = 2, -- Time in minutes after round start to block the vote. 0 to disable blocking.
+	VoteTimeout = 60, -- Time after the last vote before the vote resets.
+	NotifyOnVote = true, --  Should all players be told through the chat when a vote is cast?
+	ApplyToBots = false, --  Should bots be shuffled, or removed?
 
-	BalanceMode = Plugin.ShuffleMode.HIVE, --How should teams be balanced?
-	FallbackMode = Plugin.ShuffleMode.KDR, --Which method should be used if Elo/Hive fails?
-	--[[
-		How much of an increase in standard deviation should be allowed if the
-		average is being improved but the standard deviation can't be?
-	]]
+	BalanceMode = Plugin.ShuffleMode.HIVE, -- How should teams be balanced?
+	FallbackMode = Plugin.ShuffleMode.KDR, -- Which method should be used if Elo/Hive fails?
+
+	-- Deprecated parameter controlling how much the standard deviation can increase per swap
+	-- in a hard-rule based shuffle.
 	StandardDeviationTolerance = 40,
-	--[[
-		How much difference between team averages should be considered good enough?
-		The shuffle process will carry on until either it reaches at or below this level,
-		or it can't improve the difference anymore.
-	]]
+	-- How much difference between team averages should be considered good enough?
+	-- The shuffle process will carry on until either it reaches at or below this level,
+	-- or it can't improve the difference anymore.
+	-- This can terminate the shuffle before it has managed to optimise teams appropriately
+	-- and is not recommended.
 	AverageValueTolerance = 0,
 
-	IgnoreCommanders = true, --Should the plugin ignore commanders when switching?
-	IgnoreSpectators = false, --Should the plugin ignore spectators when switching?
-	AlwaysEnabled = false, --Should the plugin be always forcing each round?
+	IgnoreCommanders = true, -- Should the plugin ignore commanders when switching?
+	IgnoreSpectators = false, -- Should the plugin ignore spectators in player slots when switching?
+	AlwaysEnabled = false, -- Should the plugin be always forcing each round?
 
-	ReconnectLogTime = 0, --How long (in seconds) after a shuffle to log reconnecting players for?
+	ReconnectLogTime = 0, -- How long (in seconds) after a shuffle to log reconnecting players for?
 	HighlightTeamSwaps = false, -- Should players swapping teams be highlighted on the scoreboard?
 	DisplayStandardDeviations = false, -- Should the scoreboard show each team's standard deviation of skill?
 
@@ -116,7 +115,7 @@ Plugin.DefaultConfig = {
 		MinPlayerFractionToConstrain = 0.9,
 		-- The minimum difference in average skill required to permit shuffling.
 		-- A value of 0 will permit all votes.
-		MinAverageDiffToAllowShuffle = 0,
+		MinAverageDiffToAllowShuffle = 75,
 		-- The minimum difference in standard deviation of skill required to permit shuffling.
 		-- Must be greater than 0 to enable checking.
 		MinStandardDeviationDiffToAllowShuffle = 0

--- a/lua/shine/extensions/voterandom/team_balance.lua
+++ b/lua/shine/extensions/voterandom/team_balance.lua
@@ -807,7 +807,10 @@ do
 			TeamStats = {
 				MarineSkill, AlienSkill,
 				TotalPlayers = NumTotal,
-				NumMatchingTeams = NumMatchingTeams
+				NumMatchingTeams = NumMatchingTeams,
+				NumPreferencesHeld = self.LastShuffleTeamLookup.NumPreferencesHeld,
+				NumPreferencesTotal = self.LastShuffleTeamLookup.NumPreferencesTotal,
+				IsFunctionChanged = self.LastShuffleTeamLookup.IsFunctionChanged
 			}
 		else
 			TeamStats = {

--- a/lua/shine/extensions/voterandom/team_optimiser.lua
+++ b/lua/shine/extensions/voterandom/team_optimiser.lua
@@ -4,7 +4,10 @@
 
 	Skill is defined by whatever function is provided.
 
-	The method used is roughly the following:
+	The method used is either based on hard rules (legacy method, usually worse), or based on a cost
+	function to be minimised (usually produces better teams in less time).
+
+	The hard rule based method is roughly the following (assuming TakeSwapImmediately = false):
 
 	1. Start with two lists of players, one for each team. Make sure the average skill, total skill,
 	   and number of players is already known.
@@ -25,8 +28,13 @@
 
 	6. Go back to step 2 and repeat until the list of allowed swaps is empty.
 
-	This method produces a slow, but steady path towards an optimal solution. It keeps chipping away at the average
-	bit by bit, while never choosing a standard deviation that's too high.
+	The cost based method has the following key differences (assuming TakeSwapImmediately = true):
+
+	1. As soon as a swap that lowers the cost is found, it is chosen and applied. This avoids having to compute
+	   lots of potential swaps and helps avoid being overly greedy and getting stuck in a local minimum.
+
+	2. Instead of hard rules looking at average/standard deviation, a cost is derived from the difference
+	   in average/standard deviation between teams. The goal is then to lower the cost.
 ]]
 
 local Abs = math.abs

--- a/lua/shine/lib/objects/votes.lua
+++ b/lua/shine/lib/objects/votes.lua
@@ -90,6 +90,8 @@ function VoteMeta:AddVote( Client )
 end
 
 function VoteMeta:CheckForSuccess()
+	if self.Votes <= 0 then return end
+
 	if self.Votes >= self.VotesNeeded() then
 		self.LastSuccessTime = SharedTime()
 		self.OnSuccess()

--- a/test/core/server/permissions.lua
+++ b/test/core/server/permissions.lua
@@ -69,7 +69,10 @@ Shine.UserData = {
 			[ "3" ] = {
 				"defaultbadge"
 			}
-		}
+		},
+		IsBlacklist = false,
+		Commands = {},
+		Immunity = 0
 	}
 }
 
@@ -203,7 +206,23 @@ UnitTest:Test( "GetGroupAccess when allowed by default", function( Assert )
 	Assert:Falsy( Shine:GetGroupAccess( GroupName, GroupTable, "sh_randomimmune", true ) )
 	-- Not denied in blacklist.
 	Assert:Truthy( Shine:GetGroupAccess( GroupName, GroupTable, "sh_kick", true ) )
+
+	GroupTable = Shine:GetDefaultGroup()
+	-- Allowed by default for default group.
+	Assert:Truthy( Shine:GetGroupAccess( nil, GroupTable, "sh_ns2_votereset", true ) )
 end )
+
+local OldDefaultGroup = Shine.UserData.DefaultGroup
+Shine.UserData.DefaultGroup = nil
+
+UnitTest:Test( "HasAccess when no default group", function( Assert )
+	-- Guest should have access by default.
+	Assert:Truthy( Shine:HasAccess( 123456, "sh_ns2_votereset", true ) )
+	-- But should not if access is not allowed by default.
+	Assert:Falsy( Shine:HasAccess( 123456, "sh_kick" ) )
+end )
+
+Shine.UserData.DefaultGroup = OldDefaultGroup
 
 ---- USER PERMISSION TESTS ----
 UnitTest:Test( "Default group targeting", function( Assert )

--- a/test/extensions/adverts.lua
+++ b/test/extensions/adverts.lua
@@ -142,6 +142,10 @@ Adverts.Config = {
 			{
 				Message = "I can't be used on the current map",
 				ExcludedMaps = { [ Shared.GetMapName() ] = true }
+			},
+			{
+				Message = "I can't be used in the current gamestate.",
+				GameState = { "Started" }
 			}
 		},
 		INVALID = {
@@ -151,6 +155,10 @@ Adverts.Config = {
 		}
 	}
 }
+
+function Adverts:GetGameState()
+	return kGameState.NotStarted
+end
 
 UnitTest:Test( "ParseAdverts parses as expected", function( Assert )
 	Adverts:ParseAdverts()
@@ -205,6 +213,10 @@ UnitTest:Test( "ParseAdverts parses as expected", function( Assert )
 				Prefix = "[Hint]",
 				PrefixColour = { 0, 200, 255 },
 				GameState = "Started"
+			},
+			{
+				Message = "I can't be used in the current gamestate.",
+				GameState = { "Started" }
 			}
 		}
 	}, Adverts.TriggeredAdvertsByTrigger:AsTable() )
@@ -272,7 +284,12 @@ Adverts.TriggeredAdvertsByTrigger = Shine.Multimap( {
 			Message = "Commander {CommanderName} logged in."
 		},
 		{
-			Message = "Another message."
+			Message = "Another message.",
+			GameState = { "PreGame", "WarmUp", "NotStarted" }
+		},
+		{
+			Message = "Only show this when started",
+			GameState = "Started"
 		}
 	},
 	[ Adverts.AdvertTrigger.COMMANDER_LOGGED_OUT ] = {
@@ -294,10 +311,13 @@ UnitTest:Test( "TriggerAdverts - Displays adverts for given trigger", function( 
 	Adverts:TriggerAdverts( Adverts.AdvertTrigger.COMMANDER_LOGGED_IN, Data )
 
 	local AdvertsTriggered = Adverts.TriggeredAdvertsByTrigger:Get( Adverts.AdvertTrigger.COMMANDER_LOGGED_IN )
-	for i = 1, #AdvertsTriggered do
+	for i = 1, 2 do
 		Assert.Equals( "Adverts should have been triggered with the given data",
 			Data, Displayed[ AdvertsTriggered[ i ] ] )
 	end
+
+	Assert.Nil( "Third advert should not be displayed due to gamestate filter.",
+		Displayed[ AdvertsTriggered[ 3 ] ] )
 end )
 
 Displayed = {}


### PR DESCRIPTION
#### Adverts
* Triggered adverts can now specify a game state filter.

#### AFK Kick
* Altered the format of the warning message when enough players are present to kick and `KickOnConnect` is not enabled to no longer use the vanilla AFK message.

#### Base Commands
* Fixed rate settings not applying correctly on the high rate alpha build and for any future changes to default rates, and moved them to their own `Rates` section of the config.
* Added `Rates.ApplyRates` option to control whether rate values in the config should be applied or not. Set this to `false` to always use the default rates.

#### Commander Bans
* Altered the hook used to apply bans to avoid potential issues.
* Added extra debug logging.

#### Vote Shuffle
* Updated `sh_teamstats` to indicate when the shuffling algorithm has been modified, and to show the number of players that got their preferred team in the last shuffle.

#### Other
* Improved web user loading to always load the local cached users first, avoiding a window where no user data is loaded.
* Web user loading now retries and handles timeouts.
* Fixed default access not being applied when no default group exists.
* Fixed votes "passing" when the server becomes empty.