### PR TITLE
Improve team preference handling in shuffle

### DIFF
--- a/locale/shine/extensions/voterandom/enGB.json
+++ b/locale/shine/extensions/voterandom/enGB.json
@@ -85,10 +85,16 @@
 	"TEAM_SWITCH_DENIED_KDR_BASED": "You cannot switch teams. KDR based teams are enabled.",
 	"TEAM_SWITCH_DENIED_RANDOM_BASED": "You cannot switch teams. Random teams are enabled.",
 	"TEAM_SWITCH_DENIED_SCORE_BASED": "You cannot switch teams. Score based teams are enabled.",
+
 	"TEAM_PREFERENCE": "Shuffle Team Preference:",
+	"TEAM_PREFERENCE_CHANGE_HINT": "Walking into a team door or using the console to join a team before a round starts will override your configured team preference for that round.",
 	"MARINE": "Marines",
 	"ALIEN": "Aliens",
 	"NONE": "No Preference",
+	"TEAM_PREFERENCE_HINT": "Team Preference:",
+	"TEAM_PREFERENCE_SET_MARINE": "Your team preference is now: Marines.",
+	"TEAM_PREFERENCE_SET_ALIEN": "Your team preference is now: Aliens.",
+	"TEAM_PREFERENCE_SET_NONE": "Your team preference has been reset.",
 
 	"DISABLE_AUTO_SHUFFLE": "Disable Shuffle",
 	"ENABLE_AUTO_SHUFFLE": "Enable Shuffle",

--- a/locale/shine/extensions/voterandom/enGB.json
+++ b/locale/shine/extensions/voterandom/enGB.json
@@ -86,7 +86,7 @@
 	"TEAM_SWITCH_DENIED_RANDOM_BASED": "You cannot switch teams. Random teams are enabled.",
 	"TEAM_SWITCH_DENIED_SCORE_BASED": "You cannot switch teams. Score based teams are enabled.",
 
-	"TEAM_PREFERENCE": "Shuffle Team Preference:",
+	"TEAM_PREFERENCE": "Default Shuffle Team Preference:",
 	"TEAM_PREFERENCE_CHANGE_HINT": "Walking into a team door or using the console to join a team before a round starts will override your configured team preference for that round.",
 	"MARINE": "Marines",
 	"ALIEN": "Aliens",

--- a/lua/shine/core/client/votemenu_gui.lua
+++ b/lua/shine/core/client/votemenu_gui.lua
@@ -176,13 +176,6 @@ function VoteMenu:Create()
 	end
 end
 
-local function StopDrawingCrosshair( self )
-	self.crosshairs:SetIsVisible( false )
-	if self.reloadDial then
-		self.reloadDial:SetIsVisible( false )
-	end
-end
-
 Hook.Add( "PostLoadScript:lua/GUICrosshair.lua", "VoteMenu", function( Reload )
 	local GUICrosshair = _G.GUICrosshair
 	if not GUICrosshair then return end
@@ -191,7 +184,9 @@ Hook.Add( "PostLoadScript:lua/GUICrosshair.lua", "VoteMenu", function( Reload )
 	function GUICrosshair:Update( DeltaTime )
 		if VoteMenu.Visible then
 			-- Hide the crosshair when the vote menu is visible.
-			self.crosshairs:SetIsVisible( false )
+			if self.crosshairs then
+				self.crosshairs:SetIsVisible( false )
+			end
 			if self.reloadDial then
 				self.reloadDial:SetIsVisible( false )
 			end

--- a/lua/shine/core/client/votemenu_gui.lua
+++ b/lua/shine/core/client/votemenu_gui.lua
@@ -156,6 +156,7 @@ function VoteMenu:Create()
 	Background:SetPos( -BackSize * 0.5 )
 	Background:SetTexture( MenuTexture[ self.TeamType ] )
 	Background:SetIsSchemed( false )
+	Background.AlwaysInMouseFocus = true
 
 	self.Background = Background
 

--- a/lua/shine/core/client/votemenu_gui.lua
+++ b/lua/shine/core/client/votemenu_gui.lua
@@ -176,6 +176,32 @@ function VoteMenu:Create()
 	end
 end
 
+local function StopDrawingCrosshair( self )
+	self.crosshairs:SetIsVisible( false )
+	if self.reloadDial then
+		self.reloadDial:SetIsVisible( false )
+	end
+end
+
+Hook.Add( "PostLoadScript:lua/GUICrosshair.lua", "VoteMenu", function( Reload )
+	local GUICrosshair = _G.GUICrosshair
+	if not GUICrosshair then return end
+
+	local OldUpdate = GUICrosshair.Update
+	function GUICrosshair:Update( DeltaTime )
+		if VoteMenu.Visible then
+			-- Hide the crosshair when the vote menu is visible.
+			self.crosshairs:SetIsVisible( false )
+			if self.reloadDial then
+				self.reloadDial:SetIsVisible( false )
+			end
+			return
+		end
+
+		return OldUpdate( self, DeltaTime )
+	end
+end )
+
 function VoteMenu:SetIsVisible( Bool, IgnoreAnim )
 	if self.Visible == Bool then return false end
 
@@ -683,6 +709,10 @@ VoteMenu:AddPage( "Main", function( self )
 		local Button = self:AddSideButton( Text, ClickFuncs[ PluginButton ] )
 		Button.Plugin = PluginButton
 		Button.DefaultText = Text
+
+		if Enabled and Plugin and Plugin.OnVoteButtonCreated then
+			Plugin:OnVoteButtonCreated( Button, VoteMenu )
+		end
 	end
 
 	self:AddSideButton( Locale:GetPhrase( "Core", "CLIENT_CONFIG_MENU" ), function()

--- a/lua/shine/core/server/logging.lua
+++ b/lua/shine/core/server/logging.lua
@@ -503,6 +503,7 @@ do
 
 		for i = 1, #Columns do
 			local Column = Columns[ i ]
+			local FieldName = Column.Name
 
 			Column.OldName = Column.OldName or Column.Name
 			Column.Name = Column.OldName..StringRep( " ", 4 )
@@ -516,7 +517,7 @@ do
 			for j = 1, #Data do
 				local Entry = Data[ j ]
 
-				local String = Getter( Entry )
+				local String = Getter and Getter( Entry ) or Entry[ FieldName ]
 				local StringLength = #String + 4
 				if StringLength > Max then
 					Max = StringLength
@@ -529,7 +530,7 @@ do
 				local Entry = Rows[ j ]
 				local Diff = Max - #Entry
 				if Diff > 0 then
-					Rows[ j ] = Entry..StringRep( " ", Diff )
+					Rows[ j ] = Entry..StringRep( " ", Diff * SpaceMultiplier )
 				end
 			end
 

--- a/lua/shine/core/server/permissions.lua
+++ b/lua/shine/core/server/permissions.lua
@@ -1158,9 +1158,7 @@ do
 		end
 	end
 
-	Shine.Hook.Add( "PostLoadScript", "OverrideSVCommandPermissions", function( Script )
-		if Script ~= "lua/ServerAdmin.lua" then return end
-
+	Shine.Hook.Add( "PostLoadScript:lua/ServerAdmin.lua", "OverrideSVCommandPermissions", function( Reload )
 		local OldGetClientCanRunCommand = GetClientCanRunCommand
 		if not OldGetClientCanRunCommand then return end
 

--- a/lua/shine/core/shared/config.lua
+++ b/lua/shine/core/shared/config.lua
@@ -311,7 +311,10 @@ do
 
 	function Validator.InEnum( PossibleValues, DefaultValue )
 		return function( Value )
-			return not IsType( Value, "string" ) or PossibleValues[ StringUpper( Value ) ] == nil, StringUpper( Value )
+			if not IsType( Value, "string" ) or PossibleValues[ StringUpper( Value ) ] == nil then
+				return true
+			end
+			return false, StringUpper( Value )
 		end,
 		Validator.Constant( DefaultValue ),
 		function()

--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -193,9 +193,7 @@ do
 	if RegisterVoteType then
 		HookVotes()
 	else
-		Shine.Hook.Add( "PostLoadScript", "SetupCustomVote", function( Script )
-			if Script ~= "lua/Voting.lua" then return end
-
+		Shine.Hook.Add( "PostLoadScript:lua/Voting.lua", "SetupCustomVote", function( Reload )
 			HookVotes()
 		end )
 	end

--- a/lua/shine/extensions/basecommands/shared.lua
+++ b/lua/shine/extensions/basecommands/shared.lua
@@ -107,9 +107,7 @@ Plugin.DefaultConfig = {
 Plugin.CheckConfig = true
 Plugin.CheckConfigTypes = true
 
-Shine.Hook.Add( "PostLoadScript", "SetupCustomVote", function( Script )
-	if Script ~= "lua/Voting.lua" then return end
-
+Shine.Hook.Add( "PostLoadScript:lua/Voting.lua", "SetupCustomVote", function( Reload )
 	RegisterVoteType( "ShineCustomVote", { VoteQuestion = "string (64)" } )
 
 	AddVoteSetupCallback( function( VoteMenu )

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -111,10 +111,6 @@ Plugin.DefaultConfig = {
 	-- This can terminate the shuffle before it has managed to optimise teams appropriately
 	-- and is not recommended.
 	AverageValueTolerance = 0,
-	-- How much weighting to assign to team preferences when optimising teams.
-	-- Higher weighting will result in a stronger chance for team preference to be respected,
-	-- but also a stronger chance that teams will be more imbalanced.
-	TeamPreferenceWeighting = Plugin.TeamPreferenceWeighting.NONE,
 
 	IgnoreCommanders = true, -- Should the plugin ignore commanders when switching?
 	IgnoreSpectators = false, -- Should the plugin ignore spectators in player slots when switching?
@@ -204,6 +200,14 @@ Plugin.ConfigMigrationSteps = {
 			Config.RandomOnNextRound = nil
 			Config.BlockTeams = nil
 		end
+	},
+	{
+		VersionTo = "2.4",
+		Apply = function( Config )
+			if IsType( Config.TeamPreferences, "table" ) then
+				Config.TeamPreferences.CostWeighting = Plugin.TeamPreferenceWeighting.NONE
+			end
+		end
 	}
 }
 
@@ -240,8 +244,6 @@ do
 
 	Validator:AddFieldRule( "BalanceMode", Validator.InEnum( Plugin.ShuffleMode, Plugin.ShuffleMode.HIVE ) )
 	Validator:AddFieldRule( "FallbackMode", Validator.InEnum( Plugin.ShuffleMode, Plugin.ShuffleMode.KDR ) )
-	Validator:AddFieldRule( "TeamPreferenceWeighting",
-		Validator.InEnum( Plugin.TeamPreferenceWeighting, Plugin.TeamPreferenceWeighting.NONE ) )
 
 	Plugin.ConfigValidator = Validator
 end
@@ -504,8 +506,6 @@ function Plugin:Initialise()
 
 	self.TeamPreferences = {}
 	self.LastAttemptedTeamJoins = {}
-
-	self.TeamPreferenceWeighting = self.TeamPreferenceWeightingValues[ self.Config.TeamPreferenceWeighting ]
 
 	self:BroadcastModuleEvent( "Initialise" )
 	self.Enabled = true

--- a/lua/shine/extensions/voterandom/shared.lua
+++ b/lua/shine/extensions/voterandom/shared.lua
@@ -218,16 +218,17 @@ function Plugin:OnVoteButtonCreated( Button, VoteMenu )
 		PreferenceLabel:MakeVertical()
 		PreferenceLabel:SetAnchor( "CentreMiddle" )
 		PreferenceLabel:SetFontScale( Button:GetFont(), Button:GetTextScale() )
+		PreferenceLabel:SetDefaultLabelType( "ShadowLabel" )
 		PreferenceLabel:SetText( {
 			Colour( 1, 1, 1 ),
-			{ Type = "ShadowLabel", Text = self:GetPhrase( "TEAM_PREFERENCE_HINT" ) },
+			self:GetPhrase( "TEAM_PREFERENCE_HINT" ),
 			IsMarines and Colour( 0.3, 0.69, 1 ) or Colour( 1, 0.79, 0.23 ),
-			{ Type = "ShadowLabel", Text = self:GetPhrase( TeamPreference ) }
+			self:GetPhrase( TeamPreference )
 		} )
 		PreferenceLabel:SetTextAlignmentX( GUIItem.Align_Center )
 		PreferenceLabel:SetTextAlignmentY( GUIItem.Align_Max )
 		PreferenceLabel:SetShadow( {
-			Colour = Colour( 0, 0, 0, 200 ),
+			Colour = Colour( 0, 0, 0, 200 / 255 ),
 			Offset = Vector2( 2, 2 )
 		} )
 

--- a/lua/shine/extensions/voterandom/shared.lua
+++ b/lua/shine/extensions/voterandom/shared.lua
@@ -193,11 +193,13 @@ function Plugin:ReceiveTemporaryTeamPreference( Data )
 	self.TemporaryTeamPreference = self.TeamType[ Data.PreferredTeam ]
 
 	local NewPreference = self:GetTeamPreference()
-	if not Data.Silent and NewPreference ~= OldPreference then
-		self:Notify( self:GetPhrase( "TEAM_PREFERENCE_SET_"..NewPreference ) )
-	end
+	if NewPreference ~= OldPreference then
+		if not Data.Silent then
+			self:Notify( self:GetPhrase( "TEAM_PREFERENCE_SET_"..NewPreference ) )
+		end
 
-	self:OnTeamPreferenceChanged()
+		self:OnTeamPreferenceChanged()
+	end
 end
 
 function Plugin:OnTeamPreferenceChanged()

--- a/lua/shine/extensions/voterandom/team_balance.lua
+++ b/lua/shine/extensions/voterandom/team_balance.lua
@@ -27,7 +27,11 @@ BalanceModule.DefaultConfig = {
 		-- How many rounds to remember who got to play their preferred team for.
 		MaxHistoryRounds = 5,
 		-- The minimum time a round must be played before team preferences are recorded.
-		MinRoundLengthToRecordInSeconds = 5 * 60
+		MinRoundLengthToRecordInSeconds = 5 * 60,
+		-- How much weighting to assign to team preferences when optimising teams.
+		-- Higher weighting will result in a stronger chance for team preference to be respected,
+		-- but also a stronger chance that teams will be more imbalanced.
+		CostWeighting = Plugin.TeamPreferenceWeighting.NONE
 	}
 }
 
@@ -41,6 +45,9 @@ do
 	Validator:AddFieldRule( "TeamPreferences.MinRoundLengthToRecordInSeconds",
 		Validator.IsType( "number", BalanceModule.DefaultConfig.TeamPreferences.MinRoundLengthToRecordInSeconds ) )
 	Validator:AddFieldRule( "TeamPreferences.MinRoundLengthToRecordInSeconds", Validator.Min( 0 ) )
+
+	Validator:AddFieldRule( "TeamPreferences.CostWeighting",
+		Validator.InEnum( Plugin.TeamPreferenceWeighting, Plugin.TeamPreferenceWeighting.NONE ) )
 
 	BalanceModule.ConfigValidator = Validator
 end
@@ -180,6 +187,7 @@ BalanceModule.HappinessHistoryFile = "config://shine/temp/shuffle_happiness.json
 function BalanceModule:Initialise()
 	self.HappinessHistory = self:LoadHappinessHistory()
 	self.TeamStatsCache = {}
+	self.TeamPreferenceWeighting = self.TeamPreferenceWeightingValues[ self.Config.TeamPreferences.CostWeighting ]
 end
 
 function BalanceModule:LoadHappinessHistory()

--- a/lua/shine/extensions/voterandom/team_balance.lua
+++ b/lua/shine/extensions/voterandom/team_balance.lua
@@ -372,42 +372,50 @@ do
 	local AVERAGE_BOUND = 75
 	local STDDEV_BOUND = 150
 
-	local function TeamCost( AverageDiff, StdDiff )
+	local function TeamCost( AverageDiff, StdDiff, TeamPreferenceWeight )
 		-- The idea here is that, if the average or standard deviation differences grow
 		-- beyond an acceptable level (defined by the bounds above), their exponentials
 		-- will start to grow and easily cancel out any minor improvements in the other
 		-- parameter.
 		return AverageDiff * Exp( Max( AverageDiff - AVERAGE_BOUND, 0 ) )
 			+ StdDiff * Exp( Max( StdDiff - STDDEV_BOUND, 0 ) )
+			-- Add the team preference weight directly. If skills are way out, this will be
+			-- meaningless. If not, it may swap players of near skill to let them play on
+			-- their preferred team.
+			+ TeamPreferenceWeight
 	end
 
 	BalanceModule.OptimisationIterations = {
 		{
 			-- Legacy method, uses hard rules to determine if a swap
 			-- is valid.
-			TakeSwapImmediately = false
+			TakeSwapImmediately = false,
+			NeedsMultiPass = true
 		},
 		{
 			-- New cost-based method, usually ends up with a more balanced team composition.
-			SwapPassesRequirements = function( self, AverageDiff, StdDiff )
-				local NewCost = TeamCost( AverageDiff, StdDiff )
+			SwapPassesRequirements = function( self, AverageDiff, StdDiff, TeamPreferenceWeight )
+				local NewCost = TeamCost( AverageDiff, StdDiff, TeamPreferenceWeight )
 				local CurrentCost = self.CurrentPotentialState.Cost
 				if not CurrentCost or CurrentCost > NewCost then
 					return true, NewCost
 				end
 				return false
 			end,
-			TakeSwapImmediately = true
+			TakeSwapImmediately = true,
+			NeedsMultiPass = false
 		}
 	}
 
 	function BalanceModule:GetCostForOptimiser( Optimiser )
 		local State = Optimiser.CurrentPotentialState
-		return TeamCost( State.AverageDiffBefore, State.StdDiffBefore )
+		return TeamCost( State.AverageDiffBefore, State.StdDiffBefore, State.TeamPreferenceWeighting )
 	end
 
 	function BalanceModule:GetCostFromDiff( AverageDiff, StdDiff )
-		return TeamCost( AverageDiff, StdDiff )
+		-- Ignore team preferences in this case as it's for choosing the team a player
+		-- should join when teams are already chosen.
+		return TeamCost( AverageDiff, StdDiff, 0 )
 	end
 end
 
@@ -421,8 +429,12 @@ function BalanceModule:OptimiseTeams( TeamMembers, RankFunc, TeamSkills )
 	end
 
 	local IgnoreCommanders = self.Config.IgnoreCommanders
-	local function IsValidForSwap( self, Player, Pass, TeamNumber )
-		if IgnoreCommanders and Player:isa( "Commander" ) then
+	local function IsValidForSwapSinglePass( self, Player )
+		return not ( IgnoreCommanders and Player:isa( "Commander" ) )
+	end
+
+	local function IsValidForSwapMultiPass( self, Player, Pass, TeamNumber )
+		if not IsValidForSwapSinglePass( self, Player ) then
 			return false
 		end
 
@@ -431,6 +443,42 @@ function BalanceModule:OptimiseTeams( TeamMembers, RankFunc, TeamSkills )
 		end
 
 		return true
+	end
+
+	local TeamPreferenceWeighting = self.TeamPreferenceWeighting
+	local GetTeamPreferenceWeighting
+
+	if TeamPreferenceWeighting > 0 then
+		self.Logger:Debug( "Optimisation will apply team preference weighting of: %s", TeamPreferenceWeighting )
+
+		-- Configured to apply team preference weighting in cost.
+		local PreferenceCache = {}
+		GetTeamPreferenceWeighting = function( Optimiser, Player, TeamNumber )
+			local Cached = PreferenceCache[ Player ]
+			if Cached then
+				return Cached[ TeamNumber ]
+			end
+
+			local Weight
+			local Preference = TeamPreferences[ Player ]
+			if not IsType( Preference, "number" ) then
+				-- No preferred team, no effect on weighting.
+				Weight = 0
+			else
+				-- Has a preferred team, use their historic weight.
+				Weight = self:GetHistoricHappinessWeight( Player ) * TeamPreferenceWeighting
+			end
+
+			Cached = {}
+			for i = 1, 2 do
+				-- If they prefer the team, make their weight lower the cost.
+				-- If they don't prefer the team, make their weight increase the cost.
+				Cached[ i ] = ( Preference == i and -1 or 1 ) * Weight
+			end
+			PreferenceCache[ Player ] = Cached
+
+			return Cached[ TeamNumber ]
+		end
 	end
 
 	local Iterations = self.OptimisationIterations
@@ -443,8 +491,18 @@ function BalanceModule:OptimiseTeams( TeamMembers, RankFunc, TeamSkills )
 		local IterationTeamSkills = TableCopy( TeamSkills )
 
 		local Optimiser = self.TeamOptimiser( IterationTeamMembers, IterationTeamSkills, RankFunc )
-		Optimiser.GetNumPasses = GetNumPasses
-		Optimiser.IsValidForSwap = IsValidForSwap
+		if Iteration.NeedsMultiPass or TeamPreferenceWeighting <= 0 then
+			-- 2 passes as team preferences are not accounted for in cost function.
+			Optimiser.GetNumPasses = GetNumPasses
+			Optimiser.IsValidForSwap = IsValidForSwapMultiPass
+		else
+			-- 1 pass as team preferences are accounted for in cost function.
+			Optimiser.IsValidForSwap = IsValidForSwapSinglePass
+		end
+
+		if GetTeamPreferenceWeighting then
+			Optimiser.GetTeamPreferenceWeighting = GetTeamPreferenceWeighting
+		end
 
 		TableShallowMerge( Iteration, Optimiser, true )
 		TableMixin( self.Config, Optimiser, {

--- a/lua/shine/extensions/voterandom/team_balance.lua
+++ b/lua/shine/extensions/voterandom/team_balance.lua
@@ -415,14 +415,22 @@ function BalanceModule:OptimiseTeams( TeamMembers, RankFunc, TeamSkills )
 	-- Sanity check, make sure both team tables have even counts.
 	Shine.EqualiseTeamCounts( TeamMembers )
 
+	local TeamPreferences = TeamMembers.TeamPreferences
 	local function GetNumPasses( self )
-		return next( TeamMembers.TeamPreferences ) and 2 or 1
+		return next( TeamPreferences ) and 2 or 1
 	end
 
 	local IgnoreCommanders = self.Config.IgnoreCommanders
-	local function IsValidForSwap( self, Player, Pass )
-		return ( Pass == 2 or not TeamMembers.TeamPreferences[ Player ] )
-			and not ( IgnoreCommanders and Player:isa( "Commander" ) )
+	local function IsValidForSwap( self, Player, Pass, TeamNumber )
+		if IgnoreCommanders and Player:isa( "Commander" ) then
+			return false
+		end
+
+		if Pass == 1 and TeamPreferences[ Player ] == TeamNumber then
+			return false
+		end
+
+		return true
 	end
 
 	local Iterations = self.OptimisationIterations

--- a/lua/shine/extensions/voterandom/team_optimiser.lua
+++ b/lua/shine/extensions/voterandom/team_optimiser.lua
@@ -260,16 +260,22 @@ end
 function TeamOptimiser:TrySwaps( PlayerIndex, Pass )
 	local TeamMembers = self.TeamMembers
 
-	local Player = TeamMembers[ self.LargerTeam ][ PlayerIndex ]
-	if not Player or not self:IsValidForSwap( Player, Pass ) then return end
+	local LargerTeamNum = self.LargerTeam
+	local LesserTeamNum = self.LesserTeam
+
+	local LargerTeam = TeamMembers[ LargerTeamNum ]
+	local LesserTeam = TeamMembers[ LesserTeamNum ]
+
+	local Player = LargerTeam[ PlayerIndex ]
+	if not Player or not self:IsValidForSwap( Player, Pass, LargerTeamNum ) then return end
 
 	local TakeSwapImmediately = self.TakeSwapImmediately
 	-- Check every player on the other team against this player for a better swap.
-	for OtherPlayerIndex = 1, #TeamMembers[ self.LesserTeam ] do
-		local OtherPlayer = TeamMembers[ self.LesserTeam ][ OtherPlayerIndex ]
+	for OtherPlayerIndex = 1, #LesserTeam do
+		local OtherPlayer = LesserTeam[ OtherPlayerIndex ]
 
-		if OtherPlayer and self:IsValidForSwap( OtherPlayer, Pass ) then
-			if self.LargerTeam == 1 then
+		if OtherPlayer and self:IsValidForSwap( OtherPlayer, Pass, LesserTeamNum ) then
+			if LargerTeamNum == 1 then
 				self:SimulateSwap( PlayerIndex, OtherPlayerIndex )
 			else
 				self:SimulateSwap( OtherPlayerIndex, PlayerIndex )
@@ -285,10 +291,10 @@ function TeamOptimiser:TrySwaps( PlayerIndex, Pass )
 	if self.TeamsAreEqual then return end
 
 	-- Otherwise, try adding this player to the smaller team without a swap.
-	if self.LargerTeam == 1 then
-		self:SimulateSwap( PlayerIndex, #TeamMembers[ self.LesserTeam ] + 1 )
+	if LargerTeamNum == 1 then
+		self:SimulateSwap( PlayerIndex, #LesserTeam + 1 )
 	else
-		self:SimulateSwap( #TeamMembers[ self.LesserTeam ] + 1, PlayerIndex )
+		self:SimulateSwap( #LesserTeam + 1, PlayerIndex )
 	end
 end
 

--- a/lua/shine/lib/class.lua
+++ b/lua/shine/lib/class.lua
@@ -40,8 +40,7 @@ function Shine.UpdateClassNetVars( ClassName, FileName, NetVars )
 	if _G[ ClassName ] then
 		AddNetVars()
 	else
-		Shine.Hook.Add( "PostLoadScript", tostring( NetVars ), function( Script )
-			if Script ~= FileName then return end
+		Shine.Hook.Add( "PostLoadScript:"..FileName, tostring( NetVars ), function( Reload )
 			AddNetVars()
 		end )
 	end

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -366,7 +366,7 @@ function SGUI:IsWindowInFocus( Window )
 	for i = #Windows, 1, -1 do
 		local OtherWindow = Windows[ i ]
 		if Window == OtherWindow then
-			return Window:MouseInCached()
+			return Window.AlwaysInMouseFocus or Window:MouseInCached()
 		end
 
 		if not OtherWindow.IgnoreMouseFocus and OtherWindow:MouseInCached() then

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -369,7 +369,7 @@ function SGUI:IsWindowInFocus( Window )
 			return Window:MouseInCached()
 		end
 
-		if OtherWindow:MouseInCached() then
+		if not OtherWindow.IgnoreMouseFocus and OtherWindow:MouseInCached() then
 			return false
 		end
 	end

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -1018,12 +1018,18 @@ function ControlMeta:Think( DeltaTime )
 	self:HandleLayout( DeltaTime )
 end
 
-function ControlMeta:ShowTooltip( X, Y )
+function ControlMeta:GetTooltipOffset( MouseX, MouseY, Tooltip )
 	local SelfPos = self:GetScreenPos()
 
-	X = SelfPos.x + X
-	Y = SelfPos.y + Y
+	local X = SelfPos.x + MouseX
+	local Y = SelfPos.y + MouseY
 
+	Y = Y - Tooltip:GetSize().y - 4
+
+	return X, Y
+end
+
+function ControlMeta:ShowTooltip( MouseX, MouseY )
 	local Tooltip = SGUI.IsValid( self.Tooltip ) and self.Tooltip or SGUI:Create( "Tooltip" )
 
 	local W, H = SGUI.GetScreenSize()
@@ -1042,8 +1048,7 @@ function ControlMeta:ShowTooltip( X, Y )
 	Tooltip:SetTextPadding( SGUI.Layout.Units.HighResScaled( 16 ):GetValue() )
 	Tooltip:SetText( self.TooltipText, Font, TextScale )
 
-	Y = Y - Tooltip:GetSize().y - 4
-
+	local X, Y = self:GetTooltipOffset( MouseX, MouseY, Tooltip )
 	Tooltip:SetPos( Vector2( X, Y ) )
 	Tooltip:FadeIn()
 

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -203,7 +203,11 @@ function ControlMeta:ForEach( TableKey, MethodName, ... )
 
 	for i = 1, #Objects do
 		local Object = Objects[ i ]
-		Object[ MethodName ]( Object, ... )
+		local Method = Object[ MethodName ]
+
+		if Method then
+			Method( Object, ... )
+		end
 	end
 end
 

--- a/lua/shine/lib/gui/objects/colour_label.lua
+++ b/lua/shine/lib/gui/objects/colour_label.lua
@@ -22,6 +22,8 @@ function ColourLabel:Initialise()
 end
 
 function ColourLabel:MakeVertical()
+	if self.IsVertical then return end
+
 	self.Layout = SGUI.Layout:CreateLayout( "Vertical", {} )
 	self.IsVertical = true
 end

--- a/lua/shine/lib/gui/objects/colour_label.lua
+++ b/lua/shine/lib/gui/objects/colour_label.lua
@@ -10,6 +10,8 @@ local Vector2 = Vector2
 
 local ColourLabel = {}
 
+SGUI.AddProperty( ColourLabel, "DefaultLabelType", "Label" )
+
 function ColourLabel:Initialise()
 	self.Labels = {}
 	self.Layout = SGUI.Layout:CreateLayout( "Horizontal", {} )
@@ -80,20 +82,21 @@ function ColourLabel:SetText( TextContent )
 	end
 
 	local Count = 0
+	local DefaultLabelType = self:GetDefaultLabelType()
 	for i = 1, #TextContent, 2 do
 		local Colour = TextContent[ i ]
 		local Params = TextContent[ i + 1 ]
+		local Type = DefaultLabelType
+		local Text = Params
 
-		if IsType( Params, "string" ) then
-			Params = {
-				Type = "Label",
-				Text = Params
-			}
+		if IsType( Params, "table" ) then
+			Text = Params.Text
+			Type = Params.Type or DefaultLabelType
 		end
 
-		local Label = SGUI:Create( Params.Type, self )
+		local Label = SGUI:Create( Type, self )
 		Label:SetFontScale( self.Font, self.TextScale )
-		Label:SetText( Params.Text )
+		Label:SetText( Text )
 		Label:SetColour( SGUI.CopyColour( Colour ) )
 		self.Layout:AddElement( Label )
 

--- a/lua/shine/lib/gui/objects/colour_label.lua
+++ b/lua/shine/lib/gui/objects/colour_label.lua
@@ -2,6 +2,7 @@
 	Multi-coloured label.
 ]]
 
+local IsType = Shine.IsType
 local SGUI = Shine.GUI
 
 local Max = math.max
@@ -13,10 +14,16 @@ function ColourLabel:Initialise()
 	self.Labels = {}
 	self.Layout = SGUI.Layout:CreateLayout( "Horizontal", {} )
 	self.Font = Fonts.kAgencyFB_Small
+	self.IsVertical = false
 
 	local Manager = GetGUIManager()
 	self.Background = Manager:CreateGraphicItem()
 	self.Background:SetColor( Colour( 0, 0, 0, 0 ) )
+end
+
+function ColourLabel:MakeVertical()
+	self.Layout = SGUI.Layout:CreateLayout( "Vertical", {} )
+	self.IsVertical = true
 end
 
 function ColourLabel:SetSize()
@@ -37,6 +44,18 @@ end
 AddProperty( "Font", { "InvalidatesParent" } )
 AddProperty( "TextScale", { "InvalidatesParent" } )
 AddProperty( "Colour" )
+
+function ColourLabel:SetTextAlignmentX( XAlign )
+	self:ForEach( "Labels", "SetTextAlignmentX", XAlign )
+end
+
+function ColourLabel:SetTextAlignmentY( YAlign )
+	self:ForEach( "Labels", "SetTextAlignmentY", YAlign )
+end
+
+function ColourLabel:SetShadow( Params )
+	self:ForEach( "Labels", "SetShadow", Params )
+end
 
 function ColourLabel:AlphaTo( ... )
 	self:ForEach( "Labels", "AlphaTo", ... )
@@ -61,11 +80,18 @@ function ColourLabel:SetText( TextContent )
 	local Count = 0
 	for i = 1, #TextContent, 2 do
 		local Colour = TextContent[ i ]
-		local Text = TextContent[ i + 1 ]
+		local Params = TextContent[ i + 1 ]
 
-		local Label = SGUI:Create( "Label", self )
+		if IsType( Params, "string" ) then
+			Params = {
+				Type = "Label",
+				Text = Params
+			}
+		end
+
+		local Label = SGUI:Create( Params.Type, self )
 		Label:SetFontScale( self.Font, self.TextScale )
-		Label:SetText( Text )
+		Label:SetText( Params.Text )
 		Label:SetColour( SGUI.CopyColour( Colour ) )
 		self.Layout:AddElement( Label )
 
@@ -83,11 +109,20 @@ function ColourLabel:GetSize()
 	local Width = 0
 	local Height = 0
 
-	for i = 1, #self.Labels do
-		local Label = self.Labels[ i ]
-		local Size = Label:GetSize()
-		Width = Width + Size.x
-		Height = Max( Height, Size.y )
+	if self.IsVertical then
+		for i = 1, #self.Labels do
+			local Label = self.Labels[ i ]
+			local Size = Label:GetSize()
+			Width = Max( Width, Size.x )
+			Height = Height + Size.y
+		end
+	else
+		for i = 1, #self.Labels do
+			local Label = self.Labels[ i ]
+			local Size = Label:GetSize()
+			Width = Width + Size.x
+			Height = Max( Height, Size.y )
+		end
 	end
 
 	return Vector2( Width, Height )

--- a/lua/shine/lib/gui/objects/label.lua
+++ b/lua/shine/lib/gui/objects/label.lua
@@ -4,11 +4,7 @@
 
 local SGUI = Shine.GUI
 
-local StringGMatch = string.gmatch
-
 local Label = {}
-
-local ZeroCol = Colour( 0, 0, 0, 0 )
 
 SGUI.AddBoundProperty( Label, "Colour", "Label:SetColor" )
 SGUI.AddBoundProperty( Label, "InheritsParentAlpha", "Label" )

--- a/lua/shine/lib/gui/objects/shadow_label.lua
+++ b/lua/shine/lib/gui/objects/shadow_label.lua
@@ -52,8 +52,14 @@ end
 function ShadowLabel:AlphaTo( Element, Start, End, ... )
 	self.BaseClass.AlphaTo( self, Element, Start, End, ... )
 	if ( not Element or Element == self.Background ) and self.LabelShadow:GetIsVisible() then
-		local ShadowAlpha = self.LabelShadow:GetColor().a
-		self.BaseClass.AlphaTo( self, self.LabelShadow, ShadowAlpha * ( Start or 1 ), ShadowAlpha * End, ... )
+		local ShadowAlpha = self.ShadowColour.a
+		local ShadowStart = ShadowAlpha
+		if not Start then
+			ShadowStart = self.ShadowLabel:GetColor().a
+		else
+			ShadowStart = ShadowStart * Start
+		end
+		self.BaseClass.AlphaTo( self, self.LabelShadow, ShadowStart, ShadowAlpha * End, ... )
 	end
 end
 
@@ -62,11 +68,14 @@ function ShadowLabel:SetShadow( Params )
 
 	if not Params then
 		self.ShadowOffset = nil
+		self.ShadowColour = nil
 		self.LabelShadow:SetIsVisible( false )
 		return
 	end
 
 	self.ShadowOffset = Params.Offset or Vector2( 2, 2 )
+	self.ShadowColour = Params.Colour
+
 	self.LabelShadow:SetIsVisible( true )
 	self.Label:SetPosition( self:GetPos() + self.ShadowOffset )
 	self.LabelShadow:SetColor( Params.Colour )

--- a/lua/shine/lib/gui/objects/shadow_label.lua
+++ b/lua/shine/lib/gui/objects/shadow_label.lua
@@ -71,4 +71,16 @@ function ShadowLabel:SetupStencil()
 	self.LabelShadow:SetStencilFunc( GUIItem.NotEqual )
 end
 
+function ShadowLabel:Cleanup()
+	if self.Parent then return end
+
+	if self.Background then
+		GUI.DestroyItem( self.Background )
+	end
+
+	if self.LabelShadow then
+		GUI.DestroyItem( self.LabelShadow )
+	end
+end
+
 SGUI:Register( "ShadowLabel", ShadowLabel, "Label" )

--- a/lua/shine/lib/gui/objects/shadow_label.lua
+++ b/lua/shine/lib/gui/objects/shadow_label.lua
@@ -1,0 +1,74 @@
+--[[
+	An extension of Label to allow for a shadow beneath the text.
+]]
+
+local SGUI = Shine.GUI
+local Controls = SGUI.Controls
+
+local ShadowLabel = {}
+
+SGUI.AddBoundProperty( ShadowLabel, "Font", { "Label:SetFontName", "LabelShadow:SetFontName" }, { "InvalidatesParent" } )
+SGUI.AddBoundProperty( ShadowLabel, "Text", { "Label", "LabelShadow" }, { "InvalidatesParent" } )
+SGUI.AddBoundProperty( ShadowLabel, "TextAlignmentX", { "Label", "LabelShadow" } )
+SGUI.AddBoundProperty( ShadowLabel, "TextAlignmentY", { "Label", "LabelShadow" } )
+SGUI.AddBoundProperty( ShadowLabel, "TextScale", { "Label:SetScale", "LabelShadow:SetScale" }, { "InvalidatesParent" } )
+
+function ShadowLabel:Initialise()
+	self.LabelShadow = GetGUIManager():CreateTextItem()
+	self.LabelShadow:SetIsVisible( false )
+
+	Controls.Label.Initialise( self )
+end
+
+function ShadowLabel:SetPos( Pos )
+	self.BaseClass.SetPos( self, Pos )
+
+	if self.ShadowOffset then
+		self.LabelShadow:SetPosition( Pos + self.ShadowOffset )
+	end
+end
+
+function ShadowLabel:SetAnchor( Anchor )
+	self.BaseClass.SetAnchor( self, Anchor )
+	self.LabelShadow:SetAnchor( self.Label:GetAnchor() )
+end
+
+function ShadowLabel:SetParent( Control, Element )
+	-- Must add the shadow label to the parent first before the main label, otherwise
+	-- it will draw on top (would be nice to have a z-index for GUIItems...)
+	local ParentElement = Element or ( Control and Control.Background )
+	if ParentElement then
+		ParentElement:AddChild( self.LabelShadow )
+	else
+		local Parent = self.LabelShadow:GetParent()
+		if Parent then
+			Parent:RemoveChild( self.LabelShadow )
+		end
+	end
+
+	self.BaseClass.SetParent( self, Control, Element )
+end
+
+function ShadowLabel:SetShadow( Params )
+	self.Shadow = Params
+
+	if not Params then
+		self.ShadowOffset = nil
+		self.LabelShadow:SetIsVisible( false )
+		return
+	end
+
+	self.ShadowOffset = Params.Offset or Vector2( 2, 2 )
+	self.LabelShadow:SetIsVisible( true )
+	self.Label:SetPosition( self:GetPos() + self.ShadowOffset )
+	self.LabelShadow:SetColor( Params.Colour )
+end
+
+function ShadowLabel:SetupStencil()
+	Controls.Label.SetupStencil( self )
+
+	self.LabelShadow:SetInheritsParentStencilSettings( false )
+	self.LabelShadow:SetStencilFunc( GUIItem.NotEqual )
+end
+
+SGUI:Register( "ShadowLabel", ShadowLabel, "Label" )

--- a/lua/shine/lib/gui/objects/shadow_label.lua
+++ b/lua/shine/lib/gui/objects/shadow_label.lua
@@ -49,6 +49,14 @@ function ShadowLabel:SetParent( Control, Element )
 	self.BaseClass.SetParent( self, Control, Element )
 end
 
+function ShadowLabel:AlphaTo( Element, Start, End, ... )
+	self.BaseClass.AlphaTo( self, Element, Start, End, ... )
+	if ( not Element or Element == self.Background ) and self.LabelShadow:GetIsVisible() then
+		local ShadowAlpha = self.LabelShadow:GetColor().a
+		self.BaseClass.AlphaTo( self, self.LabelShadow, ShadowAlpha * ( Start or 1 ), ShadowAlpha * End, ... )
+	end
+end
+
 function ShadowLabel:SetShadow( Params )
 	self.Shadow = Params
 

--- a/lua/shine/lib/gui/objects/tooltip.lua
+++ b/lua/shine/lib/gui/objects/tooltip.lua
@@ -8,6 +8,8 @@ local SGUI = Shine.GUI
 
 local Tooltip = {}
 Tooltip.IsWindow = true
+-- Tooltips can't have hover focus.
+Tooltip.IgnoreMouseFocus = true
 
 SGUI.AddBoundProperty( Tooltip, "Colour", "Background:SetColor" )
 SGUI.AddBoundProperty( Tooltip, "Texture", "Background:SetTexture" )
@@ -41,7 +43,7 @@ function Tooltip:SetTextPadding( TextPadding )
 
 	if not self.Text then return end
 
-	self.Text:SetPos( Vector2( 0, self.TextPadding * 0.5 ) )
+	self.Text:SetPosition( Vector2( 0, self.TextPadding * 0.5 ) )
 	self:ComputeAndSetSize( self.Text:GetText() )
 end
 

--- a/lua/shine/lib/player.lua
+++ b/lua/shine/lib/player.lua
@@ -286,6 +286,16 @@ function Shine.GetAllClients()
 	return Clients, Count
 end
 
+do
+	local function AccumulateClientsByNS2ID( State, Client )
+		State[ Client:GetUserId() ] = Client
+		return State
+	end
+	function Shine.GetAllClientsByNS2ID()
+		return Shine.Stream( Shine.GetAllClients() ):Reduce( AccumulateClientsByNS2ID, {} )
+	end
+end
+
 --[[
 	Returns a client matching the given game ID.
 ]]


### PR DESCRIPTION
#### Base Commands
* Added `sh_listgags` command to print all gagged players to the console.

#### Vote Shuffle
* Team preference can now be accounted for during team optimisation. Set the `TeamPreferences.CostWeighting` to one of `LOW`, `MEDIUM` or `HIGH` to control how strongly to consider team preference. Higher values may result in slightly more imbalanced teams, but should better respect team preferences.
* Improved behaviour when team preference weighting is `NONE` to no longer ignore potential swaps when players have a team preference but are not on the team they want.
* Team preferences are now automatically set whenever a player intentionally joins a team using either console commands or walking through a team door.
  * This is set even if they cannot yet join the given team.
  * This preference is reset at the end of a round.
  * The existing team preference option is used as a default if no team has been selected.
* The vote menu now displays the current team preference if one is set.

#### API
##### Hooks
* `PreLoadScript` and `PostLoadScript` are now always available, even after map load. They will be called only once per script (unless the script is reloaded by passing `true` to `Script.Load`).
* In addition to the generic hooks, it is now possible to target specific script files with the convention `PreLoadScript:lua/path/to/script.lua`(and similarly for `PostLoadScript`).
* `JoinTeam` is no longer called for plugins when shuffle is applying its team swaps to avoid plugins incorrectly interfering with the result. Use `PostJoinTeam` to track team changes, or `PreShuffleOptimiseTeams` to control team sizes.

##### SGUI
* Added `ShadowLabel` control, which provides a way to render text with a shadow behind it.
* Updated `ColourLabel` to be able to use `ShadowLabel` controls and to layout its text elements vertically instead of horizontally.