### PR TITLE
Remove NS2:Combat compatibility layer, update AFK logic in shuffle

### DIFF
--- a/lua/shine/cl_init.lua
+++ b/lua/shine/cl_init.lua
@@ -40,12 +40,6 @@ local Scripts = {
 	"core/shared/autocomplete.lua"
 }
 
-local OnLoadedFuncs = {
-	[ "lib/game.lua" ] = function()
-		Shine.IsNS2Combat = Shine.GetGamemode() == "combat"
-	end
-}
-
 local StartupMessages = {}
 Shine.StartupMessages = StartupMessages
 
@@ -57,6 +51,6 @@ function Shine.AddStartupMessage( Message, Format, ... )
 	StartupMessages[ #StartupMessages + 1 ] = Message
 end
 
-Shine.LoadScripts( Scripts, OnLoadedFuncs )
+Shine.LoadScripts( Scripts )
 Shine.Locale:RegisterSource( "Core", "locale/shine/core" )
 Shine.Locale:OnLoaded()

--- a/lua/shine/core/shared/extensions.lua
+++ b/lua/shine/core/shared/extensions.lua
@@ -242,10 +242,6 @@ function Shine:LoadExtension( Name, DontEnable )
 end
 
 function Shine:CanPluginLoad( Plugin )
-	if self.IsNS2Combat and Plugin.NS2Only then
-		return false, "plugin not compatible with NS2:Combat"
-	end
-
 	local Gamemode = Shine.GetGamemode()
 
 	-- Allow external mods/gamemodes to decide whether the plugin can load if they know a plugin is compatible.

--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -629,23 +629,21 @@ Add( "Think", "ReplaceMethods", function()
 	SetupClassHook( Gamerules, "EndGame", "EndGame", "PassivePre" )
 	SetupClassHook( Gamerules, "OnEntityKilled", "OnEntityKilled", "PassivePre" )
 
-	if not Shine.IsNS2Combat then
-		SetupClassHook( "CommandStructure", "LoginPlayer", "CommLoginPlayer", "PassivePre" )
-		SetupClassHook( "CommandStructure", "OnCommanderLogin", "OnCommanderLogin", "PassivePre" )
-		SetupClassHook( "CommandStructure", "Logout", "CommLogout", "PassivePre" )
-		SetupClassHook( Gamerules, "OnCommanderLogin", "ValidateCommanderLogin", "ActivePre" )
+	SetupClassHook( "CommandStructure", "LoginPlayer", "CommLoginPlayer", "PassivePre" )
+	SetupClassHook( "CommandStructure", "OnCommanderLogin", "OnCommanderLogin", "PassivePre" )
+	SetupClassHook( "CommandStructure", "Logout", "CommLogout", "PassivePre" )
+	SetupClassHook( Gamerules, "OnCommanderLogin", "ValidateCommanderLogin", "ActivePre" )
 
-		SetupClassHook( "RecycleMixin", "OnResearch", "OnRecycle", "PassivePre" )
-		SetupClassHook( "RecycleMixin", "OnResearchComplete", "OnBuildingRecycled", "PassivePre" )
+	SetupClassHook( "RecycleMixin", "OnResearch", "OnRecycle", "PassivePre" )
+	SetupClassHook( "RecycleMixin", "OnResearchComplete", "OnBuildingRecycled", "PassivePre" )
 
-		SetupClassHook( "Commander", "ProcessTechTreeActionForEntity", "OnCommanderTechTreeAction",
-			"PassivePre" )
-		SetupClassHook( "Commander", "TriggerNotification", "OnCommanderNotify", "PassivePre" )
-		SetupClassHook( "Commander", "Eject", "OnCommanderEjected", "PassivePre" )
+	SetupClassHook( "Commander", "ProcessTechTreeActionForEntity", "OnCommanderTechTreeAction",
+		"PassivePre" )
+	SetupClassHook( "Commander", "TriggerNotification", "OnCommanderNotify", "PassivePre" )
+	SetupClassHook( "Commander", "Eject", "OnCommanderEjected", "PassivePre" )
 
-		SetupClassHook( "PlayingTeam", "VoteToEjectCommander", "OnVoteToEjectCommander", "PassivePost" )
-		SetupClassHook( "PlayingTeam", "VoteToGiveUp", "OnVoteToConcede", "PassivePost" )
-	end
+	SetupClassHook( "PlayingTeam", "VoteToEjectCommander", "OnVoteToEjectCommander", "PassivePost" )
+	SetupClassHook( "PlayingTeam", "VoteToGiveUp", "OnVoteToConcede", "PassivePost" )
 
 	SetupClassHook( "ConstructMixin", "OnInitialized", "OnConstructInit", "PassivePre" )
 

--- a/lua/shine/core/shared/logging.lua
+++ b/lua/shine/core/shared/logging.lua
@@ -23,8 +23,8 @@ local function ReportErrors()
 	if not Shine.Config.ReportErrors then return end
 	if not next( ErrorQueue ) then return end
 
-	TableInsert( ErrorQueue, 1, StringFormat( "Operating system: %s. Game: %s.", OS,
-			Shine.IsNS2Combat and "NS2: Combat" or "Natural Selection 2" ) )
+	TableInsert( ErrorQueue, 1, StringFormat( "Operating system: %s. Gamemode: %s.", OS,
+			Shine.GetGamemode() ) )
 
 	if Server then
 		local ModCount = Server.GetNumActiveMods()

--- a/lua/shine/extensions/afkkick/server.lua
+++ b/lua/shine/extensions/afkkick/server.lua
@@ -628,34 +628,34 @@ function Plugin:CanPlayerHearPlayer( Gamerules, Listener, Speaker )
 	end
 end
 
-if not Shine.IsNS2Combat then
-	function Plugin:OnConstructInit( Building )
-		local Team = Building:GetTeam()
-		if not Team or not Team.GetCommander then return end
+function Plugin:OnConstructInit( Building )
+	local Team = Building:GetTeam()
+	if not Team or not Team.GetCommander then return end
 
-		local Owner = Building:GetOwner()
-		Owner = Owner or Team:GetCommander()
-		if not Owner then return end
+	local Owner = Building:GetOwner()
+	Owner = Owner or Team:GetCommander()
+	if not Owner then return end
 
-		local Client = GetOwner( Owner )
-		if not Client then return end
+	local Client = GetOwner( Owner )
+	if not Client then return end
 
-		self:ResetAFKTime( Client )
-	end
+	self:ResetAFKTime( Client )
+end
 
-	function Plugin:OnRecycle( Building, ResearchID )
-		local Team = Building:GetTeam()
-		if not Team or not Team.GetCommander then return end
+function Plugin:OnRecycle( Building, ResearchID )
+	local Team = Building:GetTeam()
+	if not Team or not Team.GetCommander then return end
 
-		local Commander = Team:GetCommander()
-		if not Commander then return end
+	local Commander = Team:GetCommander()
+	if not Commander then return end
 
-		local Client = GetOwner( Commander )
-		if not Client then return end
+	local Client = GetOwner( Commander )
+	if not Client then return end
 
-		self:ResetAFKTime( Client )
-	end
+	self:ResetAFKTime( Client )
+end
 
+do
 	local function ResetForCommander()
 		return function( self, Commander )
 			local Client = GetOwner( Commander )
@@ -769,8 +769,6 @@ function Plugin:OnFirstThink()
 			Shine.Stream( ReadyRoomPlayers ):ForEach( Action )
 		end )
 	end
-
-	if Shine.IsNS2Combat then return end
 
 	local function FilterPlayers( Player )
 		local ShouldKeep = true

--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -1258,15 +1258,13 @@ function Plugin:CreateGameplayCommands()
 	ReadyRoomCommand:AddParam{ Type = "clients" }
 	ReadyRoomCommand:Help( "<players> Sends the given player(s) to the ready room." )
 
-	if not Shine.IsNS2Combat then
-		local function HiveTeams( Client )
-			--Force even teams is such an overconfident term...
-			self:SendTranslatedMessage( Client, "HIVE_TEAMS", {} )
-			ForceEvenTeams()
-		end
-		local HiveShuffle = self:BindCommand( "sh_hiveteams", { "hiveteams" }, HiveTeams )
-		HiveShuffle:Help( "Runs NS2's Hive skill team shuffler." )
+	local function HiveTeams( Client )
+		--Force even teams is such an overconfident term...
+		self:SendTranslatedMessage( Client, "HIVE_TEAMS", {} )
+		ForceEvenTeams()
 	end
+	local HiveShuffle = self:BindCommand( "sh_hiveteams", { "hiveteams" }, HiveTeams )
+	HiveShuffle:Help( "Runs NS2's Hive skill team shuffler." )
 
 	local function ForceRoundStart( Client )
 		local Gamerules = GetGamerules()
@@ -1290,27 +1288,25 @@ function Plugin:CreateGameplayCommands()
 	local ForceRoundStartCommand = self:BindCommand( "sh_forceroundstart", "forceroundstart", ForceRoundStart )
 	ForceRoundStartCommand:Help( "Forces the round to start." )
 
-	if not Shine.IsNS2Combat then
-		local function Eject( Client, Target )
-			local Player = Target:GetControllingPlayer()
-			if not Player then return end
+	local function Eject( Client, Target )
+		local Player = Target:GetControllingPlayer()
+		if not Player then return end
 
-			if Player:isa( "Commander" ) then
-				Player:Eject()
+		if Player:isa( "Commander" ) then
+			Player:Eject()
 
-				self:SendTranslatedMessage( Client, "PLAYER_EJECTED", {
-					TargetName = Player:GetName() or "<unknown>"
-				} )
-			else
-				NotifyError( Client, "ERROR_NOT_COMMANDER", {
-					TargetName = Player:GetName()
-				}, "%s is not a commander.", true, Player:GetName() )
-			end
+			self:SendTranslatedMessage( Client, "PLAYER_EJECTED", {
+				TargetName = Player:GetName() or "<unknown>"
+			} )
+		else
+			NotifyError( Client, "ERROR_NOT_COMMANDER", {
+				TargetName = Player:GetName()
+			}, "%s is not a commander.", true, Player:GetName() )
 		end
-		local EjectCommand = self:BindCommand( "sh_eject", "eject", Eject )
-		EjectCommand:AddParam{ Type = "client" }
-		EjectCommand:Help( "Ejects the given commander." )
 	end
+	local EjectCommand = self:BindCommand( "sh_eject", "eject", Eject )
+	EjectCommand:AddParam{ Type = "client" }
+	EjectCommand:Help( "Ejects the given commander." )
 end
 
 function Plugin:CreateMessageCommands()

--- a/lua/shine/extensions/commbans/shared.lua
+++ b/lua/shine/extensions/commbans/shared.lua
@@ -4,7 +4,6 @@
 
 local Plugin = {}
 
-Plugin.NS2Only = true
 Plugin.NotifyPrefixColour = {
 	255, 50, 0
 }

--- a/lua/shine/extensions/logging.lua
+++ b/lua/shine/extensions/logging.lua
@@ -204,57 +204,55 @@ function Plugin:CastVoteByPlayer( Gamerules, VoteTechID, Player )
 	end
 end
 
-if not Shine.IsNS2Combat then
-	function Plugin:CommLoginPlayer( Chair, Player )
-		if not self.Config.LogCommanderLogin then return end
-		if not Player then return end
+function Plugin:CommLoginPlayer( Chair, Player )
+	if not self.Config.LogCommanderLogin then return end
+	if not Player then return end
 
-		Shine:LogString( StringFormat( "%s became the commander of the %s.",
-			self:GetClientInfo( Server.GetOwner( Player ) ),
-			Shine:GetTeamName( Player:GetTeamNumber(), nil, true )
-		) )
-	end
+	Shine:LogString( StringFormat( "%s became the commander of the %s.",
+		self:GetClientInfo( Server.GetOwner( Player ) ),
+		Shine:GetTeamName( Player:GetTeamNumber(), nil, true )
+	) )
+end
 
-	function Plugin:CommLogout( Chair )
-		if not self.Config.LogCommanderLogin then return end
+function Plugin:CommLogout( Chair )
+	if not self.Config.LogCommanderLogin then return end
 
-		local Commander = Chair:GetCommander()
-		if not Commander then return end
+	local Commander = Chair:GetCommander()
+	if not Commander then return end
 
-		Shine:LogString( StringFormat( "%s stopped commanding the %s.",
-			self:GetClientInfo( Server.GetOwner( Commander ) ),
-			Shine:GetTeamName( Commander:GetTeamNumber(), nil, true )
-		) )
-	end
+	Shine:LogString( StringFormat( "%s stopped commanding the %s.",
+		self:GetClientInfo( Server.GetOwner( Commander ) ),
+		Shine:GetTeamName( Commander:GetTeamNumber(), nil, true )
+	) )
+end
 
-	function Plugin:OnBuildingRecycled( Building, ResearchID )
-		if not self.Config.LogRecycling then return end
+function Plugin:OnBuildingRecycled( Building, ResearchID )
+	if not self.Config.LogRecycling then return end
 
-		local ID = Building:GetId()
-		local Name = Building:GetClassName()
+	local ID = Building:GetId()
+	local Name = Building:GetClassName()
 
-		Shine:LogString( StringFormat( "%s[%s] was recycled.", Name, ID ) )
-	end
+	Shine:LogString( StringFormat( "%s[%s] was recycled.", Name, ID ) )
+end
 
-	function Plugin:OnRecycle( Building, ResearchID )
-		if not self.Config.LogRecycling then return end
+function Plugin:OnRecycle( Building, ResearchID )
+	if not self.Config.LogRecycling then return end
 
-		local ID = Building:GetId()
-		local Name = Building:GetClassName()
-		local Team = Building:GetTeam()
+	local ID = Building:GetId()
+	local Name = Building:GetClassName()
+	local Team = Building:GetTeam()
 
-		if not Team then return end
+	if not Team then return end
 
-		local Commander = Team:GetCommander()
-		if not Commander then return end
+	local Commander = Team:GetCommander()
+	if not Commander then return end
 
-		if ResearchID ~= kTechId.Recycle then return end
+	if ResearchID ~= kTechId.Recycle then return end
 
-		local Client = Server.GetOwner( Commander )
+	local Client = Server.GetOwner( Commander )
 
-		Shine:LogString( StringFormat( "%s began recycling %s[%s].",
-			self:GetClientInfo( Client ), Name, ID ) )
-	end
+	Shine:LogString( StringFormat( "%s began recycling %s[%s].",
+		self:GetClientInfo( Client ), Name, ID ) )
 end
 
 function Plugin:OnConstructInit( Building )

--- a/lua/shine/extensions/pregame/shared.lua
+++ b/lua/shine/extensions/pregame/shared.lua
@@ -7,8 +7,6 @@ Plugin.NotifyPrefixColour = {
 	100, 100, 255
 }
 
-Plugin.NS2Only = true
-
 function Plugin:SetupDataTable()
 	self:AddNetworkMessage( "StartDelay", { StartTime = "integer" }, "Client" )
 

--- a/lua/shine/extensions/tournamentmode/shared.lua
+++ b/lua/shine/extensions/tournamentmode/shared.lua
@@ -4,8 +4,6 @@
 
 local Plugin = {}
 
-Plugin.NS2Only = true
-
 local StringFormat = string.format
 
 --[[

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -674,6 +674,14 @@ do
 			end
 		end
 
+
+		local function IsClientAFK( Client )
+			-- Consider players that have either been stationary for the appropriate amount of time,
+			-- or have never been seen moving as AFK.
+			return AFKKick:IsAFKFor( Client, self.Config.VoteSettings.AFKTimeInSeconds )
+				or not AFKKick:HasClientMoved( Client )
+		end
+
 		local function AddPlayer( Player, Pass )
 			if not Player then return end
 
@@ -695,12 +703,13 @@ do
 
 			local Commander = Player:isa( "Commander" ) and self.Config.IgnoreCommanders
 
-			if AFKEnabled then -- Ignore AFK players in sorting.
-				if Commander or not AFKKick:IsAFKFor( Client, self.Config.VoteSettings.AFKTimeInSeconds ) then
+			if AFKEnabled then
+				if Commander or not IsClientAFK( Client ) then
+					-- Player is a commander or is not AFK, add them to the teams.
 					SortPlayer( Player, Client, Commander, Pass )
-				elseif Pass == 1 then -- Chuck AFK players into the ready room.
+				elseif Pass == 1 then
+					-- Player is AFK, chuck them into the ready room.
 					local Team = Player:GetTeamNumber()
-
 					-- Only move players on playing teams...
 					if Team == 1 or Team == 2 then
 						Gamerules:JoinTeam( Player, 0, nil, true )

--- a/lua/shine/extensions/workshopupdater/server.lua
+++ b/lua/shine/extensions/workshopupdater/server.lua
@@ -34,16 +34,14 @@ local RemainingNotifications = Huge
 local ModChangeTimer = "CheckForModChange"
 
 function Plugin:Initialise()
-	if not Shine.IsNS2Combat then
-		--Have to load manually as Server.GetConfigSetting doesn't exist at the point this is run
-		local ServerConfig = Shine.LoadJSONFile( "config://ServerConfig.json" )
+	-- Have to load manually as Server.GetConfigSetting doesn't exist at the point this is run
+	local ServerConfig = Shine.LoadJSONFile( "config://ServerConfig.json" )
 
-		if ServerConfig then
-			local BackupServers = ServerConfig.settings and ServerConfig.settings.mod_backup_servers
+	if ServerConfig then
+		local BackupServers = ServerConfig.settings and ServerConfig.settings.mod_backup_servers
 
-			if BackupServers and #BackupServers > 0 then
-				return false, "backup server is configured, this plugin is not required"
-			end
+		if BackupServers and #BackupServers > 0 then
+			return false, "backup server is configured, this plugin is not required"
 		end
 	end
 

--- a/lua/shine/init.lua
+++ b/lua/shine/init.lua
@@ -3,7 +3,6 @@
 	Loads stuff.
 ]]
 
---Load order.
 local Scripts = {
 	"lib/debug.lua",
 	"lib/string.lua",
@@ -38,13 +37,7 @@ local Scripts = {
 	"core/shared/autocomplete.lua"
 }
 
-local OnLoadedFuncs = {
-	[ "lib/game.lua" ] = function()
-		Shine.IsNS2Combat = Shine.GetGamemode() == "combat"
-		Shine.BaseGamemode = Shine.IsNS2Combat and "combat" or "ns2"
-	end
-}
-
-Shine.LoadScripts( Scripts, OnLoadedFuncs )
+Shine.BaseGamemode = "ns2"
+Shine.LoadScripts( Scripts )
 
 Shine:Print( "Shine started up successfully." )

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -787,17 +787,7 @@ Hook.Add( "OnMapLoad", "LoadGUIElements", function()
 
 	MouseTracker_ListenToMovement( Listener )
 	MouseTracker_ListenToButtons( Listener )
-
-	if Shine.IsNS2Combat then
-		--Combat has a userdata listener at the top which blocks SGUI scrolling.
-		--So we're going to put ourselves above it.
-		local Listeners = Shine.GetUpValue( MouseTracker_ListenToWheel,
-			"gMouseWheelMovementListeners" )
-
-		TableInsert( Listeners, 1, Listener )
-	else
-		MouseTracker_ListenToWheel( Listener )
-	end
+	MouseTracker_ListenToWheel( Listener )
 end )
 
 include( "lua/shine/lib/gui/base_control.lua" )

--- a/lua/shine/startup.lua
+++ b/lua/shine/startup.lua
@@ -17,7 +17,7 @@ function Shine.LoadScripts( Scripts, OnLoadedFuncs )
 	for i = 1, #Scripts do
 		include( "lua/shine/"..Scripts[ i ] )
 
-		if OnLoadedFuncs[ Scripts[ i ] ] then
+		if OnLoadedFuncs and OnLoadedFuncs[ Scripts[ i ] ] then
 			OnLoadedFuncs[ Scripts[ i ] ]()
 		end
 	end


### PR DESCRIPTION
#### Vote Shuffle
* Players that have never moved since loading in will now be treated as AFK and not placed on a team, regardless of how long they have been idle.

#### Misc
* Removed old NS2:Combat compatibility layer.