### PR TITLE
Numerous bug fixes, improve sh_changelevel, update pregame config

### DIFF
--- a/locale/shine/extensions/basecommands/enGB.json
+++ b/locale/shine/extensions/basecommands/enGB.json
@@ -78,5 +78,7 @@
 	"MAPS": "Maps",
 	"PLUGINS": "Plugins",
 	"VOTE_STOPPED": "stopped the current vote.",
-	"ERROR_GAG_BOT": "Bots cannot be gagged."
+	"ERROR_GAG_BOT": "Bots cannot be gagged.",
+	"UNCLEAR_MAP_NAME": "{MapName} matches multiple maps, a more precise name is required.",
+	"UNKNOWN_MAP_NAME": "{MapName} is not a known map name."
 }

--- a/locale/shine/extensions/voterandom/enGB.json
+++ b/locale/shine/extensions/voterandom/enGB.json
@@ -119,13 +119,13 @@
 
 	"AUTO_SHUFFLE_DISABLED_HIVE_BASED": "Automatic Hive skill based teams have been disabled.",
 	"AUTO_SHUFFLE_DISABLED_KDR_BASED": "Automatic KDR based teams have been disabled.",
-	"AUTO_SHUFFLE_DISABLED_RANDOM_BASED": "Automatic score based teams have been disabled.",
-	"AUTO_SHUFFLE_DISABLED_SCORE_BASED": "Automatic random teams have been disabled.",
+	"AUTO_SHUFFLE_DISABLED_RANDOM_BASED": "Automatic random teams have been disabled.",
+	"AUTO_SHUFFLE_DISABLED_SCORE_BASED": "Automatic score based teams have been disabled.",
 
 	"AUTO_SHUFFLE_ENABLED_HIVE_BASED": "Automatic Hive skill based teams have been enabled.",
 	"AUTO_SHUFFLE_ENABLED_KDR_BASED": "Automatic KDR based teams have been enabled.",
-	"AUTO_SHUFFLE_ENABLED_RANDOM_BASED": "Automatic score based teams have been enabled.",
-	"AUTO_SHUFFLE_ENABLED_SCORE_BASED": "Automatic random teams have been enabled.",
+	"AUTO_SHUFFLE_ENABLED_RANDOM_BASED": "Automatic random teams have been enabled.",
+	"AUTO_SHUFFLE_ENABLED_SCORE_BASED": "Automatic score based teams have been enabled.",
 
 	"ERROR_CONSTRAINTS": "Teams are already sufficiently balanced."
 }

--- a/lua/shine/core/server/permissions.lua
+++ b/lua/shine/core/server/permissions.lua
@@ -898,7 +898,6 @@ local function GetPermissionInheritance( self, GroupName, GroupTable, Command )
 			if IsType( InheritGroups, "string" ) then
 				-- May have forgotten the brackets, so assume it's a single group name.
 				GroupTable.InheritsFrom = { InheritGroups }
-				InheritGroups = GroupTable.InheritGroups
 			else
 				-- Don't try to inherit again.
 				GroupTable.InheritsFrom = nil

--- a/lua/shine/core/server/permissions.lua
+++ b/lua/shine/core/server/permissions.lua
@@ -510,6 +510,11 @@ local function InitialPermissions()
 	}
 end
 
+local function ToBool( Flag )
+	-- Someone is bound to make this mistake...
+	return Flag == true or Flag == "true"
+end
+
 local function AddCommand( Entry, Permissions, Blacklist )
 	if IsType( Entry, "string" ) then
 		if Blacklist or not Permissions.Commands[ Entry ] then
@@ -564,7 +569,7 @@ local function GetGroupPermissions( GroupName, GroupTable )
 		Permissions = InitialPermissions()
 
 		for i = 1, #GroupTable.Commands do
-			AddCommand( GroupTable.Commands[ i ], Permissions, GroupTable.IsBlacklist )
+			AddCommand( GroupTable.Commands[ i ], Permissions, ToBool( GroupTable.IsBlacklist ) )
 		end
 
 		PermissionCache[ GroupName ] = Permissions
@@ -636,7 +641,7 @@ local function BuildPermissions( self, GroupName, GroupTable, Blacklist, Permiss
 	local InheritFromDefault = GroupTable.InheritFromDefault
 	local TopLevelCommands = GroupTable.Commands
 
-	if GroupTable.IsBlacklist == Blacklist then
+	if ToBool( GroupTable.IsBlacklist ) == Blacklist then
 		if IsType( TopLevelCommands, "table" ) then
 			AddPermissionsToTable( TopLevelCommands, Permissions, Blacklist )
 		else
@@ -655,7 +660,7 @@ local function BuildPermissions( self, GroupName, GroupTable, Blacklist, Permiss
 			if not Processed[ DefaultGroup ] then
 				Processed[ DefaultGroup ] = true
 
-				if VerifyGroup( nil, DefaultGroup ) and DefaultGroup.IsBlacklist == Blacklist then
+				if VerifyGroup( nil, DefaultGroup ) and ToBool( DefaultGroup.IsBlacklist ) == Blacklist then
 					AddPermissionsToTable( DefaultGroup.Commands, Permissions, Blacklist )
 				end
 			end
@@ -729,14 +734,15 @@ do
 
 	local function ForEachInheritingGroup( GroupName, Action )
 		for Name, Group in pairs( Shine.UserData.Groups ) do
-			if Group.InheritsFrom and TableHasValue( Group.InheritsFrom, GroupName ) then
-				Action( Name, Group )
+			if IsType( Group.InheritsFrom, "table" ) and TableHasValue( Group.InheritsFrom, GroupName ) then
+				Action( Name )
 			end
 		end
 	end
 
-	local function FlushPermissionsCache( Name )
-		PermissionCache[ Name ] = nil
+	local function IsEntryForRight( Entry, AccessRight )
+		return Entry == AccessRight or ( IsType( Entry, "table" )
+			and Entry.Command == AccessRight )
 	end
 
 	local function IsAllowedEntry( Entry, AccessRight )
@@ -744,28 +750,50 @@ do
 			and Entry.Command == AccessRight and not Entry.Denied )
 	end
 
+	local function FlushPermissionsCacheRecursively( GroupName )
+		if PermissionCache[ GroupName ] then
+			PermissionCache[ GroupName ] = nil
+			ForEachInheritingGroup( GroupName, FlushPermissionsCacheRecursively )
+		end
+	end
+
 	function Shine:AddGroupAccess( GroupName, AccessRight )
 		local Group = self:GetGroupData( GroupName )
 		if not Group then return false end
 
-		for i = #Group.Commands, 1, -1 do
-			local Entry = Group.Commands[ i ]
-			if IsAllowedEntry( Entry, AccessRight ) then
-				return false
+		Shine.TypeCheck( AccessRight, "string", 2, "AddGroupAccess" )
+
+		if ToBool( Group.IsBlacklist ) then
+			-- For a blacklist group, remove the access right from the commands list.
+			local Found
+			for i = #Group.Commands, 1, -1 do
+				local Entry = Group.Commands[ i ]
+				if IsEntryForRight( Entry, AccessRight ) then
+					Found = true
+					TableRemove( Group.Commands, i )
+				end
 			end
 
-			if IsType( Entry, "table" ) and Entry.Denied then
-				TableRemove( Group.Commands, i )
+			if not Found then return false end
+
+			FlushPermissionsCacheRecursively( GroupName )
+		else
+			-- For a whitelist, add the command if its not already present, and remove any
+			-- entries that deny it.
+			for i = #Group.Commands, 1, -1 do
+				local Entry = Group.Commands[ i ]
+				if IsAllowedEntry( Entry, AccessRight ) then
+					return false
+				end
+
+				if IsType( Entry, "table" ) and Entry.Denied then
+					TableRemove( Group.Commands, i )
+				end
 			end
-		end
 
-		Group.Commands[ #Group.Commands + 1 ] = AccessRight
+			Group.Commands[ #Group.Commands + 1 ] = AccessRight
 
-		local CachedPermissions = PermissionCache[ GroupName ]
-		if CachedPermissions and ( not CachedPermissions.Commands[ AccessRight ]
-		or CachedPermissions.Denied[ AccessRight ] ) then
-			PermissionCache[ GroupName ] = nil
-			ForEachInheritingGroup( GroupName, FlushPermissionsCache )
+			FlushPermissionsCacheRecursively( GroupName )
 		end
 
 		self:SaveUsers( true )
@@ -779,20 +807,35 @@ do
 		local Group = self:GetGroupData( GroupName )
 		if not Group then return false end
 
-		local Found
-		for i = #Group.Commands, 1, -1 do
-			local Entry = Group.Commands[ i ]
-			if IsAllowedEntry( Entry, AccessRight ) then
-				Found = true
-				TableRemove( Group.Commands, i )
+		Shine.TypeCheck( AccessRight, "string", 2, "RevokeGroupAccess" )
+
+		if ToBool( Group.IsBlacklist ) then
+			-- For a blacklist, add the right to the commands list if it's not already there.
+			for i = 1, #Group.Commands do
+				local Entry = Group.Commands[ i ]
+				if IsEntryForRight( Entry, AccessRight ) then
+					-- Already blocked.
+					return false
+				end
 			end
-		end
 
-		if not Found then return false end
+			Group.Commands[ #Group.Commands + 1 ] = AccessRight
 
-		if PermissionCache[ GroupName ] then
-			PermissionCache[ GroupName ].Commands[ AccessRight ] = nil
-			ForEachInheritingGroup( GroupName, FlushPermissionsCache )
+			FlushPermissionsCacheRecursively( GroupName )
+		else
+			-- For a whitelist, remove all entries for the given right that allow it.
+			local Found
+			for i = #Group.Commands, 1, -1 do
+				local Entry = Group.Commands[ i ]
+				if IsAllowedEntry( Entry, AccessRight ) then
+					Found = true
+					TableRemove( Group.Commands, i )
+				end
+			end
+
+			if not Found then return false end
+
+			FlushPermissionsCacheRecursively( GroupName )
 		end
 
 		self:SaveUsers( true )
@@ -852,20 +895,23 @@ local function GetPermissionInheritance( self, GroupName, GroupTable, Command )
 		if not IsType( InheritGroups, "table" ) then
 			PrintOnce( "Group with ID %s has a non-array entry for \"InheritsFrom\"!",
 				true, GroupName )
-
-			return false
-		end
-
-		local NumInheritGroups = #InheritGroups
-		if NumInheritGroups == 0 then
-			PrintOnce( "Group with ID %s has an empty \"InheritsFrom\" entry!",
-				true, GroupName )
-
-			return false
+			if IsType( InheritGroups, "string" ) then
+				-- May have forgotten the brackets, so assume it's a single group name.
+				GroupTable.InheritsFrom = { InheritGroups }
+				InheritGroups = GroupTable.InheritGroups
+			else
+				-- Don't try to inherit again.
+				GroupTable.InheritsFrom = nil
+			end
+		else
+			if #InheritGroups == 0 then
+				PrintOnce( "Group with ID %s has an empty \"InheritsFrom\" entry!",
+					true, GroupName )
+			end
 		end
 	end
 
-	local Blacklist = GroupTable.IsBlacklist
+	local Blacklist = ToBool( GroupTable.IsBlacklist )
 	local Permissions = PermissionCache[ GroupName ]
 
 	if not Permissions then
@@ -905,7 +951,7 @@ function Shine:GetGroupPermission( GroupName, GroupTable, ConCommand )
 	end
 
 	local GroupPermissions = GetGroupPermissions( GroupName, GroupTable )
-	local GrantedLevel, Restrictions = GetAccess( GroupPermissions, ConCommand, GroupTable.IsBlacklist )
+	local GrantedLevel, Restrictions = GetAccess( GroupPermissions, ConCommand, ToBool( GroupTable.IsBlacklist ) )
 
 	return IsCommandPermitted( Command, GrantedLevel, Restrictions )
 end
@@ -962,7 +1008,7 @@ function Shine:GetGroupAccess( GroupName, GroupTable, ConCommand, AllowByDefault
 	end
 
 	local GroupPermissions = GetGroupPermissions( GroupName, GroupTable )
-	return GetAccess( GroupPermissions, ConCommand, GroupTable.IsBlacklist ) >= MinimumLevel
+	return GetAccess( GroupPermissions, ConCommand, ToBool( GroupTable.IsBlacklist ) ) >= MinimumLevel
 end
 
 --[[

--- a/lua/shine/core/shared/config.lua
+++ b/lua/shine/core/shared/config.lua
@@ -461,3 +461,42 @@ do
 		return setmetatable( { Rules = {} }, Validator )
 	end
 end
+
+do
+	-- Small helper for common config migration tasks.
+	local Migrator = Shine.TypeDef()
+	Migrator.__call = function( self, Config )
+		for i = 1, #self.Actions do
+			self.Actions[ i ]( Config )
+		end
+		return Config
+	end
+
+	function Migrator:Init()
+		self.Actions = {}
+		return self
+	end
+
+	function Migrator:RenameField( FromName, ToName )
+		self.Actions[ #self.Actions + 1 ] = function( Config )
+			local OldValue = Config[ FromName ]
+			Config[ ToName ] = OldValue
+			Config[ FromName ] = nil
+		end
+		return self
+	end
+
+	function Migrator:UseEnum( FieldWithNumber, EnumValues )
+		self.Actions[ #self.Actions + 1 ] = function( Config )
+			Config[ FieldWithNumber ] = EnumValues[ Config[ FieldWithNumber ] ]
+		end
+		return self
+	end
+
+	function Migrator:ApplyAction( Action )
+		self.Actions[ #self.Actions + 1 ] = Action
+		return self
+	end
+
+	Shine.Migrator = Migrator
+end

--- a/lua/shine/core/shared/hotfix.lua
+++ b/lua/shine/core/shared/hotfix.lua
@@ -6,42 +6,7 @@ local Shine = Shine
 local Hotfixes
 
 if Server then
-	local function ValidClientFilter( Bot )
-		return Shine:IsValidClient( Bot.client )
-	end
-
 	-- Server hotfixes
-	Hotfixes = {
-		[ "lua/bots/Bot.lua" ] = {
-			Hotfix = function()
-				local OldDisconnect
-				OldDisconnect = Shine.ReplaceClassMethod( "Bot", "Disconnect", function( self )
-					-- Get rid of bots whose client has disconnected so it doesn't script error
-					-- getting their ID and break team swapping...
-					Shine.Stream( gServerBots ):Filter( ValidClientFilter )
-
-					-- Make sure this bot has a valid client too.
-					if not Shine:IsValidClient( self.client ) then return end
-
-					return OldDisconnect( self )
-				end )
-			end,
-			ShouldApply = function() return gServerBots ~= nil end
-		},
-		[ "lua/bots/CommanderBot.lua" ] = {
-			Hotfix = function()
-				-- Same as above, but commander bots have their own global table...
-				local OldDisconnect
-				OldDisconnect = Shine.ReplaceClassMethod( "CommanderBot", "Disconnect", function( self )
-					Shine.Stream( gCommanderBots ):Filter( ValidClientFilter )
-
-					-- This will end up calling Bot.Disconnect which is covered above.
-					return OldDisconnect( self )
-				end )
-			end,
-			ShouldApply = function() return gCommanderBots ~= nil end
-		}
-	}
 else
 	-- Client hotfixes
 end

--- a/lua/shine/extensions/adverts/server.lua
+++ b/lua/shine/extensions/adverts/server.lua
@@ -696,7 +696,8 @@ function Plugin:DisplayAdvert( Advert, EventData )
 			Duration = 7,
 			R = R, G = G, B = B,
 			Alignment = Align,
-			Size = 2, FadeIn = 1
+			Size = 2, FadeIn = 1,
+			IgnoreFormat = true
 		}, Targets )
 	end
 end

--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -286,7 +286,7 @@ function Plugin:OnFirstThink()
 	self:UpdateVanillaConfig()
 
 	Hook.SetupClassHook( "NS2Gamerules", "GetFriendlyFire", "GetFriendlyFire", "ActivePre" )
-	Hook.SetupGlobalHook( "GetFriendlyFire", "GetFriendlyFire", "ActivePre" )
+	Hook.SetupGlobalHook( "GetFriendlyFire", "GetFriendlyFire", "ActivePre", { OverrideWithoutWarning = true } )
 
 	local function TakeDamage( OldFunc, self, Damage, Attacker, Inflictor, Point, Direction, ArmourUsed, HealthUsed, DamageType, PreventAlert )
 		local NewDamage, NewArmour, NewHealth = Call( "TakeDamage", self, Damage, Attacker, Inflictor, Point, Direction, ArmourUsed, HealthUsed, DamageType, PreventAlert )

--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -13,7 +13,9 @@ local Notify = Shared.Message
 local pairs = pairs
 local SharedTime = Shared.GetTime
 local StringExplode = string.Explode
+local StringFind = string.find
 local StringFormat = string.format
+local StringMatch = string.match
 local TableConcat = table.concat
 local TableEmpty = table.Empty
 local TableShuffle = table.Shuffle
@@ -919,7 +921,83 @@ function Plugin:CreateAdminCommands()
 	KickCommand:Help( "Kicks the given player." )
 
 	local function ChangeLevel( Client, MapName )
-		MapCycle_ChangeMap( MapName )
+		local Cycle = MapCycle_GetMapCycle()
+		local FoundMap
+		local KnownMaps = {}
+
+		-- Check the map cycle for the given map first to find maps in mods that are mounted
+		-- by the cycle.
+		if IsType( Cycle, "table" ) and IsType( Cycle.maps, "table" ) then
+			for i = 1, #Cycle.maps do
+				local Entry = Cycle.maps[ i ]
+				local EntryName = IsType( Entry, "table" ) and Entry.map or Entry
+				if EntryName == MapName then
+					FoundMap = MapName
+					break
+				end
+
+				KnownMaps[ EntryName ] = true
+			end
+		end
+
+		if not FoundMap then
+			-- Map was not in the cycle, so check the maps folder for all .level files starting with ns2_.
+			-- This will find vanilla maps, and any mounted mod maps.
+			local LevelFiles = {}
+			Shared.GetMatchingFileNames( "maps/*.level", false, LevelFiles )
+			for i = 1, #LevelFiles do
+				local Map = LevelFiles[ i ]
+				local LevelName = StringMatch( Map, "([^/]+)%.level$" )
+				-- Only check maps starting with ns2_ to avoid the menu level.
+				if StringMatch( LevelName, "^ns2_" ) then
+					if LevelName == MapName then
+						FoundMap = MapName
+						break
+					end
+					KnownMaps[ LevelName ] = true
+				end
+			end
+		end
+
+		if not FoundMap then
+			-- Still don't know what map it is, try adding ns2_ at the start.
+			local MapWithNS2 = "ns2_"..MapName
+			if KnownMaps[ MapWithNS2 ] then
+				FoundMap = MapWithNS2
+			else
+				-- Doesn't match a known map even with ns2_, so try to find a single matching
+				-- map that contains the given name.
+				local MatchingMapName
+				for KnownMap in pairs( KnownMaps ) do
+					if StringFind( KnownMap, MapName, 1, true ) then
+						if MatchingMapName then
+							-- More than one map matches, so ask for a more precise name.
+							NotifyError( Client, "UNCLEAR_MAP_NAME", {
+								MapName = MapName
+							}, "%s matches multiple maps, a more precise name is required.", true, MapName )
+							return
+						end
+
+						MatchingMapName = KnownMap
+					end
+				end
+
+				if MatchingMapName then
+					-- Exactly one map matched the given name, so use it.
+					FoundMap = MatchingMapName
+				end
+			end
+		end
+
+		if not FoundMap then
+			-- No maps match the given name, give up.
+			NotifyError( Client, "UNKNOWN_MAP_NAME", {
+				MapName = MapName
+			}, "%s is not a known map name.", true, MapName )
+			return
+		end
+
+		MapCycle_ChangeMap( FoundMap )
 	end
 	local ChangeLevelCommand = self:BindCommand( "sh_changelevel", "map", ChangeLevel )
 	ChangeLevelCommand:AddParam{ Type = "string", TakeRestOfLine = true,

--- a/lua/shine/extensions/basecommands/shared.lua
+++ b/lua/shine/extensions/basecommands/shared.lua
@@ -38,6 +38,9 @@ function Plugin:SetupDataTable()
 		TargetName = {
 			TargetName = self:GetNameNetworkField()
 		},
+		MapName = {
+			MapName = "string (64)"
+		},
 		Gagged = {
 			TargetName = self:GetNameNetworkField(),
 			Duration = "integer (0 to 1800)"
@@ -89,6 +92,9 @@ function Plugin:SetupDataTable()
 			"ERROR_TICKRATE_CONSTRAINT", "ERROR_SENDRATE_CONSTRAINT",
 			"ERROR_SENDRATE_MOVE_CONSTRAINT", "ERROR_MOVERATE_CONSTRAINT",
 			"ERROR_MOVERATE_SENDRATE_CONSTRAINT"
+		},
+		[ MessageTypes.MapName ] = {
+			"UNKNOWN_MAP_NAME", "UNCLEAR_MAP_NAME"
 		}
 	} )
 

--- a/lua/shine/extensions/chatbox/chatline.lua
+++ b/lua/shine/extensions/chatbox/chatline.lua
@@ -232,6 +232,12 @@ function ChatLine:GetWrappedLabel()
 end
 
 function ChatLine:GetSize()
+	if not self.ComputedWrapping and self.MaxWidth then
+		-- Ensure wrapping is computed before returning the size, otherwise we may return an older
+		-- size value if we've been re-used.
+		self:InvalidateLayout( true )
+	end
+
 	local Width = self.PreLabel:GetTextWidth() + self.MessageLabel:GetTextWidth()
 	local Height = self.MessageLabel:GetTextHeight( "!" )
 

--- a/lua/shine/extensions/chatbox/client.lua
+++ b/lua/shine/extensions/chatbox/client.lua
@@ -477,7 +477,7 @@ function Plugin:CreateChatbox()
 		Fill = true,
 		Margin = Spacing( 0, 0, 0, PaddingUnit )
 	}
-	Box.BufferAmount = 5
+	Box.BufferAmount = PaddingUnit:GetValue()
 	ChatBoxLayout:AddElement( Box )
 
 	self.ChatBox = Box

--- a/lua/shine/extensions/pingtracker/server.lua
+++ b/lua/shine/extensions/pingtracker/server.lua
@@ -18,11 +18,11 @@ Plugin.HasConfig = true
 Plugin.ConfigName = "PingTracker.json"
 
 Plugin.DefaultConfig = {
-	MaxPing = 200, --Maximum allowed average ping.
-	MaxJitter = 50, --Maximum allowed average jitter.
-	Warn = true, --Should players be warned first?
-	MeasureInterval = 1, --Time in seconds between measurements.
-	CheckInterval = 60, --Interval to check averages and warn/kick.
+	MaxPing = 200, -- Maximum allowed average ping.
+	MaxJitter = 50, -- Maximum allowed average jitter.
+	Warn = true, -- Should players be warned first?
+	MeasureInterval = 1, -- Time in seconds between measurements.
+	CheckInterval = 60 -- Interval to check averages and warn/kick.
 }
 
 Plugin.CheckConfig = true
@@ -35,7 +35,6 @@ function Plugin:Initialise()
 
 	if self.Enabled ~= nil then
 		local Clients, Count = Shine.GetAllClients()
-
 		for i = 1, Count do
 			local Client = Clients[ i ]
 			self:ClientConnect( Client )
@@ -48,8 +47,9 @@ function Plugin:Initialise()
 end
 
 function Plugin:ClientConnect( Client )
-	local Time = Shared.GetTime()
+	if not Client or Client:GetIsVirtual() then return end
 
+	local Time = SharedGetTime()
 	local FirstCheck = Time + 30
 	local NextAverage = FirstCheck + self.Config.CheckInterval
 

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -658,27 +658,6 @@ do
 			AddTeamPreference( Player, Client, Preference )
 		end
 
-		local function DisconnectBot( Client )
-			local Bots = gServerBots
-			local Found = false
-
-			if Bots then
-				-- No reference back to the bot, so have to search the table...
-				for i = 1, #Bots do
-					if Bots[ i ] and Bots[ i ].client == Client then
-						Found = true
-						Bots[ i ]:Disconnect()
-						break
-					end
-				end
-			end
-
-			if not Found then
-				Server.DisconnectClient( Client )
-			end
-		end
-
-
 		local function IsClientAFK( Client )
 			-- Consider players that have either been stationary for the appropriate amount of time,
 			-- or have never been seen moving as AFK.
@@ -699,7 +678,7 @@ do
 			-- Bot and we don't want to deal with them, so kick them out.
 			if Client:GetIsVirtual() and not self.Config.ApplyToBots then
 				if Pass == 1 then
-					DisconnectBot( Client )
+					Server.DisconnectClient( Client )
 				end
 
 				return

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -310,9 +310,13 @@ function EnforcementPolicy:JoinTeam( Plugin, Gamerules, Player, NewTeam, Force )
 		if ( Team == 0 or Team == 3 ) and Shine.IsPlayingTeam( NewTeam ) then
 			Player.ShineRandomised = true -- Prevent an infinite loop!
 
-			Plugin:NotifyTranslated( Player, Plugin.LastShuffleMode == Plugin.ShuffleMode.HIVE and "PLACED_ON_HIVE_TEAM"
-				or "PLACED_ON_RANDOM_TEAM" )
-			Plugin:JoinRandomTeam( Player )
+			local TeamJoined = Plugin:JoinRandomTeam( Gamerules, Player )
+			if TeamJoined ~= NewTeam then
+				-- Notify the player why they're not on their chosen team.
+				local Message = Plugin.LastShuffleMode == Plugin.ShuffleMode.HIVE and "PLACED_ON_HIVE_TEAM"
+					or "PLACED_ON_RANDOM_TEAM"
+				Plugin:NotifyTranslated( Client, Message )
+			end
 
 			return false
 		end
@@ -838,37 +842,37 @@ end
 --[[
 	Moves a single player onto a random team.
 ]]
-function Plugin:JoinRandomTeam( Player )
-	local Gamerules = GetGamerules()
-	if not Gamerules then return end
-
+function Plugin:JoinRandomTeam( Gamerules, Player )
 	local Team1 = Gamerules:GetTeam( kTeam1Index ):GetNumPlayers()
 	local Team2 = Gamerules:GetTeam( kTeam2Index ):GetNumPlayers()
 
 	if Team1 < Team2 then
 		Gamerules:JoinTeam( Player, 1 )
-	elseif Team2 < Team1 then
+		return 1
+	end
+
+	if Team2 < Team1 then
 		Gamerules:JoinTeam( Player, 2 )
-	else
-		if self.LastShuffleMode == self.ShuffleMode.HIVE then
-			local Team1Players = Gamerules.team1:GetPlayers()
-			local Team2Players = Gamerules.team2:GetPlayers()
+		return 2
+	end
 
-			local TeamToJoin = self:GetOptimalTeamForPlayer( Player,
-				Team1Players, Team2Players, self.SkillGetters.GetHiveSkill )
+	if self.LastShuffleMode == self.ShuffleMode.HIVE then
+		local Team1Players = Gamerules.team1:GetPlayers()
+		local Team2Players = Gamerules.team2:GetPlayers()
 
-			if TeamToJoin then
-				Gamerules:JoinTeam( Player, TeamToJoin )
-				return
-			end
-		end
+		local TeamToJoin = self:GetOptimalTeamForPlayer( Player,
+			Team1Players, Team2Players, self.SkillGetters.GetHiveSkill )
 
-		if Random() < 0.5 then
-			Gamerules:JoinTeam( Player, 1 )
-		else
-			Gamerules:JoinTeam( Player, 2 )
+		if TeamToJoin then
+			Gamerules:JoinTeam( Player, TeamToJoin )
+			return TeamToJoin
 		end
 	end
+
+	local TeamNumber = Random() < 0.5 and 1 or 2
+	Gamerules:JoinTeam( Player, TeamNumber )
+
+	return TeamNumber
 end
 
 function Plugin:SetGameState( Gamerules, NewState, OldState )

--- a/lua/shine/lib/gui/objects/scrollbar.lua
+++ b/lua/shine/lib/gui/objects/scrollbar.lua
@@ -54,7 +54,7 @@ end
 
 function Scrollbar:SetScrollSize( Size )
 	local OldPos = self.Pos or 0
-	local OldDiff = self.Size.y - self.ScrollSizeVec.y
+	local OldDiff = self:GetDiffSize()
 
 	self.ScrollSize = Size
 
@@ -66,8 +66,8 @@ function Scrollbar:SetScrollSize( Size )
 
 	self.Bar:SetSize( self.ScrollSizeVec )
 
-	local NewDiff = self.Size.y - self.ScrollSizeVec.y
-	--If the scrolling size has shrunk, we may need to move up.
+	local NewDiff = self:GetDiffSize()
+	-- If the scrolling size has shrunk, we may need to move up.
 	if NewDiff < OldDiff then
 		self:SetScroll( OldPos )
 	end
@@ -77,14 +77,12 @@ end
 	Sets how far down the scroll bar is.
 ]]
 function Scrollbar:SetScroll( Scroll, Smoothed )
-	local Diff = self.Size.y - self.ScrollSizeVec.y
+	local Diff = self:GetDiffSize()
 
 	Scroll = Clamp( Scroll, 0, Diff )
 
 	self.Pos = Scroll
-
 	self.BarPos.y = Scroll
-
 	self.Bar:SetPosition( self.BarPos )
 
 	if self.Parent and self.Parent.OnScrollChange then
@@ -97,15 +95,7 @@ function Scrollbar:GetDiffSize()
 end
 
 function Scrollbar:ScrollToBottom( Smoothed )
-	local Diff = self.Size.y - self.ScrollSizeVec.y
-
-	self.Pos = Diff
-	self.BarPos.y = Diff
-	self.Bar:SetPosition( self.BarPos )
-
-	if self.Parent and self.Parent.OnScrollChange then
-		self.Parent:OnScrollChange( Diff, Diff, Smoothed )
-	end
+	self:SetScroll( self:GetDiffSize() )
 end
 
 local GetCursorPos

--- a/test/core/shared/config.lua
+++ b/test/core/shared/config.lua
@@ -178,3 +178,22 @@ UnitTest:Test( "VerifyConfig does nothing when config matches", function( Assert
 	Assert.False( "Config should not have been updated", Updated )
 	Assert.DeepEquals( "Config values should remain unchanged", ExpectedConfig, ProvidedConfig )
 end )
+
+UnitTest:Test( "Migrator", function( Assert )
+	local Migrator = Shine.Migrator()
+		:RenameField( "A", "B" )
+		:UseEnum( "Mode", { "Mode1", "Mode2", "Mode3" } )
+		:ApplyAction( function( Config )
+			Config.ActionApplied = true
+		end )
+
+	local Config = {
+		A = "Value for A",
+		Mode = 2
+	}
+	Assert.DeepEquals( "Migrator should apply actions as expected", {
+		B = "Value for A",
+		Mode = "Mode2",
+		ActionApplied = true
+	}, Migrator( Config ) )
+end )

--- a/test/extensions/ban.lua
+++ b/test/extensions/ban.lua
@@ -1,0 +1,152 @@
+--[[
+	Bans plugin unit test.
+]]
+
+local UnitTest = Shine.UnitTest
+local Plugin = UnitTest:LoadExtension( "ban" )
+if not Plugin then return end
+
+Plugin = UnitTest.MockOf( Plugin )
+
+UnitTest:Test( "AddNS2BansIntoTable - Adds missing bans and updates existing ones", function( Assert )
+	local VanillaBans = {
+		{
+			name = "Ignore as it has no id value", time = 0
+		},
+		{
+			id = 123, name = "Test", reason = "Testing.", time = os.time() + 1000
+		},
+		{
+			id = 456, name = "AnotherTest", reason = "More testing.", time = "not a number"
+		},
+		{
+			id = 789,
+			name = "WithDuration",
+			reason = "Even more testing.",
+			time = 1000,
+			duration = 2000,
+			bannerid = 123456,
+			bannedby = "Someone"
+		},
+		{
+			id = 987, name = "WithPermaBan", time = 0
+		},
+		{
+			name = "An invalid ID", id = "abc"
+		}
+	}
+
+	local OutputTable = {
+		[ "123" ] = {
+			UnbanTime = 0,
+			Reason = "",
+			Name = "Test"
+		}
+	}
+	local VanillaIDs, Edited = Plugin:AddNS2BansIntoTable( VanillaBans, OutputTable )
+
+	Assert.DeepEquals( "Should output all valid IDs", {
+		[ "123" ] = true,
+		[ "456" ] = true,
+		[ "789" ] = true,
+		[ "987" ] = true
+	}, VanillaIDs )
+	Assert.True( "Should be marked as edited", Edited )
+	Assert.DeepEquals( "Should have added/updated the passed in table", {
+		[ "123" ] = {
+			-- Valid time values should be passed through as-is.
+			UnbanTime = VanillaBans[ 2 ].time,
+			BannerID = 0,
+			BannedBy = "<unknown>",
+			Name = "Test",
+			Reason = "Testing.",
+			-- Duration should be derived from the time.
+			Duration = 1000
+		},
+		[ "456" ] = {
+			-- Non-number values should be interpreted as 0.
+			UnbanTime = 0,
+			BannerID = 0,
+			BannedBy = "<unknown>",
+			Name = "AnotherTest",
+			Reason = "More testing.",
+			-- Duration should also be 0 in this case.
+			Duration = 0
+		},
+		[ "789" ] = {
+			UnbanTime = 1000,
+			-- Should pick up on the banner values.
+			BannerID = 123456,
+			BannedBy = "Someone",
+			Name = "WithDuration",
+			Reason = "Even more testing.",
+			-- Duration should be derived from the 'duration' field.
+			Duration = 2000
+		},
+		[ "987" ] = {
+			UnbanTime = 0,
+			BannerID = 0,
+			BannedBy = "<unknown>",
+			Name = "WithPermaBan",
+			-- Duration should be 0 as the time is 0.
+			Duration = 0
+		}
+	}, OutputTable )
+end )
+
+UnitTest:Test( "AddNS2BansIntoTable - Does nothing if all bans match", function( Assert )
+	local VanillaBans = {
+		{
+			name = "Ignore as it has no id value", time = 0
+		},
+		{
+			id = 123,
+			name = "Test",
+			reason = "Testing.",
+			time = os.time() + 100,
+			duration = 1000,
+			bannerid = 0,
+			bannedby = "<unknown>"
+		},
+		{
+			id = 456,
+			name = "AnotherTest",
+			reason = "More testing.",
+			time = 0,
+			duration = 0,
+			bannerid = 0,
+			bannedby = "<unknown>"
+		},
+		{
+			name = "An invalid ID", id = "abc"
+		}
+	}
+
+	local OutputTable = {
+		[ "123" ] = {
+			UnbanTime = VanillaBans[ 2 ].time,
+			BannerID = 0,
+			BannedBy = "<unknown>",
+			Name = "Test",
+			Reason = "Testing.",
+			Duration = 1000
+		},
+		[ "456" ] = {
+			UnbanTime = 0,
+			BannerID = 0,
+			BannedBy = "<unknown>",
+			Name = "AnotherTest",
+			Reason = "More testing.",
+			Duration = 0
+		}
+	}
+	local OriginalBans = table.Copy( OutputTable )
+
+	local VanillaIDs, Edited = Plugin:AddNS2BansIntoTable( VanillaBans, OutputTable )
+	Assert.Falsy( "Should not be marked as edited", Edited )
+	Assert.DeepEquals( "Should output all valid IDs", {
+		[ "123" ] = true,
+		[ "456" ] = true
+	}, VanillaIDs )
+	Assert.DeepEquals( "Should have made no changes to the given table", OriginalBans, OutputTable )
+end )


### PR DESCRIPTION
#### Bans
* Fixed a script error that could occur when a vanilla ban entry has a non-number `time` value.

#### Base Commands
* `sh_changelevel` (`!map`) now accepts map names without the `ns2_` prefix, as well as partial map names. It will first attempt to find an exact matching map, then add `ns2_` to the start, and finally search all known maps for exactly one that contains the given map name. If a map is unknown (i.e. not in the map cycle or mounted as a `.level` file), it will no longer attempt to load it blindly and instead display an error message.

#### Chatbox
* Fixed an empty space being left at the bottom of the chatbox sometimes after many messages have been received.

#### Pregame
* The default start delay time is now 30 seconds.
* Updated the [configuration format](https://github.com/Person8880/Shine/wiki/Pregame#config) to be more clear around time units and the selected mode.

#### Vote Shuffle
* Fixed an incorrect message being displayed when automatic score based/random teams are enabled/disabled.
* When auto-assigning is enabled, the "you have been placed on a team" message will no longer show when the assigned team matches the desired team.

#### User Config
* Fixed a script error when evaluating permissions if the `InheritsFrom` value in a group is not an array.
* String values for `InheritsFrom` are now interpreted as a single group whose name is the given string, rather than ignored.
* Using the string value `"true"` for the `IsBlacklist` group flag is now interpreted the same as boolean `true`.

#### API
* Hooks are no longer duplicated when `Hook.SetupClassHook` or `Hook.SetupGlobalHook` are called with the same hook name and function/class method.
* Adding the same hook name more than once with `Hook.SetupClassHook` or `Hook.SetupGlobalHook` against a different function/class method will now log a warning message.
* Providing an unknown mode name to `Hook.SetupClassHook` or `Hook.SetupGlobalHook` will now result in an error rather than silently failing.