### PR TITLE
Build 328 fixes, SGUI improvements

### DIFF
--- a/locale/shine/core/enGB.json
+++ b/locale/shine/core/enGB.json
@@ -49,6 +49,7 @@
 	"VIEW_WEB_IN_STEAM_DESCRIPTION": "View web pages in the Steam overlay.",
 	"REPORT_ERRORS_DESCRIPTION": "Report script errors caused by Shine.",
 	"ANIMATE_UI_DESCRIPTION": "Use animations in the UI.",
+	"SKIN_DESCRIPTION": "GUI skin:",
 	"CLIENT_CONFIG_MENU": "Client Config",
 	"ERROR_CANT_TARGET_SELF": "You cannot target yourself with this command.",
 	"ERROR_NO_MATCHING_PLAYER": "No player matching '{PlayerName}' was found.",

--- a/lua/shine/core/client/adminmenu.lua
+++ b/lua/shine/core/client/adminmenu.lua
@@ -691,7 +691,7 @@ do
 
 		CommandsList[ #CommandsList + 1 ] = Data
 
-		if Commands then
+		if SGUI.IsValid( Commands ) then
 			if ShouldAdd then
 				Commands:AddCategory( Category )
 			end

--- a/lua/shine/core/client/config.lua
+++ b/lua/shine/core/client/config.lua
@@ -14,7 +14,8 @@ local DefaultConfig = {
 	AnimateUI = true,
 	DebugLogging = false,
 	ExpandAdminMenuTabs = true,
-	ExpandConfigMenuTabs = true
+	ExpandConfigMenuTabs = true,
+	Skin = "Default"
 }
 
 function Shine:CreateClientBaseConfig()
@@ -137,6 +138,48 @@ for i = 1, #Options do
 	if Shine.Config[ Option.Data[ 2 ] ] == Option.MessageState or Option.AlwaysShowMessage then
 		Shine.AddStartupMessage( Option.Message )
 	end
+end
+
+do
+	local SGUI = Shine.GUI
+	Shine:RegisterClientCommand( "sh_setskin", function( SkinName )
+		local Skins = SGUI.SkinManager:GetSkinsByName()
+		if not Skins[ SkinName ] then
+			Notify( StringFormat( "%s is not a valid skin name.", SkinName ) )
+			return
+		end
+
+		if Shine.Config.Skin == SkinName then return end
+
+		Shine.Config.Skin = SkinName
+		SGUI.SkinManager:SetSkin( SkinName )
+
+		Notify( StringFormat( "Default skin changed to: %s.", SkinName ) )
+
+		Shine:SaveClientBaseConfig()
+	end ):AddParam{
+		Type = "string", TakeRestOfLine = true
+	}
+
+	table.insert( Options, 1, {
+		Type = "Dropdown",
+		Command = "sh_setskin",
+		Description = "SKIN_DESCRIPTION",
+		ConfigOption = "Skin",
+		Options = function()
+			local Skins = SGUI.SkinManager:GetSkinsByName()
+			local Options = {}
+
+			for Skin in SortedPairs( Skins ) do
+				Options[ #Options + 1 ] = {
+					Text = Skin,
+					Value = Skin
+				}
+			end
+
+			return Options
+		end
+	} )
 end
 
 Script.Load( "lua/shine/core/client/config_gui.lua" )

--- a/lua/shine/core/client/config_gui.lua
+++ b/lua/shine/core/client/config_gui.lua
@@ -187,6 +187,42 @@ local SettingsTypes = {
 			return CheckBox
 		end
 	},
+	Dropdown = {
+		Create = function( Panel, Entry )
+			local DropdownPanel = Panel:Add( "Panel" )
+			DropdownPanel:SetStyleName( "RadioBackground" )
+			DropdownPanel:SetAutoSize( UnitVector(
+				Percentage( 100 ),
+				Units.Auto()
+			) )
+
+			local TranslationSource = Entry.TranslationSource or "Core"
+			local VerticalLayout = SGUI.Layout:CreateLayout( "Vertical" )
+
+			local Description = DropdownPanel:Add( "Label" )
+			Description:SetFontScale( GetSmallFont() )
+			Description:SetText( Locale:GetPhrase( TranslationSource, Entry.Description ) )
+			Description:SetAutoSize( UnitVector( Percentage( 100 ), Units.Auto() ) )
+			Description:SetMargin( Spacing( 0, 0, 0, HighResScaled( 8 ) ) )
+			VerticalLayout:AddElement( Description )
+
+			local Dropdown = DropdownPanel:Add( "Dropdown" )
+			Dropdown:SetFontScale( GetSmallFont() )
+			Dropdown:AddOptions( Shine.IsCallable( Entry.Options ) and Entry.Options() or Entry.Options )
+			Dropdown:AddPropertyChangeListener( "SelectedOption", function( Option )
+				Shared.ConsoleCommand( Entry.Command.." "..( Option.Value or Option.Text ) )
+			end )
+			Dropdown:SetAutoSize( UnitVector( Percentage( 100 ), HighResScaled( 32 ) ) )
+			VerticalLayout:AddElement( Dropdown )
+
+			local CurrentValue = GetConfiguredValue( Entry )
+			Dropdown:SelectOption( CurrentValue )
+
+			DropdownPanel:SetLayout( VerticalLayout, true )
+
+			return DropdownPanel
+		end
+	},
 	Radio = {
 		Create = function( Panel, Entry )
 			local RadioPanel = Panel:Add( "Panel" )

--- a/lua/shine/core/client/config_gui.lua
+++ b/lua/shine/core/client/config_gui.lua
@@ -202,7 +202,7 @@ local SettingsTypes = {
 			local Description = RadioPanel:Add( "Label" )
 			Description:SetFontScale( GetSmallFont() )
 			Description:SetText( Locale:GetPhrase( TranslationSource, Entry.Description ) )
-			Description:SetAutoSize( UnitVector( Percentage( 100 ), HighResScaled( 24 ) ) )
+			Description:SetAutoSize( UnitVector( Percentage( 100 ), Units.Auto() ) )
 			Description:SetMargin( Spacing( 0, 0, 0, HighResScaled( 8 ) ) )
 			VerticalLayout:AddElement( Description )
 

--- a/lua/shine/core/shared/config.lua
+++ b/lua/shine/core/shared/config.lua
@@ -61,15 +61,22 @@ end
 local JSONErrorHandler = Shine.BuildErrorHandler( "JSON serialisation error" )
 function Shine.SaveJSONFile( Table, Path, Settings )
 	Settings = Settings or JSONSettings
+
 	local FormattingOptions = {
 		PrettyPrint = Settings.indent or false,
 		IndentSize = 4 * ( Settings.level or 1 )
 	}
+	if not FormattingOptions.PrettyPrint then
+		-- No point having consistent order if not pretty printing.
+		FormattingOptions.TableIterator = pairs
+	end
+
 	local Success, JSON = xpcall( TableToJSON, JSONErrorHandler, Table, FormattingOptions )
 	if not Success then
 		-- Fallback to DKJSON if there's somehow a bug in our serialiser.
 		JSON = Encode( Table, Settings )
 	end
+
 	return WriteFile( Path, JSON )
 end
 

--- a/lua/shine/core/shared/config.lua
+++ b/lua/shine/core/shared/config.lua
@@ -15,9 +15,6 @@ local TableSetField = table.SetField
 local TableToJSON = table.ToJSON
 local type = type
 
--- Make JSON encoding always have consistent order.
-Shine.SetUpValue( Encode, "pairs", SortedPairs, true )
-
 local JSONSettings = { indent = true, level = 1 }
 
 local IsType = Shine.IsType

--- a/lua/shine/core/shared/webpage.lua
+++ b/lua/shine/core/shared/webpage.lua
@@ -15,6 +15,8 @@ local Hook = Shine.Hook
 local Locale = Shine.Locale
 local SGUI = Shine.GUI
 
+local Binder = require "shine/lib/gui/binding/binder"
+
 local CloseButtonCol = Colour( 0.6, 0.3, 0.1, 1 )
 local CloseButtonHighlight = Colour( 0.8, 0.4, 0.1, 1 )
 local SteamButtonCol = Colour( 0.1, 0.6, 0.2, 1 )
@@ -218,7 +220,15 @@ function Shine:OpenWebpage( URL, TitleText )
 	Webpage:SetPos( Vector( -WebpageWidth * 0.5, -WebpageHeight * 0.5 + TitleBarH * 0.5, 0 ) )
 	Webpage:LoadURL( URL, WebpageWidth, WebpageHeight )
 
+	-- Hide/show the loading text depending on whether the page is actually loading.
+	-- Some pages may have transparency which would make the loading text visible behind them.
+	Binder():FromElement( Webpage, "IsLoading" )
+		:ToElement( LoadingText, "IsVisible" )
+		:BindProperty()
+
 	SGUI:EnableMouse( true )
+
+	return Webpage
 end
 
 function Shine:CloseWebPage()

--- a/lua/shine/core/shared/webpage.lua
+++ b/lua/shine/core/shared/webpage.lua
@@ -21,6 +21,7 @@ local CloseButtonCol = Colour( 0.6, 0.3, 0.1, 1 )
 local CloseButtonHighlight = Colour( 0.8, 0.4, 0.1, 1 )
 local SteamButtonCol = Colour( 0.1, 0.6, 0.2, 1 )
 local SteamButtonHighlight = Colour( 0.15, 0.9, 0.3, 1 )
+local ButtonTextColour = Colour( 1, 1, 1, 1 )
 
 local LoadingFont = Fonts.kAgencyFB_Large
 local TitleFont = Fonts.kAgencyFB_Small
@@ -92,7 +93,8 @@ local function OpenInSteamPopup( URL, ScrW, ScrH, TitleBarH, Font, TextScale )
 		Text = Locale:GetPhrase( "Core", "NOW" ),
 		Font = Font,
 		ActiveCol = CloseButtonHighlight,
-		InactiveCol = CloseButtonCol
+		InactiveCol = CloseButtonCol,
+		TextColour = ButtonTextColour
 	}
 	if TextScale then
 		NowButton:SetTextScale( TextScale )
@@ -115,7 +117,8 @@ local function OpenInSteamPopup( URL, ScrW, ScrH, TitleBarH, Font, TextScale )
 		Text = Locale:GetPhrase( "Core", "ALWAYS" ),
 		Font = Font,
 		ActiveCol = SteamButtonHighlight,
-		InactiveCol = SteamButtonCol
+		InactiveCol = SteamButtonCol,
+		TextColour = ButtonTextColour
 	}
 	if TextScale then
 		AlwaysButton:SetTextScale( TextScale )
@@ -150,7 +153,7 @@ function Shine:OpenWebpage( URL, TitleText )
 	local WidthMult = Max( W / 1920, 1 )
 	local HeightMult = Max( H / 1080, 1 )
 
-	local TitleBarH = 24
+	local TitleBarH = 32
 	local Font = Fonts.kAgencyFB_Small
 	local TextScale
 	if H > SGUI.ScreenHeight.Normal and H <= SGUI.ScreenHeight.Large then
@@ -194,7 +197,8 @@ function Shine:OpenWebpage( URL, TitleText )
 		Font = Font,
 		TextScale = SteamButtonScale * ( TextScale or Vector( 1, 1, 0 ) ),
 		ActiveCol = SteamButtonHighlight,
-		InactiveCol = SteamButtonCol
+		InactiveCol = SteamButtonCol,
+		TextColour = ButtonTextColour
 	}
 
 	function OpenInSteam:DoClick()

--- a/lua/shine/extensions/ban/client.lua
+++ b/lua/shine/extensions/ban/client.lua
@@ -119,59 +119,33 @@ function Plugin:SetupAdminMenu()
 		SearchLayout:AddElement( MenuButton )
 		Layout:AddElement( SearchLayout )
 
-		local Menu
+		MenuButton:SetOpenMenuOnClick( function( Button )
+			return {
+				MenuPos = Vector2( -IDEntry:GetSize().x, Button:GetSize().y ),
+				Size = Vector2( IDEntry:GetSize().x + Button:GetSize().x, HighResScaled( 24 ):GetValue() ),
+				Populate = function( Menu )
+					Menu:SetMaxVisibleButtons( 12 )
+					Shine.AdminMenu:DestroyOnClose( Menu )
 
-		function MenuButton.DoClick( Button )
-			if Menu then
-				Shine.AdminMenu:DontDestroyOnClose( Menu )
-				MenuButton:SetForceHighlight( false )
+					Menu:CallOnRemove( function()
+						Shine.AdminMenu:DontDestroyOnClose( Menu )
+					end )
 
-				if Menu:IsValid() then
-					Menu:Destroy()
-				end
+					local PlayerEnts = GetEnts( "PlayerInfoEntity" )
+					for _, Ent in IterateEntList( PlayerEnts ) do
+						local SteamID = tostring( Ent.steamId )
+						local Name = Ent.playerName
 
-				Menu = nil
-
-				return
-			end
-
-			local Pos = Button:GetScreenPos()
-			Pos.x = Pos.x - IDEntry:GetSize().x
-			Pos.y = Pos.y + Button:GetSize().y
-
-			Menu = SGUI:Create( "Menu" )
-			Menu:SetPos( Pos )
-			Menu:SetButtonSize( Vector2( IDEntry:GetSize().x + Button:GetSize().x, HighResScaled( 24 ):GetValue(), 0 ) )
-			Menu:CallOnRemove( function()
-				-- Prevent clicking the menu button re-opening the menu instead of closing it.
-				if Menu.DestroyedBy == MenuButton then return end
-
-				Shine.AdminMenu:DontDestroyOnClose( Menu )
-				MenuButton:SetForceHighlight( false )
-				Menu = nil
-			end )
-			Menu:SetMaxVisibleButtons( 12 )
-			Shine.AdminMenu:DestroyOnClose( Menu )
-
-			MenuButton:SetForceHighlight( true )
-
-			local PlayerEnts = GetEnts( "PlayerInfoEntity" )
-
-			for _, Ent in IterateEntList( PlayerEnts ) do
-				local SteamID = tostring( Ent.steamId )
-				local Name = Ent.playerName
-
-				Menu:AddButton( Name, function()
-					if SGUI.IsValid( IDEntry ) then
-						IDEntry:SetText( SteamID )
+						Menu:AddButton( Name, function()
+							if SGUI.IsValid( IDEntry ) then
+								IDEntry:SetText( SteamID )
+							end
+							Menu:Destroy()
+						end ):SetFontScale( Font, Scale )
 					end
-
-					Shine.AdminMenu:DontDestroyOnClose( Menu )
-					Menu:Destroy()
-					Menu = nil
-				end ):SetFontScale( Font, Scale )
-			end
-		end
+				end
+			}
+		end )
 
 		local DurationLabel = SGUI:Create( "Label", Window )
 		DurationLabel:SetText( self:GetPhrase( "DURATION_LABEL" ) )

--- a/lua/shine/extensions/ban/server.lua
+++ b/lua/shine/extensions/ban/server.lua
@@ -724,17 +724,25 @@ function Plugin:CheckFamilySharing( ID, NoAPIRequest, OnAsyncResponse )
 
 	local Sharer = Shine.ExternalAPIHandler:GetCachedValue( "Steam", "IsPlayingSharedGame", RequestParams )
 	if Sharer ~= nil then
+		self.Logger:Debug( "Have cached response for family sharing state of %s: %s", ID, Sharer )
+
 		if not Sharer then return false end
 
 		return self:IsIDBanned( Sharer ), Sharer
 	end
 
 	if NoAPIRequest then return false end
-	if not Shine.ExternalAPIHandler:HasAPIKey( "Steam" ) then return false end
+	if not Shine.ExternalAPIHandler:HasAPIKey( "Steam" ) then
+		self.Logger:Warn( "No Steam API key has been configured, thus family sharing cannot be queried." )
+		return false
+	end
+
+	self.Logger:Debug( "Querying Steam for family sharing state of %s...", ID )
 
 	Shine.ExternalAPIHandler:PerformRequest( "Steam", "IsPlayingSharedGame", RequestParams, {
 		OnSuccess = self:WrapCallback( function( Sharer )
 			if not Sharer then
+				self.Logger:Debug( "Steam responded with no sharer for %s.", ID )
 				return OnAsyncResponse( false )
 			end
 

--- a/lua/shine/extensions/chatbox/chatline.lua
+++ b/lua/shine/extensions/chatbox/chatline.lua
@@ -11,8 +11,13 @@ SGUI.AddProperty( ChatLine, "LineSpacing" )
 SGUI.AddProperty( ChatLine, "PreMargin" )
 
 function ChatLine:Initialise()
+	self:SetIsSchemed( false )
 	self.PreLabel = SGUI:Create( "Label", self.Parent )
 	self.MessageLabel = SGUI:Create( "Label", self.Parent )
+
+	-- Avoid skin changes altering the text colour.
+	self.PreLabel:SetIsSchemed( false )
+	self.MessageLabel:SetIsSchemed( false )
 
 	self.Pos = Vector2( 0, 0 )
 end

--- a/lua/shine/extensions/chatbox/client.lua
+++ b/lua/shine/extensions/chatbox/client.lua
@@ -26,6 +26,7 @@ local StringUTF8Length = string.UTF8Length
 local StringUTF8Sub = string.UTF8Sub
 local TableEmpty = table.Empty
 local TableRemove = table.remove
+local TableShallowMerge = table.ShallowMerge
 local type = type
 
 local Plugin = Shine.Plugin( ... )
@@ -209,6 +210,7 @@ local Skin = {
 		Default = {
 			ActiveCol = Colours.Highlight,
 			InactiveCol = Colours.Dark,
+			TextColour = Colours.ModeText,
 			States = {
 				Open = {
 					InactiveCol = Colours.Highlight
@@ -243,9 +245,15 @@ local Skin = {
 			TextColour = Colour( 1, 1, 1, 1 ),
 			PlaceholderTextColour = Colour( 0.8, 0.8, 0.8, 0.5 )
 		}
-	},
-
+	}
 }
+
+function Plugin:OnFirstThink()
+	-- Copy over default skin values to ensure they are applied regardless of the chosen
+	-- default skin.
+	local DefaultSkin = SGUI.SkinManager:GetSkinsByName().Default
+	TableShallowMerge( DefaultSkin, Skin )
+end
 
 local LayoutData = {
 	Sizes = {
@@ -465,6 +473,7 @@ function Plugin:CreateChatbox()
 		ScrollbarWidth = Ceil( 8 * WidthMult ),
 		ScrollbarHeightOffset = 0,
 		Scrollable = true,
+		HorizontalScrollingEnabled = false,
 		AllowSmoothScroll = self.Config.SmoothScroll,
 		StickyScroll = true,
 		Skin = Skin,
@@ -1154,6 +1163,7 @@ function Plugin:SubmitAutoCompleteRequest( Text )
 		local ResultPanel = self.AutoCompletePanel
 		if not ResultPanel then
 			ResultPanel = SGUI:Create( "Panel", self.MainPanel )
+			ResultPanel:SetIsSchemed( false )
 			self.AutoCompletePanel = ResultPanel
 
 			ResultPanel:SetAnchor( "BottomLeft" )
@@ -1190,6 +1200,7 @@ function Plugin:SubmitAutoCompleteRequest( Text )
 				if not Label then
 					ShouldFade = true
 					Label = SGUI:Create( "ColourLabel", ResultPanel )
+					Label:SetIsSchemed( false )
 					Label:SetMargin( Spacing( 0, 0, 0, Scaled( 2, self.ScalarScale ) ) )
 					Elements[ i ] = Label
 				end

--- a/lua/shine/extensions/chatbox/client.lua
+++ b/lua/shine/extensions/chatbox/client.lua
@@ -59,15 +59,17 @@ function Plugin:HookChat( ChatElement )
 	local OriginalOffset = Vector( GetOffset() )
 
 	function ChatElement:Initialize()
-		OldInit(self)
-
 		Plugin.GUIChat = self
+
+		return OldInit( self )
 	end
 
 	function ChatElement:Uninitialize()
-		Plugin.GUIChat = nil
+		if Plugin.GUIChat == self then
+			Plugin.GUIChat = nil
+		end
 
-		OldUninit(self)
+		return OldUninit( self )
 	end
 
 	function ChatElement:SendKeyEvent( Key, Down )

--- a/lua/shine/extensions/mapvote/server.lua
+++ b/lua/shine/extensions/mapvote/server.lua
@@ -365,6 +365,8 @@ do
 end
 
 function Plugin:Initialise()
+	self:BroadcastModuleEvent( "Initialise" )
+
 	self.Round = 0
 
 	self.Vote = self.Vote or {}
@@ -1027,11 +1029,12 @@ end
 
 function Plugin:Cleanup()
 	if self:VoteStarted() then
+		-- Remember to clean up client side vote text/menu entries...
 		self:NotifyTranslated( nil, "PLUGIN_DISABLED" )
-
-		--Remember to clean up client side vote text/menu entries...
 		self:EndVote()
 	end
 
 	self.BaseClass.Cleanup( self )
 end
+
+Shine.LoadPluginModule( "logger.lua", Plugin )

--- a/lua/shine/lib/colour.lua
+++ b/lua/shine/lib/colour.lua
@@ -7,7 +7,11 @@ local SGUI = Shine.GUI
 Colour = Color --I'm British, I can't stand writing Color.
 local Colour = Colour
 
+local Floor = math.floor
 local getmetatable = getmetatable
+local Max = math.max
+local Min = math.min
+
 local ColourMetatable = getmetatable( Colour( 0, 0, 0 ) )
 
 --[[
@@ -20,7 +24,7 @@ end
 
 --[[
 	Returns the sum of two colours.
-	Note that the elements of the returned colour may be more than 255.
+	Note that the elements of the returned colour may be more than 1.
 ]]
 function SGUI.ColourSum( Col1, Col2 )
 	return Colour( Col1.r + Col2.r, Col1.g + Col2.g, Col1.b + Col2.b, Col1.a + Col2.a )
@@ -45,11 +49,11 @@ end
 	Lerps the current colour from the start value with the given difference and progress.
 	Edits the current colour.
 ]]
-function SGUI.ColourLerp( self, Start, Progress, Diff )
-	self.r = Start.r + Progress * Diff.r
-	self.g = Start.g + Progress * Diff.g
-	self.b = Start.b + Progress * Diff.b
-	self.a = Start.a + Progress * Diff.a
+function SGUI.ColourLerp( ColourToLerp, Start, Progress, Diff )
+	ColourToLerp.r = Start.r + Progress * Diff.r
+	ColourToLerp.g = Start.g + Progress * Diff.g
+	ColourToLerp.b = Start.b + Progress * Diff.b
+	ColourToLerp.a = Start.a + Progress * Diff.a
 end
 
 --[[
@@ -57,4 +61,73 @@ end
 ]]
 function SGUI.ColourWithAlpha( ColourToCopy, Alpha )
 	return Colour( ColourToCopy.r, ColourToCopy.g, ColourToCopy.b, Alpha )
+end
+
+local function RGBToHSV( R, G, B )
+	local MaxValue = Max( R, G, B )
+	local MinValue = Min( R, G, B )
+	local Diff = MaxValue - MinValue
+
+	local Hue
+	if MaxValue == MinValue then
+		Hue = 0
+	elseif MaxValue == R then
+		Hue = 60 * ( G - B ) / Diff
+	elseif MaxValue == G then
+		Hue = 60 * ( 2 + ( B - R ) / Diff )
+	else
+		Hue = 60 * ( 4 + ( R - G ) / Diff )
+	end
+
+	if Hue < 0 then
+		Hue = Hue + 360
+	end
+
+	local Saturation
+	if Max == 0 then
+		Saturation = 0
+	else
+		Saturation = Diff / MaxValue
+	end
+
+	return Hue / 360, Saturation, MaxValue
+end
+SGUI.RGBToHSV = RGBToHSV
+
+local function HSVToRGB( H, S, V )
+	local R, G, B
+
+	local i = Floor( H * 6 )
+	local f = H * 6 - i
+	local p = V * ( 1 - S )
+	local q = V * ( 1 - f * S )
+	local t = V * ( 1 - ( 1 - f ) * S )
+
+	i = i % 6
+
+	if i == 0 then
+		R, G, B = V, t, p
+	elseif i == 1 then
+		R, G, B = q, V, p
+	elseif i == 2 then
+		R, G, B = p, V, t
+	elseif i == 3 then
+		R, G, B = p, q, V
+	elseif i == 4 then
+		R, G, B = t, p, V
+	elseif i == 5 then
+		R, G, B = V, p, q
+	end
+
+	return R, G, B
+end
+SGUI.HSVToRGB = HSVToRGB
+
+--[[
+	Applies the given multiplier to the colour's current saturation value (in HSV space).
+	Saturation cannot exceed 100%.
+]]
+function SGUI.SaturateColour( ColourToSaturate, Multiplier )
+	local Hue, Saturation, Value = RGBToHSV( ColourToSaturate.r, ColourToSaturate.g, ColourToSaturate.b )
+	return Colour( HSVToRGB( Hue, Min( Saturation * Multiplier, 1 ), Value ) )
 end

--- a/lua/shine/lib/external_apis.lua
+++ b/lua/shine/lib/external_apis.lua
@@ -93,10 +93,7 @@ do
 		local URL = APIData.URL..Data.URL
 
 		-- Inherit the base API definition's parameters automatically.
-		if Data.DefaultRequestParams then
-			setmetatable( Data.DefaultRequestParams, { __index = APIData.GlobalRequestParams } )
-		end
-
+		local DefaultRequestParams = Data.DefaultRequestParams or {}
 		local Params = TableShallowMerge( Data.Params, {} )
 		TableShallowMerge( APIData.Params, Params )
 
@@ -105,17 +102,33 @@ do
 		APICallers[ APIName ][ EndPointName ] = function( RequestParams, Callbacks, Attempts )
 			Attempts = Attempts or 1
 
+			-- Build the default parameters (some of which may not be expected to be provided by the caller).
+			local DefaultParams = TableShallowMerge( DefaultRequestParams, {} )
+
 			-- Inherit the base API definition's global request parameters (e.g. for an API key).
-			setmetatable( RequestParams, { __index = Data.DefaultRequestParams or APIData.GlobalRequestParams } )
+			TableShallowMerge( APIData.GlobalRequestParams, DefaultParams )
 
 			-- Parse the request parameters using the set converters.
 			local FinalParams = {}
 			for Key, Transformer in pairs( Params ) do
-				if not RequestParams[ Key ] then
+				local Value = RequestParams[ Key ]
+				if Value == nil then
+					-- Fall back to the defaults only if the value is nil (to allow false values).
+					Value = DefaultParams[ Key ]
+				end
+
+				if Value == nil then
 					error( StringFormat( "Missing request parameter: '%s'", Key ), 2 )
 				end
 
-				FinalParams[ Key ] = Transformer( RequestParams[ Key ] )
+				FinalParams[ Key ] = Transformer( Value )
+			end
+
+			-- Add any missing default parameters.
+			for Key, Value in pairs( DefaultParams ) do
+				if FinalParams[ Key ] == nil then
+					FinalParams[ Key ] = Value
+				end
 			end
 
 			-- Pass the transformed JSON response through to the OnSuccess callback.

--- a/lua/shine/lib/external_apis.lua
+++ b/lua/shine/lib/external_apis.lua
@@ -4,13 +4,14 @@
 
 local Shine = Shine
 
+local IsType = Shine.IsType
 local OSTime = os.time
 local StringFormat = string.format
 local tostring = tostring
 
 local APIs = {
 	Steam = {
-		URL = "http://api.steampowered.com/",
+		URL = "https://api.steampowered.com/",
 		Params = {
 			key = tostring
 		},
@@ -32,9 +33,11 @@ local APIs = {
 				GetCacheKey = function( Params ) return tostring( Params.steamid ) end,
 				ResponseTransformer = function( Response )
 					-- Do not cache on invalid JSON.
-					if not Response then return nil end
+					if not IsType( Response, "table" ) or not IsType( Response.response, "table" ) then
+						return nil
+					end
 
-					local Lender = Response.lender_steamid
+					local Lender = Response.response.lender_steamid
 					if not Lender or Lender == "0" then return false end
 
 					return Shine.SteamID64ToNS2ID( Lender )

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -878,6 +878,8 @@ Hook.Add( "OnMapLoad", "LoadGUIElements", function()
 	MouseTracker_ListenToMovement( Listener )
 	MouseTracker_ListenToButtons( Listener )
 	MouseTracker_ListenToWheel( Listener )
+
+	Shine.Hook.SetupGlobalHook( "Client.SetMouseVisible", "OnMouseVisibilityChange", "PassivePost" )
 end )
 
 include( "lua/shine/lib/gui/base_control.lua" )

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -130,13 +130,24 @@ do
 		end
 
 		local BoundFields = {}
+
 		for i = 1, #BoundObject do
-			local FieldName, Setter = unpack( StringExplode( BoundObject[ i ], ":" ) )
-			BoundFields[ i ] = {
-				FieldName = FieldName,
+			local Entry = BoundObject[ i ]
+			if IsType( Entry, "string" ) then
+				local FieldName, Setter = unpack( StringExplode( Entry, ":" ) )
 				Setter = Setter or "Set"..PropertyName
-			}
+
+				BoundFields[ i ] = function( self, Value )
+					local Object = self[ FieldName ]
+					if Object then
+						Object[ Setter ]( Object, Value )
+					end
+				end
+			else
+				BoundFields[ i ] = Entry
+			end
 		end
+
 		return BoundFields
 	end
 
@@ -160,11 +171,7 @@ do
 			self[ Name ] = Value
 
 			for i = 1, #BoundFields do
-				local Entry = BoundFields[ i ]
-				local Object = self[ Entry.FieldName ]
-				if Object then
-					Object[ Entry.Setter ]( Object, Value )
-				end
+				BoundFields[ i ]( self, Value )
 			end
 
 			if OldValue == Value then return end

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -678,12 +678,17 @@ do
 end
 
 do
+	local DebugGetInfo = debug.getinfo
 	local rawget = rawget
 	local ValidityKey = "IsValid"
 	local function CheckDestroyed( self, Key )
 		local Destroyed = rawget( self, "__Destroyed" )
 		if Destroyed and Key ~= ValidityKey and Destroyed < SGUI.FrameNumber() then
-			error( "Attempted to use a destroyed SGUI object!", 3 )
+			local Caller = DebugGetInfo( 2, "f" ).func
+			-- Allow access in __tostring(), otherwise the element can't be printed.
+			if Caller ~= getmetatable( self ).__tostring then
+				error( "Attempted to use a destroyed SGUI object!", 3 )
+			end
 		end
 
 		return rawget( self, "__OriginalIndex" )[ Key ]

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -426,7 +426,7 @@ function SGUI:IsWindowInFocus( Window )
 			return Window.AlwaysInMouseFocus or Window:MouseInCached()
 		end
 
-		if not OtherWindow.IgnoreMouseFocus and OtherWindow:MouseInCached() then
+		if not OtherWindow.IgnoreMouseFocus and OtherWindow:GetIsVisible() and OtherWindow:MouseInCached() then
 			return false
 		end
 	end

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -701,6 +701,10 @@ do
 			Control:SetParent( nil )
 		end
 
+		if Control.LayoutParent then
+			Control.LayoutParent:RemoveElement( Control )
+		end
+
 		self.ActiveControls:Remove( Control )
 
 		if self.IsValid( Control.Tooltip ) then

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -841,10 +841,17 @@ local function NotifyFocusChange( Element, ClickingOtherElement )
 end
 SGUI.NotifyFocusChange = NotifyFocusChange
 
+local GetCursorPosScreen = Client.GetCursorPosScreen
+function SGUI.GetCursorPos()
+	return GetCursorPosScreen()
+end
+
 --[[
 	If we don't load after everything, things aren't registered properly.
 ]]
 Hook.Add( "OnMapLoad", "LoadGUIElements", function()
+	GetCursorPosScreen = Client.GetCursorPosScreen
+
 	Shine.LoadScriptsByPath( "lua/shine/lib/gui/objects" )
 	include( "lua/shine/lib/gui/skin_manager.lua" )
 

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -464,35 +464,42 @@ end
 --[[
 	Sets visibility of the control.
 ]]
-function ControlMeta:SetIsVisible( Bool )
+function ControlMeta:SetIsVisible( IsVisible )
 	if not self.Background then return end
-	if self.Background.GetIsVisible and self.Background:GetIsVisible() == Bool then return end
+	if self.Background.GetIsVisible and self.Background:GetIsVisible() == IsVisible then return end
 
-	self.Background:SetIsVisible( Bool )
+	self.Background:SetIsVisible( IsVisible )
 	self:InvalidateParent()
 
-	if self.IsAWindow then
-		if Bool then --Take focus on show.
-			if SGUI.FocusedWindow == self then return end
-			local Windows = SGUI.Windows
+	if not self.IsAWindow then return end
 
-			for i = 1, #Windows do
-				local Window = Windows[ i ]
+	if IsVisible then
+		if SGUI.FocusedWindow == self then return end
 
-				if Window == self then
-					SGUI:SetWindowFocus( self, i )
-					break
-				end
+		-- Take focus on show.
+		local Windows = SGUI.Windows
+		for i = 1, #Windows do
+			local Window = Windows[ i ]
+			if Window == self then
+				SGUI:SetWindowFocus( self, i )
+				break
 			end
-		else --Give focus to the next window down on hide.
-			if SGUI.WindowFocus ~= self then return end
+		end
+	else
+		if SGUI.FocusedWindow ~= self then return end
 
-			local Windows = SGUI.Windows
-			local NextDown = #Windows - 1
-
-			if NextDown > 0 then
-				SGUI:SetWindowFocus( Windows[ NextDown ], NextDown )
+		-- Give focus to the next visible window down on hide.
+		local Windows = SGUI.Windows
+		local NextDownIndex = 0
+		for i = #Windows, 1, -1 do
+			if Windows[ i ] ~= self and Windows[ i ]:GetIsVisible() then
+				NextDownIndex = i
+				break
 			end
+		end
+
+		if NextDownIndex > 0 then
+			SGUI:SetWindowFocus( Windows[ NextDownIndex ], NextDownIndex )
 		end
 	end
 end

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -21,6 +21,7 @@ local Source = require "shine/lib/gui/binding/source"
 SGUI.AddBoundProperty( ControlMeta, "InheritsParentAlpha", "Background" )
 SGUI.AddBoundProperty( ControlMeta, "Texture", "Background" )
 
+SGUI.AddProperty( ControlMeta, "PropagateSkin" )
 SGUI.AddProperty( ControlMeta, "Skin" )
 SGUI.AddProperty( ControlMeta, "StyleName" )
 
@@ -35,6 +36,7 @@ end
 ]]
 function ControlMeta:Initialise()
 	self.UseScheme = true
+	self.PropagateSkin = true
 	self.Stencilled = false
 end
 
@@ -200,12 +202,27 @@ function ControlMeta:SetStyleName( Name )
 end
 
 function ControlMeta:SetSkin( Skin )
+	local OldSkin = self.Skin
+	if OldSkin == Skin then return end
+
 	self.Skin = Skin
 	SGUI.SkinManager:ApplySkin( self )
+
+	self:OnPropertyChanged( "Skin", Skin )
+
+	if self.PropagateSkin and self.Children then
+		for Child in self:IterateChildren() do
+			Child:SetSkin( Skin )
+		end
+	end
 end
 
 function ControlMeta:GetStyleValue( Key )
-	return SGUI.SkinManager:GetStyleForElement( self )[ Key ]
+	local Style = SGUI.SkinManager:GetStyleForElement( self )
+	if not Style then
+		return nil
+	end
+	return Style[ Key ]
 end
 
 --[[
@@ -269,6 +286,9 @@ function ControlMeta:SetParent( Control, Element )
 	if Control.Stencilled then
 		self:SetInheritsParentStencilSettings( true )
 	end
+	if Control.PropagateSkin then
+		self:SetSkin( Control.Skin )
+	end
 
 	-- If the control was a window, now it's not.
 	self.IsAWindow = false
@@ -321,8 +341,20 @@ function ControlMeta:ForEach( TableKey, MethodName, ... )
 	for i = 1, #Objects do
 		local Object = Objects[ i ]
 		local Method = Object[ MethodName ]
-
 		if Method then
+			Method( Object, ... )
+		end
+	end
+end
+
+function ControlMeta:ForEachFiltered( TableKey, MethodName, Filter, ... )
+	local Objects = self[ TableKey ]
+	if not Objects then return end
+
+	for i = 1, #Objects do
+		local Object = Objects[ i ]
+		local Method = Object[ MethodName ]
+		if Method and Filter( self, Object, i ) then
 			Method( Object, ... )
 		end
 	end
@@ -461,7 +493,7 @@ end
 	Determines if the given control should use the global skin.
 ]]
 function ControlMeta:SetIsSchemed( Bool )
-	self.UseScheme = Bool and true or false
+	self.UseScheme = not not Bool
 end
 
 --[[
@@ -549,12 +581,13 @@ function ControlMeta:PerformLayout()
 	if not self.Layout then return end
 
 	local Margin = self.Layout:GetComputedMargin()
+	local Padding = self:GetComputedPadding()
 	local Size = self:GetSize()
 
-	self.Layout:SetPos( Vector2( Margin[ 1 ], Margin[ 2 ] ) )
+	self.Layout:SetPos( Vector2( Margin[ 1 ] + Padding[ 1 ], Margin[ 2 ] + Padding[ 2 ] ) )
 	self.Layout:SetSize( Vector2(
-		Max( Size.x - Margin[ 1 ] - Margin[ 3 ], 0 ),
-		Max( Size.y - Margin[ 2 ] - Margin[ 4 ], 0 )
+		Max( Size.x - Margin[ 1 ] - Margin[ 3 ] - Padding[ 1 ] - Padding[ 3 ], 0 ),
+		Max( Size.y - Margin[ 2 ] - Margin[ 4 ] - Padding[ 2 ] - Padding[ 4 ], 0 )
 	) )
 	self.Layout:InvalidateLayout( true )
 end
@@ -872,13 +905,8 @@ function ControlMeta:GetAnchor()
 end
 
 do
-	--We call this so many times it really needs to be local, not global.
-	local MousePos
-
-	local function GetMousePos()
-		MousePos = MousePos or Client.GetCursorPosScreen
-		return MousePos()
-	end
+	-- We call this so many times it really needs to be local, not global.
+	local GetCursorPos = SGUI.GetCursorPos
 
 	local function IsInBox( Pos, Size, Mult, MaxX, MaxY )
 		if Mult then
@@ -893,7 +921,7 @@ do
 		MaxX = MaxX or Size.x
 		MaxY = MaxY or Size.y
 
-		local X, Y = GetMousePos()
+		local X, Y = GetCursorPos()
 
 		local InX = X >= Pos.x and X < Pos.x + MaxX
 		local InY = Y >= Pos.y and Y < Pos.y + MaxY
@@ -1411,6 +1439,10 @@ function ControlMeta:SetHighlighted( Highlighted, SkipAnim )
 	if Highlighted then
 		self.Highlighted = true
 
+		if not self:GetStylingState() then
+			self:SetStylingState( "Highlighted" )
+		end
+
 		if not self.TextureHighlight then
 			if SkipAnim then
 				self:StopFade( self.Background )
@@ -1425,6 +1457,9 @@ function ControlMeta:SetHighlighted( Highlighted, SkipAnim )
 		end
 	else
 		self.Highlighted = false
+		if self:GetStylingState() == "Highlighted" then
+			self:SetStylingState( nil )
+		end
 
 		if not self.TextureHighlight then
 			if SkipAnim then

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -264,12 +264,15 @@ function ControlMeta:SetParent( Control, Element )
 
 	self.Parent = Control
 	self.ParentElement = Element
-	self:SetTopLevelWindow( Control.IsAWindow and Control or Control.TopLevelWindow )
+	self:SetTopLevelWindow( SGUI:IsWindow( Control ) and Control or Control.TopLevelWindow )
 	self:SetStencilled( Control.Stencilled )
 	if Control.Stencilled then
 		self:SetInheritsParentStencilSettings( true )
 	end
+
+	-- If the control was a window, now it's not.
 	self.IsAWindow = false
+	SGUI:RemoveWindow( self )
 
 	Control.Children = Control.Children or Map()
 	Control.Children:Add( self, true )
@@ -471,20 +474,11 @@ function ControlMeta:SetIsVisible( IsVisible )
 	self.Background:SetIsVisible( IsVisible )
 	self:InvalidateParent()
 
-	if not self.IsAWindow then return end
+	if not SGUI:IsWindow( self ) then return end
 
 	if IsVisible then
-		if SGUI.FocusedWindow == self then return end
-
 		-- Take focus on show.
-		local Windows = SGUI.Windows
-		for i = 1, #Windows do
-			local Window = Windows[ i ]
-			if Window == self then
-				SGUI:SetWindowFocus( self, i )
-				break
-			end
-		end
+		SGUI:SetWindowFocus( self )
 	else
 		if SGUI.FocusedWindow ~= self then return end
 

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -518,8 +518,7 @@ end
 	Override this for stencilled stuff.
 ]]
 function ControlMeta:GetIsVisible()
-	if not self.Background.GetIsVisible then return false end
-
+	if not self.Background then return false end
 	return self.Background:GetIsVisible()
 end
 
@@ -531,7 +530,9 @@ SGUI.AddProperty( ControlMeta, "Layout" )
 ]]
 function ControlMeta:SetLayout( Layout, DeferInvalidation )
 	self.Layout = Layout
-	Layout:SetParent( self )
+	if Layout then
+		Layout:SetParent( self )
+	end
 	self:InvalidateLayout( not DeferInvalidation )
 end
 
@@ -1236,6 +1237,9 @@ function ControlMeta:StopResizing( Element )
 	self:StopEasing( Element, Easers.Size )
 end
 
+SGUI.AddProperty( ControlMeta, "ActiveCol" )
+SGUI.AddProperty( ControlMeta, "InactiveCol" )
+
 --[[
 	Sets an SGUI control to highlight on mouse over automatically.
 
@@ -1343,6 +1347,13 @@ function ControlMeta:Think( DeltaTime )
 	self:HandleEasing( Time, DeltaTime )
 	self:HandleHovering( Time )
 	self:HandleLayout( DeltaTime )
+end
+
+function ControlMeta:ThinkWithChildren( DeltaTime )
+	if not self:GetIsVisible() then return end
+
+	self.BaseClass.Think( self, DeltaTime )
+	self:CallOnChildren( "Think", DeltaTime )
 end
 
 function ControlMeta:GetTooltipOffset( MouseX, MouseY, Tooltip )

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -474,6 +474,10 @@ function ControlMeta:SetIsVisible( IsVisible )
 	self.Background:SetIsVisible( IsVisible )
 	self:InvalidateParent()
 
+	if not IsVisible then
+		self:HideTooltip()
+	end
+
 	if not SGUI:IsWindow( self ) then return end
 
 	if IsVisible then

--- a/lua/shine/lib/gui/layout/layout.lua
+++ b/lua/shine/lib/gui/layout/layout.lua
@@ -153,8 +153,8 @@ function BaseLayout:PerformLayout()
 	-- When this layout is invalidated, invalidate all of its children too.
 	-- This ensures layout changes cascade downwards in a single frame, rather than
 	-- some children waiting for the next frame to invalidate and thus causing a slight jitter.
-	for i = 1, #self.LayoutChildren do
-		self.LayoutChildren[ i ]:InvalidateLayout( true )
+	for i = 1, #self.Elements do
+		self.Elements[ i ]:InvalidateLayout( true )
 	end
 end
 

--- a/lua/shine/lib/gui/objects/button.lua
+++ b/lua/shine/lib/gui/objects/button.lua
@@ -17,11 +17,21 @@ Client.PrecacheLocalSound( ClickSound )
 Button.Sound = ClickSound
 
 SGUI.AddBoundProperty( Button, "Font", "Label:SetFont" )
-SGUI.AddBoundProperty( Button, "TextColour", "Label:SetColour" )
+SGUI.AddBoundProperty( Button, "TextAlignment", "Label:SetAlignment" )
+SGUI.AddBoundProperty( Button, "TextColour", {
+	"Label:SetColour",
+	function( self, Colour )
+		if self.Icon and not self.IconColour then
+			self.Icon:SetColour( Colour )
+		end
+	end
+} )
 SGUI.AddBoundProperty( Button, "TextInheritsParentAlpha", { "Label:SetInheritsParentAlpha", "Icon:SetInheritsParentAlpha" } )
 SGUI.AddBoundProperty( Button, "TextIsVisible", "Label:SetIsVisible" )
 SGUI.AddBoundProperty( Button, "TextScale", "Label:SetTextScale" )
 
+SGUI.AddBoundProperty( Button, "IconAlignment", "Icon:SetAlignment" )
+SGUI.AddBoundProperty( Button, "IconColour", "Icon:SetColour" )
 SGUI.AddBoundProperty( Button, "IconIsVisible", "Icon:SetIsVisible" )
 SGUI.AddBoundProperty( Button, "IconMargin", "Icon:SetMargin" )
 
@@ -64,10 +74,13 @@ function Button:SetText( Text )
 	end
 
 	local Description = SGUI:Create( "Label", self )
-	Description:SetAlignment( SGUI.LayoutAlignment.CENTRE )
+	Description:SetIsSchemed( false )
+	Description:SetAlignment( self.TextAlignment or SGUI.LayoutAlignment.CENTRE )
 	Description:SetCrossAxisAlignment( SGUI.LayoutAlignment.CENTRE )
 	Description:SetText( Text )
-	Description:SetColour( self.TextColour )
+	if self.TextColour then
+		Description:SetColour( self.TextColour )
+	end
 	Description:SetInheritsParentAlpha( self.TextInheritsParentAlpha )
 	Description:SetIsVisible( self.TextIsVisible )
 
@@ -137,10 +150,13 @@ function Button:SetIcon( IconName, Font, Scale )
 	end
 
 	local Icon = SGUI:Create( "Label", self )
-	Icon:SetAlignment( SGUI.LayoutAlignment.CENTRE )
+	Icon:SetIsSchemed( false )
+	Icon:SetAlignment( self.IconAlignment or SGUI.LayoutAlignment.CENTRE )
 	Icon:SetCrossAxisAlignment( SGUI.LayoutAlignment.CENTRE )
 	Icon:SetFontScale( Font, Scale )
-	Icon:SetColour( self:GetTextColour() )
+	if self.IconColour or self.TextColour then
+		Icon:SetColour( self.IconColour or self.TextColour )
+	end
 	Icon:SetText( IconName )
 	Icon:SetInheritsParentAlpha( self.TextInheritsParentAlpha )
 	Icon:SetIsVisible( self.IconIsVisible )

--- a/lua/shine/lib/gui/objects/button.lua
+++ b/lua/shine/lib/gui/objects/button.lua
@@ -192,19 +192,6 @@ function Button:SetInactiveCol( Col )
 	end
 end
 
-function Button:Think( DeltaTime )
-	if not self.Background then return end
-	if not self.Background:GetIsVisible() then return end
-
-	self.BaseClass.Think( self, DeltaTime )
-
-	if SGUI.IsValid( self.Tooltip ) then
-		self.Tooltip:Think( DeltaTime )
-	end
-
-	self:CallOnChildren( "Think", DeltaTime )
-end
-
 function Button:SetDoClick( Func )
 	self.DoClick = Func
 end

--- a/lua/shine/lib/gui/objects/button.lua
+++ b/lua/shine/lib/gui/objects/button.lua
@@ -228,8 +228,10 @@ function Button:AddMenu( Size, MenuPos )
 	local Pos = self:GetScreenPos()
 	if MenuPos == self.MenuPos.RIGHT then
 		Pos.x = Pos.x + self:GetSize().x
-	else
+	elseif MenuPos == self.MenuPos.BOTTOM then
 		Pos.y = Pos.y + self:GetSize().y
+	elseif MenuPos then
+		Pos = Pos + MenuPos
 	end
 
 	local Menu = SGUI:Create( "Menu" )
@@ -238,7 +240,9 @@ function Button:AddMenu( Size, MenuPos )
 
 	self:SetForceHighlight( true )
 	Menu:CallOnRemove( function()
-		self:SetForceHighlight( false )
+		if self:IsValid() then
+			self:SetForceHighlight( false )
+		end
 	end )
 
 	self.Menu = Menu

--- a/lua/shine/lib/gui/objects/checkbox.lua
+++ b/lua/shine/lib/gui/objects/checkbox.lua
@@ -138,6 +138,7 @@ function CheckBox:AddLabel( Text )
 	end
 
 	local Label = SGUI:Create( "Label", self )
+	Label:SetIsSchemed( false )
 	Label:SetAnchor( GUIItem.Left, GUIItem.Center )
 	Label:SetTextAlignmentY( GUIItem.Align_Center )
 	Label:SetText( Text )

--- a/lua/shine/lib/gui/objects/colour_label.lua
+++ b/lua/shine/lib/gui/objects/colour_label.lua
@@ -94,6 +94,7 @@ function ColourLabel:SetText( TextContent )
 		end
 
 		local Label = SGUI:Create( Type, self )
+		Label:SetIsSchemed( false )
 		Label:SetFontScale( self.Font, self.TextScale )
 		Label:SetText( Text )
 		Label:SetColour( SGUI.CopyColour( Colour ) )

--- a/lua/shine/lib/gui/objects/colour_label.lua
+++ b/lua/shine/lib/gui/objects/colour_label.lua
@@ -132,10 +132,5 @@ function ColourLabel:GetSize()
 	return Vector2( Width, Height )
 end
 
-function ColourLabel:Think( DeltaTime )
-	self.BaseClass.Think( self, DeltaTime )
-	self:CallOnChildren( "Think", DeltaTime )
-end
-
 SGUI:AddMixin( ColourLabel, "Clickable" )
 SGUI:Register( "ColourLabel", ColourLabel )

--- a/lua/shine/lib/gui/objects/dropdown.lua
+++ b/lua/shine/lib/gui/objects/dropdown.lua
@@ -30,6 +30,7 @@ function Dropdown:Initialise()
 			MenuPos = self.MenuPos.BOTTOM,
 			Populate = function( Menu )
 				Menu:SetMaxVisibleButtons( Max( self:GetMaxVisibleOptions(), 1 ) )
+				Menu:SetFontScale( self:GetFont(), self:GetTextScale() )
 
 				for i = 1, #self.Options do
 					local Option = self.Options[ i ]

--- a/lua/shine/lib/gui/objects/dropdown.lua
+++ b/lua/shine/lib/gui/objects/dropdown.lua
@@ -1,0 +1,100 @@
+--[[
+	Simple dropdown menu.
+]]
+
+local SGUI = Shine.GUI
+local Controls = SGUI.Controls
+
+local Binder = require "shine/lib/gui/binding/binder"
+
+local Max = math.max
+local TableEmpty = table.Empty
+local TableRemoveByValue = table.RemoveByValue
+
+local Dropdown = {}
+
+SGUI.AddProperty( Dropdown, "MaxVisibleOptions", 16 )
+SGUI.AddProperty( Dropdown, "SelectedOption" )
+
+function Dropdown:Initialise()
+	Controls.Button.Initialise( self )
+
+	self:SetHorizontal( true )
+	self:SetTextAlignment( SGUI.LayoutAlignment.MIN )
+	self:SetIconAlignment( SGUI.LayoutAlignment.MAX )
+
+	self.Options = {}
+
+	self:SetOpenMenuOnClick( function( self )
+		return {
+			MenuPos = self.MenuPos.BOTTOM,
+			Populate = function( Menu )
+				Menu:SetMaxVisibleButtons( Max( self:GetMaxVisibleOptions(), 1 ) )
+
+				for i = 1, #self.Options do
+					local Option = self.Options[ i ]
+
+					local function DoClick( Button )
+						local Result = true
+						if Option.DoClick then
+							Result = Option.DoClick( Button )
+						end
+
+						self:SetSelectedOption( Option )
+
+						Menu:Destroy()
+
+						return Result
+					end
+
+					local Button = Menu:AddButton( Option.Text, DoClick, Option.Tooltip )
+					if Option.Icon then
+						Button:SetIcon( Option.Icon, Option.IconFont, Option.IconScale )
+					end
+					Button:SetStyleName( "DropdownButton" )
+				end
+			end
+		}
+	end )
+
+	Binder():FromElement( self, "SelectedOption" )
+		:ToElement( self, "Text", {
+			Transformer = function( Option ) return Option and Option.Text or "" end
+		} )
+		:BindProperty()
+end
+
+function Dropdown:SelectOption( Value )
+	for i = 1, #self.Options do
+		local Option = self.Options[ i ]
+		if Option.Value == Value or Option.Text == Value then
+			self:SetSelectedOption( Option )
+			return true
+		end
+	end
+
+	return false
+end
+
+function Dropdown:AddOption( Option )
+	Shine.TypeCheck( Option, "table", 1, "AddOption" )
+	Shine.TypeCheckField( Option, "Text", "string", "Option" )
+
+	self.Options[ #self.Options + 1 ] = Option
+end
+
+function Dropdown:AddOptions( Options )
+	for i = 1, #Options do
+		self:AddOption( Options[ i ] )
+	end
+end
+
+function Dropdown:RemoveOption( Option )
+	return TableRemoveByValue( self.Options, Option )
+end
+
+function Dropdown:Clear()
+	TableEmpty( self.Options )
+end
+
+SGUI:Register( "Dropdown", Dropdown, "Button" )

--- a/lua/shine/lib/gui/objects/hint.lua
+++ b/lua/shine/lib/gui/objects/hint.lua
@@ -42,6 +42,7 @@ function Hint:Initialise()
 	} )
 
 	local HelpText = SGUI:Create( "Label", self )
+	HelpText:SetIsSchemed( false )
 	HelpText:SetCrossAxisAlignment( SGUI.LayoutAlignment.CENTRE )
 	HelpText:SetFill( true )
 	HelpText:SetAutoWrap( true )

--- a/lua/shine/lib/gui/objects/listentry.lua
+++ b/lua/shine/lib/gui/objects/listentry.lua
@@ -28,19 +28,23 @@ function ListEntry:Initialise()
 	self:SetHighlightOnMouseOver( true )
 end
 
+function ListEntry:IsDefaultStyle( TextObj, Index )
+	return not self.TextOverrides or not self.TextOverrides[ Index ]
+end
+
 function ListEntry:SetTextColour( Colour )
 	self.TextColour = Colour
-	self:ForEach( "TextObjs", "SetColor", Colour )
+	self:ForEachFiltered( "TextObjs", "SetColor", self.IsDefaultStyle, Colour )
 end
 
 function ListEntry:SetFont( Font )
 	self.Font = Font
-	self:ForEach( "TextObjs", "SetFontName", Font )
+	self:ForEachFiltered( "TextObjs", "SetFontName", self.IsDefaultStyle, Font )
 end
 
 function ListEntry:SetTextScale( Scale )
 	self.TextScale = Scale
-	self:ForEach( "TextObjs", "SetScale", Scale )
+	self:ForEachFiltered( "TextObjs", "SetScale", self.IsDefaultStyle, Scale )
 end
 
 function ListEntry:Setup( Index, Columns, Size, ... )

--- a/lua/shine/lib/gui/objects/listentry.lua
+++ b/lua/shine/lib/gui/objects/listentry.lua
@@ -223,7 +223,9 @@ end
 
 function ListEntry:Think( DeltaTime )
 	if not self:IsInView() then return end
+
 	self.BaseClass.Think( self, DeltaTime )
+	self:CallOnChildren( "Think", DeltaTime )
 end
 
 function ListEntry:OnMouseDown( Key, DoubleClick )

--- a/lua/shine/lib/gui/objects/listheader.lua
+++ b/lua/shine/lib/gui/objects/listheader.lua
@@ -92,10 +92,4 @@ function ListHeader:OnMouseUp( Key )
 	return true
 end
 
-function ListHeader:Think( DeltaTime )
-	if not self:GetIsVisible() then return end
-
-	self.BaseClass.Think( self, DeltaTime )
-end
-
 SGUI:Register( "ListHeader", ListHeader, "Button" )

--- a/lua/shine/lib/gui/objects/listheader.lua
+++ b/lua/shine/lib/gui/objects/listheader.lua
@@ -15,6 +15,7 @@ function ListHeader:Initialise()
 	self.Background = Background
 
 	local SortIndicator = SGUI:Create( "Label", self )
+	SortIndicator:SetIsSchemed( false )
 	SortIndicator:SetFont( SGUI.Fonts.Ionicons )
 	SortIndicator:SetText( "" )
 	SortIndicator:SetAnchor( "CenterRight" )

--- a/lua/shine/lib/gui/objects/menu.lua
+++ b/lua/shine/lib/gui/objects/menu.lua
@@ -6,6 +6,7 @@
 
 local SGUI = Shine.GUI
 local Controls = SGUI.Controls
+local Units = SGUI.Layout.Units
 
 local Menu = {}
 
@@ -31,11 +32,13 @@ function Menu:Initialise()
 	self.Font = Fonts.kAgencyFB_Small
 end
 
-function Menu:SetMaxVisibleButtons( Max )
+function Menu:SetMaxVisibleButtons( Max, ScrollbarWidth )
+	local Width = ScrollbarWidth or Units.HighResScaled( 8 ):GetValue()
+
 	self.MaxVisibleButtons = Max
 	self:SetScrollable()
-	self:SetScrollbarPos( Vector( -8, 0, 0 ) )
-	self:SetScrollbarWidth( 8 )
+	self:SetScrollbarPos( Vector( -Width, 0, 0 ) )
+	self:SetScrollbarWidth( Width )
 	self:SetScrollbarHeightOffset( 0 )
 	self.BufferAmount = 0
 end

--- a/lua/shine/lib/gui/objects/notification.lua
+++ b/lua/shine/lib/gui/objects/notification.lua
@@ -68,6 +68,7 @@ function Notification:SetText( Text, Font, Scale )
 	local Label = self.Text
 	if not SGUI.IsValid( Label ) then
 		Label = SGUI:Create( "Label", self )
+		Label:SetIsSchemed( false )
 		self.Text = Label
 	end
 

--- a/lua/shine/lib/gui/objects/notification.lua
+++ b/lua/shine/lib/gui/objects/notification.lua
@@ -184,6 +184,7 @@ end
 
 function Notification:Think( DeltaTime )
 	self.BaseClass.Think( self, DeltaTime )
+	self:CallOnChildren( "Think", DeltaTime )
 
 	if self.FadingIn or self.FadingOut then
 		return
@@ -246,11 +247,6 @@ function Notification:FadeOutAfter( Duration, Callback )
 		self.FadeOutTimer = nil
 		self:FadeOut()
 	end )
-end
-
-function Notification:Think( DeltaTime )
-	self.BaseClass.Think( self, DeltaTime )
-	self:CallOnChildren( "Think", DeltaTime )
 end
 
 SGUI:Register( "Notification", Notification )

--- a/lua/shine/lib/gui/objects/panel.lua
+++ b/lua/shine/lib/gui/objects/panel.lua
@@ -264,6 +264,8 @@ function Panel:SetSize( Size )
 
 	if Size == OldSize then return end
 
+	self:UpdateScrollbarSize()
+
 	if SGUI.IsValid( self.TitleBar ) then
 		self.TitleBar:SetSize( Vector( Size.x, self.TitleBarHeight, 0 ) )
 	end
@@ -458,10 +460,10 @@ function Panel:SetMaxWidth( MaxWidth )
 
 		self.ScrollParentPos = self.ScrollParentPos or Vector2( 0, 0 )
 
-		function self:OnScrollChange( Pos, MaxPos, Smoothed )
+		function self:OnScrollChangeX( Pos, MaxPos, Smoothed )
 			local SetWidth = self:GetSize().x
 
-			local Fraction = Pos / MaxPos
+			local Fraction = MaxPos == 0 and 0 or Pos / MaxPos
 			local Diff = self.MaxWidth - SetWidth
 
 			self.ScrollParentPos.x = -Diff * Fraction
@@ -543,7 +545,7 @@ function Panel:SetMaxHeight( MaxHeight, ForceInstantScroll )
 			local SetHeight = self:GetSize().y
 			local MaxHeight = self.MaxHeight
 
-			local Fraction = Pos / MaxPos
+			local Fraction = MaxPos == 0 and 0 or Pos / MaxPos
 			local Diff = MaxHeight - SetHeight
 
 			self.ScrollParentPos.y = -Diff * Fraction

--- a/lua/shine/lib/gui/objects/panel.lua
+++ b/lua/shine/lib/gui/objects/panel.lua
@@ -178,6 +178,12 @@ function Panel:RecomputeMaxWidth()
 			local MaxX = ComputeMaxWidth( Child, PanelWidth )
 			MaxWidth = Max( MaxWidth, MaxX )
 		end
+
+		if self.Layout then
+			-- Account for how the layout has positioned its elements.
+			-- This only works *after* layout has completed.
+			MaxWidth = Max( MaxWidth, self.Layout.MaxPosX or 0 )
+		end
 	end
 
 	self:SetMaxWidth( MaxWidth )
@@ -192,6 +198,10 @@ function Panel:RecomputeMaxHeight()
 		for Child in self.Children:Iterate() do
 			local MaxY = ComputeMaxHeight( Child, PanelHeight )
 			MaxHeight = Max( MaxHeight, MaxY )
+		end
+
+		if self.Layout then
+			MaxHeight = Max( MaxHeight, self.Layout.MaxPosY or 0 )
 		end
 	end
 
@@ -767,6 +777,16 @@ function Panel:Think( DeltaTime )
 	end
 
 	self:CallOnChildren( "Think", DeltaTime )
+end
+
+function Panel:PerformLayout()
+	self.BaseClass.PerformLayout( self )
+
+	if self.Stencil then
+		-- Some elements may have moved to no longer be so far down/to the right.
+		self:RecomputeMaxHeight()
+		self:RecomputeMaxWidth()
+	end
 end
 
 function Panel:OnMouseWheel( Down )

--- a/lua/shine/lib/gui/objects/panel.lua
+++ b/lua/shine/lib/gui/objects/panel.lua
@@ -704,7 +704,7 @@ function Panel:OnMouseDown( Key, DoubleClick )
 
 	if self:DragClick( Key, DoubleClick ) then return true, self end
 
-	if ( self.IsAWindow and self:MouseInCached() ) or self.BlockOnMouseDown then
+	if ( SGUI:IsWindow( self ) and self:MouseInCached() ) or self.BlockOnMouseDown then
 		return true, self
 	end
 end
@@ -758,7 +758,7 @@ function Panel:OnMouseMove( Down )
 	end
 
 	-- Block mouse movement for lower windows.
-	if self.IsAWindow or self.BlockOnMouseDown then
+	if SGUI:IsWindow( self ) or self.BlockOnMouseDown then
 		if MouseIn == nil then
 			MouseIn = self:MouseIn( self.Background )
 		end
@@ -806,7 +806,7 @@ function Panel:OnMouseWheel( Down )
 	end
 
 	-- We block the event, so that only the focused window can scroll.
-	if self.IsAWindow then
+	if SGUI:IsWindow( self ) then
 		return false
 	end
 end
@@ -819,7 +819,7 @@ function Panel:PlayerKeyPress( Key, Down )
 	end
 
 	-- Block the event so only the focused window receives input.
-	if self.IsAWindow then
+	if SGUI:IsWindow( self ) then
 		return false
 	end
 end
@@ -831,7 +831,7 @@ function Panel:PlayerType( Char )
 		return true
 	end
 
-	if self.IsAWindow then
+	if SGUI:IsWindow( self ) then
 		return false
 	end
 end

--- a/lua/shine/lib/gui/objects/panel.lua
+++ b/lua/shine/lib/gui/objects/panel.lua
@@ -11,12 +11,21 @@ local Min = math.min
 
 local Panel = {}
 
---We're a window object!
+-- We're a window object!
 Panel.IsWindow = true
 
 local DefaultBuffer = 20
 local ScrollPos = Vector( -20, 10, 0 )
 local ZeroColour = Colour( 0, 0, 0, 0 )
+
+SGUI.AddProperty( Panel, "AutoHideScrollbar" )
+SGUI.AddProperty( Panel, "Draggable" )
+SGUI.AddProperty( Panel, "HorizontalScrollingEnabled", true )
+SGUI.AddProperty( Panel, "ResizeLayoutForScrollbar" )
+SGUI.AddProperty( Panel, "StickyScroll" )
+
+SGUI.AddBoundProperty( Panel, "Colour", "Background:SetColor" )
+SGUI.AddBoundProperty( Panel, "HideHorizontalScrollbar", "HorizontalScrollbar:SetHidden" )
 
 function Panel:Initialise()
 	self.BaseClass.Initialise( self )
@@ -25,6 +34,7 @@ function Panel:Initialise()
 	self.TitleBarHeight = 24
 	self.OverflowX = false
 	self.OverflowY = false
+	self.HorizontalScrollingEnabled = true
 end
 
 function Panel:SkinColour()
@@ -309,10 +319,6 @@ function Panel:Clear()
 	self.Layout = nil
 end
 
-SGUI.AddProperty( Panel, "StickyScroll" )
-SGUI.AddProperty( Panel, "ResizeLayoutForScrollbar" )
-SGUI.AddBoundProperty( Panel, "HideHorizontalScrollbar", "HorizontalScrollbar:SetHidden" )
-
 function Panel:ScrollIntoView( Child, ForceInstantScroll )
 	if Child.Parent ~= self then return end
 	if not self.ScrollParent or not self.ScrollParentPos then return end
@@ -424,7 +430,7 @@ end
 function Panel:SetMaxWidth( MaxWidth )
 	self.MaxWidth = MaxWidth
 
-	if not self.ShowScrollbar then return end
+	if not self.ShowScrollbar or not self.HorizontalScrollingEnabled then return end
 
 	local ElementWidth = self:GetSize().x
 
@@ -614,11 +620,7 @@ function Panel:SetScrollbarPos( Pos )
 	end
 end
 
-SGUI.AddBoundProperty( Panel, "Colour", "Background:SetColor" )
-SGUI.AddProperty( Panel, "Draggable" )
-SGUI.AddProperty( Panel, "AutoHideScrollbar" )
-
-local GetCursorPos
+local GetCursorPos = SGUI.GetCursorPos
 
 local LastInput = 0
 local Clock = Shared.GetSystemTimeReal
@@ -640,8 +642,6 @@ function Panel:DragClick( Key, DoubleClick )
 
 		return true
 	end
-
-	GetCursorPos = GetCursorPos or Client.GetCursorPosScreen
 
 	local X, Y = GetCursorPos()
 

--- a/lua/shine/lib/gui/objects/scrollbar.lua
+++ b/lua/shine/lib/gui/objects/scrollbar.lua
@@ -30,11 +30,13 @@ function Scrollbar:Initialise()
 
 	self.Horizontal = false
 	self.ScrollAxis = "y"
+	self.ScrollEvent = "OnScrollChange"
 end
 
 function Scrollbar:SetHorizontal( Horizontal )
 	self.Horizontal = Horizontal
 	self.ScrollAxis = Horizontal and "x" or "y"
+	self.ScrollEvent = Horizontal and "OnScrollChangeX" or "OnScrollChange"
 end
 
 function Scrollbar:FadeIn( Duration, Callback, EaseFunc )
@@ -116,8 +118,8 @@ function Scrollbar:SetScroll( Scroll, Smoothed )
 	self.BarPos[ self.ScrollAxis ] = Scroll
 	self.Bar:SetPosition( self.BarPos )
 
-	if self.Parent and self.Parent.OnScrollChange then
-		self.Parent:OnScrollChange( Scroll, Diff, Smoothed )
+	if self.Parent and self.Parent[ self.ScrollEvent ] then
+		self.Parent[ self.ScrollEvent ]( self.Parent, Scroll, Diff, Smoothed )
 	end
 end
 

--- a/lua/shine/lib/gui/objects/scrollbar.lua
+++ b/lua/shine/lib/gui/objects/scrollbar.lua
@@ -69,10 +69,12 @@ end
 
 function Scrollbar:GetNormalAlpha( Element )
 	if Element == self.Background then
-		return self:GetStyleValue( "BackgroundColour" ).a
+		local Colour = self:GetStyleValue( "BackgroundColour" )
+		return Colour and Colour.a or 1
 	end
 
-	return self:GetStyleValue( "InactiveCol" ).a
+	local Colour = self:GetStyleValue( "InactiveCol" )
+	return Colour and Colour.a or 1
 end
 
 function Scrollbar:SetSize( Size )
@@ -131,7 +133,7 @@ function Scrollbar:ScrollToBottom( Smoothed )
 	self:SetScroll( self:GetDiffSize() )
 end
 
-local GetCursorPos
+local GetCursorPos = SGUI.GetCursorPos
 
 function Scrollbar:OnMouseDown( Key, DoubleClick )
 	if self.Disabled then return end
@@ -140,8 +142,6 @@ function Scrollbar:OnMouseDown( Key, DoubleClick )
 	if not self:MouseIn( self.Bar ) then return end
 
 	self.Scrolling = true
-
-	GetCursorPos = GetCursorPos or Client.GetCursorPosScreen
 
 	local X, Y = GetCursorPos()
 

--- a/lua/shine/lib/gui/objects/shadow_label.lua
+++ b/lua/shine/lib/gui/objects/shadow_label.lua
@@ -8,6 +8,7 @@ local Controls = SGUI.Controls
 local ShadowLabel = {}
 
 SGUI.AddBoundProperty( ShadowLabel, "Font", { "Label:SetFontName", "LabelShadow:SetFontName" }, { "InvalidatesParent" } )
+SGUI.AddBoundProperty( ShadowLabel, "InheritsParentAlpha", { "Label", "LabelShadow" } )
 SGUI.AddBoundProperty( ShadowLabel, "Text", { "Label", "LabelShadow" }, { "InvalidatesParent" } )
 SGUI.AddBoundProperty( ShadowLabel, "TextAlignmentX", { "Label", "LabelShadow" } )
 SGUI.AddBoundProperty( ShadowLabel, "TextAlignmentY", { "Label", "LabelShadow" } )

--- a/lua/shine/lib/gui/objects/tabbedpanel.lua
+++ b/lua/shine/lib/gui/objects/tabbedpanel.lua
@@ -19,7 +19,7 @@ local TabPanelButton = {}
 function TabPanelButton:Initialise()
 	Controls.Button.Initialise( self )
 
-	--We'll handle it ourselves.
+	-- We'll handle it ourselves.
 	self:SetHighlightOnMouseOver( false )
 end
 
@@ -34,6 +34,22 @@ function TabPanelButton:DoClick()
 	self:SetSelected( true )
 	self.Parent:ScrollIntoView( self )
 	self.Parent.Parent:OnTabSelect( self )
+end
+
+function TabPanelButton:SetActiveCol( Col )
+	self.ActiveCol = Col
+
+	if self.Highlighted or self.Selected then
+		self.Background:SetColor( Col )
+	end
+end
+
+function TabPanelButton:SetInactiveCol( Col )
+	self.InactiveCol = Col
+
+	if not self.Highlighted and not self.Selected then
+		self.Background:SetColor( Col )
+	end
 end
 
 function TabPanelButton:SetSelected( Selected )
@@ -82,11 +98,11 @@ function TabPanel:Initialise()
 	self.TabPanel:SetScrollbarPos( Vector2( -Units.HighResScaled( 8 ):GetValue(), 0 ) )
 	self.TabPanel:SetScrollbarHeightOffset( 0 )
 	self.TabPanel.BufferAmount = 0
-	self.TabPanel.UseScheme = false
+	self.TabPanel:SetIsSchemed( false )
 
 	-- This panel is populated with a tab's content.
 	self.ContentPanel = SGUI:Create( "Panel", self )
-	self.ContentPanel.UseScheme = false
+	self.ContentPanel:SetIsSchemed( false )
 	self.ContentPanel:SetFill( true )
 
 	self.Tabs = {}

--- a/lua/shine/lib/gui/objects/textentry.lua
+++ b/lua/shine/lib/gui/objects/textentry.lua
@@ -762,6 +762,7 @@ function TextEntry:Think( DeltaTime )
 	end
 
 	self.BaseClass.Think( self, DeltaTime )
+	self:CallOnChildren( "Think", DeltaTime )
 end
 
 function TextEntry:OnMouseUp()

--- a/lua/shine/lib/gui/objects/textentry.lua
+++ b/lua/shine/lib/gui/objects/textentry.lua
@@ -25,10 +25,10 @@ local TextEntry = {}
 
 TextEntry.UsesKeyboardFocus = true
 
-local BorderSize = Vector( 2, 2, 0 )
-local CaretCol = Color( 1, 1, 1, 1 )
-local Clear = Color( 0, 0, 0, 0 )
-local TextPos = Vector( 2, 0, 0 )
+local BorderSize = Vector2( 2, 2 )
+local CaretCol = Colour( 1, 1, 1, 1 )
+local Clear = Colour( 0, 0, 0, 0 )
+local TextPos = Vector2( 2, 0 )
 
 SGUI.AddProperty( TextEntry, "MaxUndoHistory", 100 )
 SGUI.AddProperty( TextEntry, "AutoCompleteHandler" )
@@ -93,6 +93,7 @@ function TextEntry:Initialise()
 
 	--The actual text string.
 	self.Text = ""
+	self.TextColour = CaretCol
 
 	--Where's the caret?
 	self.Column = 0
@@ -160,6 +161,7 @@ function TextEntry:SetBorderColour( Col )
 end
 
 function TextEntry:SetTextColour( Col )
+	self.TextColour = Col
 	self.TextObj:SetColor( Col )
 end
 
@@ -757,7 +759,7 @@ function TextEntry:Think( DeltaTime )
 		if ( self.NextCaretChange or 0 ) < Time then
 			self.NextCaretChange = Time + 0.5
 			self.CaretVis = not self.CaretVis
-			self.Caret:SetColor( self.CaretVis and CaretCol or Clear )
+			self.Caret:SetColor( self.CaretVis and self.TextColour or Clear )
 		end
 	end
 

--- a/lua/shine/lib/gui/objects/tooltip.lua
+++ b/lua/shine/lib/gui/objects/tooltip.lua
@@ -90,6 +90,7 @@ function Tooltip:Think( DeltaTime )
 	end
 
 	self.BaseClass.Think( self, DeltaTime )
+	self:CallOnChildren( "Think", DeltaTime )
 end
 
 function Tooltip:FadeIn()

--- a/lua/shine/lib/gui/objects/webpage.lua
+++ b/lua/shine/lib/gui/objects/webpage.lua
@@ -92,6 +92,7 @@ end
 
 function Webpage:Think( DeltaTime )
 	self.BaseClass.Think( self, DeltaTime )
+	self:CallOnChildren( "Think", DeltaTime )
 
 	if self.IsLoading and self:GetHasLoaded() then
 		self.IsLoading = false

--- a/lua/shine/lib/gui/skin_manager.lua
+++ b/lua/shine/lib/gui/skin_manager.lua
@@ -30,7 +30,7 @@ function SkinManager:RegisterSkin( Name, SkinTable )
 end
 
 function SkinManager:RefreshSkin()
-	for Control in SGUI.ActiveControls:Iterate() do
+	for Element in SGUI.ActiveControls:Iterate() do
 		self:ApplySkin( Element )
 	end
 end

--- a/lua/shine/lib/gui/skin_manager.lua
+++ b/lua/shine/lib/gui/skin_manager.lua
@@ -21,7 +21,13 @@ function SkinManager:RegisterSkin( Name, SkinTable )
 
 		for StyleName, StyleData in pairs( Data ) do
 			if StyleName ~= "Default" then
+				-- Inherit default styling values
 				TableShallowMerge( Default, StyleData )
+
+				-- Also inherit any states from the default that are not overridden.
+				if Default.States and StyleData.States then
+					TableShallowMerge( Default.States, StyleData.States )
+				end
 			end
 		end
 	end
@@ -47,6 +53,10 @@ function SkinManager:GetSkin()
 	return self.Skin
 end
 
+function SkinManager:GetSkinsByName()
+	return self.Skins
+end
+
 function SkinManager:SetSkin( Name )
 	local SkinTable = self.Skins[ Name ]
 
@@ -67,6 +77,29 @@ function SkinManager:GetStyleForElement( Element )
 	return Styles[ Style ] or Styles.Default
 end
 
+-- These are properties that should be applied only as defaults. They may be changed
+-- dynamically based on resolution and thus should not be reset if the skin changes.
+local PropertiesToApplyAsDefaults = {
+	Font = true,
+	TextScale = true,
+	HeaderSize = true,
+	LineSize = true
+}
+
+local function CopyValues( Element, Values, Destination )
+	for Key, Value in pairs( Values ) do
+		if not PropertiesToApplyAsDefaults[ Key ] or Element[ Key ] == nil then
+			if SGUI.IsColour( Value ) then
+				Destination[ Key ] = SGUI.CopyColour( Value )
+			else
+				Destination[ Key ] = Value
+			end
+		end
+	end
+
+	return Destination
+end
+
 function SkinManager:ApplySkin( Element )
 	if not Element.UseScheme then return end
 
@@ -74,22 +107,23 @@ function SkinManager:ApplySkin( Element )
 	if not StyleDef then return end
 
 	-- States can apply different scheme values, e.g. focus/hover etc.
-	local State = Element:GetStylingState()
-	if State and StyleDef.States then
-		StyleDef = StyleDef.States[ State ] or StyleDef
-	end
+	local StateValues = StyleDef.States and StyleDef.States[ Element:GetStylingState() ]
 
-	local StyleCopy = {}
-	for Key, Value in pairs( StyleDef ) do
-		if SGUI.IsColour( Value ) then
-			StyleCopy[ Key ] = SGUI.CopyColour( Value )
-		else
-			StyleCopy[ Key ] = Value
-		end
+	-- Combine the current styling with the state to get the final styling values.
+	-- If only the state values were applied, changing skins could lead to incorrect
+	-- values being left from a previous skin.
+	local StyleCopy = CopyValues( Element, StyleDef, {} )
+	if StateValues then
+		StyleCopy = CopyValues( Element, StateValues, StyleCopy )
 	end
 
 	Element:SetupFromTable( StyleCopy )
 end
 
 Shine.LoadScriptsByPath( "lua/shine/lib/gui/skins" )
-SkinManager:SetSkin( "Default" )
+
+local ConfiguredSkin = Shine.Config.Skin
+if not SkinManager.Skins[ ConfiguredSkin ] then
+	ConfiguredSkin = "Default"
+end
+SkinManager:SetSkin( ConfiguredSkin )

--- a/lua/shine/lib/gui/skins/default.lua
+++ b/lua/shine/lib/gui/skins/default.lua
@@ -3,6 +3,7 @@
 ]]
 
 local SGUI = Shine.GUI
+local Units = SGUI.Layout.Units
 
 local WindowBackground = Colour( 0.5, 0.5, 0.5, 1 )
 local HorizontalTabBackground = Colour( 0.4, 0.4, 0.4, 1 )
@@ -20,20 +21,23 @@ local DangerButton = Colour( 1, 0.2, 0.1, 1 )
 
 local OrangeButtonHighlight = Colour( 1, 0.4, 0, 1 )
 
+local DefaultButton = {
+	ActiveCol = ButtonHighlight,
+	InactiveCol = DarkButton,
+	TextColour = BrightText,
+	HighlightOnMouseOver = true,
+	States = {
+		Disabled = {
+			HighlightOnMouseOver = false,
+			InactiveCol = SGUI.ColourWithAlpha( DarkButton, 0.5 )
+		}
+	}
+}
+local DropdownPadding = Units.Spacing( Units.HighResScaled( 4 ), 0, Units.HighResScaled( 4 ), 0 )
+
 local Skin = {
 	Button = {
-		Default = {
-			ActiveCol = ButtonHighlight,
-			InactiveCol = DarkButton,
-			TextColour = BrightText,
-			HighlightOnMouseOver = true,
-			States = {
-				Disabled = {
-					HighlightOnMouseOver = false,
-					InactiveCol = SGUI.ColourWithAlpha( DarkButton, 0.5 )
-				}
-			}
-		},
+		Default = DefaultButton,
 		CloseButton = {
 			ActiveCol = Colour( 0.7, 0.2, 0.2, 1 ),
 			InactiveCol = Colour( 0.5, 0.2, 0.2, 1 )
@@ -66,6 +70,11 @@ local Skin = {
 			InactiveCol = Clear,
 			ActiveCol = Clear,
 			TextInheritsParentAlpha = false
+		},
+		DropdownButton = {
+			Padding = DropdownPadding,
+			TextAlignment = SGUI.LayoutAlignment.MIN,
+			IconAlignment = SGUI.LayoutAlignment.MIN
 		}
 	},
 	CategoryPanel = {
@@ -85,6 +94,12 @@ local Skin = {
 		Default = {
 			Font = Fonts.kAgencyFB_Small
 		}
+	},
+	Dropdown = {
+		Default = table.ShallowMerge( DefaultButton, {
+			Padding = DropdownPadding,
+			Icon = SGUI.Icons.Ionicons.ArrowDownB
+		} )
 	},
 	Hint = {
 		Default = {

--- a/lua/shine/lib/gui/skins/default_light.lua
+++ b/lua/shine/lib/gui/skins/default_light.lua
@@ -1,22 +1,25 @@
 --[[
-	Default Shine GUI skin.
+	Default light Shine GUI skin.
 ]]
 
 local SGUI = Shine.GUI
 local Units = SGUI.Layout.Units
 
-local WindowBackground = Colour( 0.5, 0.5, 0.5, 1 )
-local HorizontalTabBackground = Colour( 0.4, 0.4, 0.4, 1 )
-local DarkButton = Colour( 0.2, 0.2, 0.2, 1 )
-local ButtonHighlight = Colour( 0.8, 0.5, 0.1, 1 )
-local BrightText = Colour( 1, 1, 1, 1 )
+local White = Colour( 1, 1, 1, 1 )
+
+local WindowBackground = White
+local HorizontalTabBackground = Colour( 0.85, 0.85, 0.85, 1 )
+local DarkButton = Colour( 0.9, 0.9, 0.9, 1 )
+local ButtonHighlight = Colour( 1, 0.878, 0.666, 1 )
+local BrightText = Colour( 0.25, 0.25, 0.25, 1 )
 local Clear = Colour( 0, 0, 0, 0 )
 
 local Danger = Colour( 1, 0, 0 )
 local Warning = Colour( 1, 0.6, 0 )
 local Info = Colour( 0, 0.5, 1 )
 
-local SuccessButton = Colour( 0.1, 0.6, 0.1, 1 )
+local SuccessButton = Colour( 0.1, 1, 0.1, 1 )
+local DarkerSuccessButton = Colour( 0.1, 0.6, 0.1, 1 )
 local DangerButton = Colour( 1, 0.2, 0.1, 1 )
 
 local OrangeButtonHighlight = Colour( 1, 0.4, 0, 1 )
@@ -40,31 +43,49 @@ local Skin = {
 		Default = DefaultButton,
 		CloseButton = {
 			ActiveCol = Colour( 0.7, 0.2, 0.2, 1 ),
-			InactiveCol = Colour( 0.5, 0.2, 0.2, 1 )
+			InactiveCol = Colour( 0.5, 0.2, 0.2, 1 ),
+			TextColour = White
 		},
 		MenuButton = {
-			InactiveCol = Colour( 0.25, 0.25, 0.25, 1 )
+			InactiveCol = WindowBackground
 		},
 		CategoryPanelButton = {
 			Font = Fonts.kAgencyFB_Small,
 			ActiveCol = OrangeButtonHighlight,
-			InactiveCol = Colour( 0.3, 0.3, 0.3, 1 )
+			InactiveCol = Colour( 0.8, 0.8, 0.8, 1 ),
+			States = {
+				Highlighted = {
+					TextColour = White
+				}
+			}
 		},
 		SuccessButton = {
-			ActiveCol = SuccessButton
+			ActiveCol = SuccessButton,
+			States = {
+				Highlighted = {
+					TextColour = White
+				}
+			}
 		},
 		DangerButton = {
-			ActiveCol = DangerButton
+			ActiveCol = DangerButton,
+			States = {
+				Highlighted = {
+					TextColour = White
+				}
+			}
 		},
 		AcceptButton = {
-			InactiveCol = SuccessButton,
-			ActiveCol = SGUI.ColourWithAlpha( SuccessButton, 2 ),
-			InheritsParentAlpha = true
+			InactiveCol = DarkerSuccessButton,
+			ActiveCol = SGUI.ColourWithAlpha( DarkerSuccessButton, 2 ),
+			InheritsParentAlpha = true,
+			TextColour = White
 		},
 		DeclineButton = {
 			InactiveCol = DangerButton,
 			ActiveCol = SGUI.ColourWithAlpha( DangerButton, 2 ),
-			InheritsParentAlpha = true
+			InheritsParentAlpha = true,
+			TextColour = White
 		},
 		TabPanelTabListButton = {
 			InactiveCol = Clear,
@@ -85,7 +106,7 @@ local Skin = {
 	CheckBox = {
 		Default = {
 			BackgroundColour = DarkButton,
-			CheckedColour = ButtonHighlight,
+			CheckedColour = OrangeButtonHighlight,
 			TextColour = BrightText,
 			Font = Fonts.kAgencyFB_Small
 		}
@@ -121,33 +142,43 @@ local Skin = {
 			Colour = BrightText
 		},
 		Link = {
-			Colour = Colour( 1, 0.8, 0 )
+			Colour = OrangeButtonHighlight
 		}
 	},
 	List = {
 		Default = {
-			Colour = Colour( 0.2, 0.2, 0.2, 1 ),
+			Colour = Colour( 0.85, 0.85, 0.85, 1 ),
 			HeaderSize = 32,
 			LineSize = 32
 		}
 	},
 	ListEntry = {
 		Default = {
-			InactiveCol = Colour( 0.4, 0.4, 0.4, 1 ),
+			InactiveCol = Colour( 0.9, 0.9, 0.9, 1 ),
 			ActiveCol = OrangeButtonHighlight,
 			TextColour = BrightText,
-			Font = Fonts.kAgencyFB_Small
+			Font = Fonts.kAgencyFB_Small,
+			States = {
+				Highlighted = {
+					TextColour = White
+				}
+			}
 		},
 		DefaultEven = {
-			InactiveCol = Colour( 0.3, 0.3, 0.3, 1 )
+			InactiveCol = Colour( 0.8, 0.8, 0.8, 1 )
 		}
 	},
 	ListHeader = {
 		Default = {
-			ActiveCol = Colour( 0.6, 0.3, 0.2, 1 ),
-			InactiveCol = Colour( 0.2, 0.2, 0.2, 1 ),
+			ActiveCol = SGUI.SaturateColour( OrangeButtonHighlight, 0.75 ),
+			InactiveCol = Colour( 0.8, 0.8, 0.8, 1 ),
 			TextColour = BrightText,
-			Font = Fonts.kAgencyFB_Small
+			Font = Fonts.kAgencyFB_Small,
+			States = {
+				Highlighted = {
+					TextColour = White
+				}
+			}
 		}
 	},
 	Menu = {
@@ -157,9 +188,10 @@ local Skin = {
 	},
 	Notification = {
 		Default = {
-			TextColour = SGUI.ColourWithAlpha( BrightText, 2 ),
-			FlairIconColour = SGUI.ColourWithAlpha( BrightText, 2 ),
-			Colour = SGUI.ColourWithAlpha( DarkButton, 0.8 )
+			-- Same as the dark skin, lighter notifications don't look very good.
+			TextColour = SGUI.ColourWithAlpha( White, 2 ),
+			FlairIconColour = SGUI.ColourWithAlpha( White, 2 ),
+			Colour = Colour( 0.2, 0.2, 0.2, 0.8 )
 		},
 		Danger = {
 			FlairIconText = SGUI.Icons.Ionicons.AlertCircled,
@@ -179,10 +211,10 @@ local Skin = {
 			Colour = WindowBackground
 		},
 		TitleBar = {
-			Colour = Colour( 0.25, 0.25, 0.25, 1 )
+			Colour = Colour( 0.9, 0.9, 0.9, 1 )
 		},
 		MenuPanel = {
-			Colour = Colour( 0.25, 0.25, 0.25, 1 )
+			Colour = WindowBackground
 		},
 		RadioBackground = {
 			Colour = Clear
@@ -198,8 +230,8 @@ local Skin = {
 	},
 	Scrollbar = {
 		Default = {
-			BackgroundColour = Colour( 0, 0, 0, 0.2 ),
-			InactiveCol = Colour( 0.7, 0.7, 0.7, 1 ),
+			BackgroundColour = Colour( 0, 0, 0, 0.1 ),
+			InactiveCol = Colour( 0.6, 0.6, 0.6, 1 ),
 			ActiveCol = Colour( 1, 0.6, 0, 1 )
 		}
 	},
@@ -240,12 +272,12 @@ local Skin = {
 	},
 	TextEntry = {
 		Default = {
-			FocusColour = Colour( 0.35, 0.35, 0.35, 1 ),
-			DarkColour = Colour( 0.4, 0.4, 0.4, 1 ),
+			FocusColour = Colour( 0.95, 0.95, 0.95, 1 ),
+			DarkColour = Colour( 0.9, 0.9, 0.9, 1 ),
 			HighlightColour = SGUI.ColourWithAlpha( OrangeButtonHighlight, 0.5 ),
 			PlaceholderTextColour = SGUI.ColourWithAlpha( BrightText, 0.8 ),
 			TextColour = BrightText,
-			BorderColour = Colour( 0.3, 0.3, 0.3, 1 ),
+			BorderColour = Colour( 0.8, 0.8, 0.8, 1 ),
 			BorderSize = Vector2( 1, 1 ),
 			States = {
 				Focus = {
@@ -262,4 +294,4 @@ local Skin = {
 	}
 }
 
-SGUI.SkinManager:RegisterSkin( "Default", Skin )
+SGUI.SkinManager:RegisterSkin( "Default - Light", Skin )

--- a/lua/shine/lib/player.lua
+++ b/lua/shine/lib/player.lua
@@ -64,7 +64,6 @@ local TableShuffle = table.Shuffle
 local TableSort = table.sort
 local TableToString = table.ToString
 local tonumber = tonumber
-local Traceback = debug.traceback
 
 --[[
 	Returns whether the given client is valid.
@@ -72,16 +71,6 @@ local Traceback = debug.traceback
 function Shine:IsValidClient( Client )
 	return Client and self.GameIDs:Get( Client ) ~= nil
 end
-
-local function OnJoinError( Error )
-	local Trace = Traceback()
-
-	Shine:DebugLog( "Error: %s.\nEvenlySpreadTeams failed. %s", true, Error, Trace )
-	Shine:AddErrorReport( StringFormat(
-		"A player failed to join a team in EvenlySpreadTeams: %s.", Error ), Trace )
-end
-
-local Hook = Shine.Hook
 
 function Shine.EqualiseTeamCounts( TeamMembers )
 	local Marine = TeamMembers[ 1 ]
@@ -119,6 +108,9 @@ function Shine.EqualiseTeamCounts( TeamMembers )
 end
 
 do
+	local Hook = Shine.Hook
+	local OnJoinError = Shine.BuildErrorHandler( "EvenlySpreadTeams team join error" )
+
 	local function MoveToTeam( Gamerules, Players, TeamNumber )
 		for i = #Players, 1, -1 do
 			local Player = Players[ i ]

--- a/lua/shine/lib/table.lua
+++ b/lua/shine/lib/table.lua
@@ -391,6 +391,15 @@ do
 		end
 	end
 
+	local function SafeToString( Value )
+		-- __tostring() metamethods can throw errors. Unfortunately there's no rawtostring().
+		local Success, String = pcall( tostring, Value )
+		if not Success then
+			return "error calling tostring()"
+		end
+		return String
+	end
+
 	local DefaultPrinters = {
 		string = function( Value )
 			if StringFind( Value, "\n", 1, true ) then
@@ -405,7 +414,7 @@ do
 		userdata = function( Value )
 			local Meta = getmetatable( Value )
 			if IsType( Meta, "table" ) and Meta.__towatch then
-				return tostring( Meta.__towatch( Value ) )
+				return SafeToString( Meta.__towatch( Value ) )
 			end
 
 			-- Some userdata may error for unknown keys.
@@ -414,16 +423,17 @@ do
 				return Name
 			end
 
-			return tostring( Value )
+			return SafeToString( Value )
 		end
 	}
 
 	local function ToPrintKey( Key, Printers )
 		local Type = type( Key )
-		return StringFormat( "[ %s ]", ( Printers[ Type ] or tostring )( Key ) )
+		return StringFormat( "[ %s ]", ( Printers[ Type ] or SafeToString )( Key ) )
 	end
+
 	local function ToPrintString( Value, Printers )
-		return ( Printers[ type( Value ) ] or tostring )( Value )
+		return ( Printers[ type( Value ) ] or SafeToString )( Value )
 	end
 
 	local function KeySorter( A, B )
@@ -441,7 +451,7 @@ do
 			return false
 		end
 
-		return StringLower( tostring( A ) ) < StringLower( tostring( B ) )
+		return StringLower( SafeToString( A ) ) < StringLower( SafeToString( B ) )
 	end
 
 	local function TableToString( Table, Indent, Done )
@@ -454,7 +464,7 @@ do
 		Done = Done or {}
 
 		local Strings = {}
-		Strings[ 1 ] = StringFormat( "%s {", tostring( Table ) )
+		Strings[ 1 ] = StringFormat( "%s {", SafeToString( Table ) )
 		if not next( Table ) then
 			return Strings[ 1 ].."}"
 		end
@@ -496,9 +506,9 @@ do
 		table = function( Value )
 			local Meta = getmetatable( Value )
 			if IsType( Meta, "table" ) and Meta.__tostring and Meta.__PrintAsString then
-				return tostring( Value )
+				return SafeToString( Value )
 			end
-			return StringFormat( "%s (%d array element%s, %s)", Value, #Value, #Value == 1 and "" or "s",
+			return StringFormat( "%s (%d array element%s, %s)", SafeToString( Value ), #Value, #Value == 1 and "" or "s",
 				next( Value ) ~= nil and "not empty" or "empty" )
 		end
 	}, { __index = DefaultPrinters } )

--- a/lua/shine/lib/table.lua
+++ b/lua/shine/lib/table.lua
@@ -176,6 +176,19 @@ function table.Add( Destination, Source )
 	return Destination
 end
 
+--[[
+	Returns a range of values from the given table.
+]]
+function table.Slice( Table, StartIndex, EndIndex )
+	EndIndex = EndIndex or #Table
+
+	local Ret = {}
+	for i = StartIndex, EndIndex do
+		Ret[ #Ret + 1 ] = Table[ i ]
+	end
+	return Ret
+end
+
 do
 	local TableRemove = table.remove
 

--- a/test/extensions/mapvote.lua
+++ b/test/extensions/mapvote.lua
@@ -7,7 +7,186 @@ local UnitTest = Shine.UnitTest
 local MapVotePlugin = UnitTest:LoadExtension( "mapvote" )
 if not MapVotePlugin then return end
 
-local MapVote = UnitTest.MockOf( MapVotePlugin )
+local MapVote = UnitTest.MockPlugin( MapVotePlugin )
+
+function MapVote:LoadMapStats() end
+
+UnitTest:Test( "SetupMaps - Adds all valid maps from the map cycle when GetMapsFromMapCycle = true", function( Assert )
+	MapVote.Config.GetMapsFromMapCycle = true
+
+	local Cycle = {
+		maps = {
+			"ns2_derelict",
+			"ns2_tram",
+			"ns2_veil",
+			12345,
+			{ map = "ns2_summit", chance = 0.5, percent = 10 },
+			{ map = "ns2_biodome" },
+			{}
+		},
+		groups = {}
+	}
+
+	MapVote:SetupMaps( Cycle )
+
+	Assert.Equals( "Should take the map groups from the cycle", Cycle.groups, MapVote.MapGroups )
+
+	Assert.DeepEquals( "Should have copied all valid maps into Config.Maps", {
+		ns2_derelict = true,
+		ns2_tram = true,
+		ns2_veil = true,
+		ns2_biodome = true,
+		ns2_summit = true
+	}, MapVote.Config.Maps )
+
+	Assert.DeepEquals( "Should read the chance value from maps, defaulting to 1", {
+		ns2_derelict = 1,
+		ns2_tram = 1,
+		ns2_veil = 1,
+		ns2_biodome = 1,
+		ns2_summit = 0.5
+	}, MapVote.MapProbabilities )
+
+	Assert.DeepEquals( "Should copy the valid maps into MapChoices", {
+		"ns2_derelict",
+		"ns2_tram",
+		"ns2_veil",
+		{ map = "ns2_summit", chance = 0.5, percent = 10 },
+		{ map = "ns2_biodome" },
+	}, MapVote.MapChoices )
+
+	Assert.DeepEquals( "Should store table maps in MapOptions", {
+		ns2_biodome = {
+			map = "ns2_biodome"
+		},
+		ns2_summit = {
+			map = "ns2_summit",
+			chance = 0.5,
+			percent = 10
+		}
+	}, MapVote.MapOptions )
+end )
+
+UnitTest:Test( "SetupMaps - Sets up maps from config and cycle when GetMapsFromMapCycle = false", function( Assert )
+	MapVote.Config.GetMapsFromMapCycle = false
+
+	local Cycle = {
+		maps = {
+			"ns2_derelict",
+			"ns2_tram",
+			"ns2_veil",
+			12345,
+			{ map = "ns2_summit", chance = 0.5, percent = 10 },
+			{ map = "ns2_biodome" },
+			{}
+		}
+	}
+	MapVote.Config.Maps = {
+		ns2_descent = true,
+		ns2_eclipse = {
+			chance = 0.2,
+			percent = 50
+		}
+	}
+
+	MapVote:SetupMaps( Cycle )
+
+	Assert.DeepEquals( "Config.Maps should be unchanged", {
+		ns2_descent = true,
+		ns2_eclipse = {
+			map = "ns2_eclipse",
+			chance = 0.2,
+			percent = 50
+		}
+	}, MapVote.Config.Maps )
+
+	Assert.DeepEquals( "Should read the chance value from maps, defaulting to 1", {
+		ns2_derelict = 1,
+		ns2_tram = 1,
+		ns2_veil = 1,
+		ns2_biodome = 1,
+		ns2_descent = 1,
+		ns2_summit = 0.5,
+		ns2_eclipse = 0.2
+	}, MapVote.MapProbabilities )
+
+	Assert.DeepEquals( "Should copy the valid maps from the cycle into MapChoices", {
+		"ns2_derelict",
+		"ns2_tram",
+		"ns2_veil",
+		{ map = "ns2_summit", chance = 0.5, percent = 10 },
+		{ map = "ns2_biodome" },
+	}, MapVote.MapChoices )
+
+	Assert.DeepEquals( "Should store table maps in MapOptions", {
+		ns2_biodome = {
+			map = "ns2_biodome"
+		},
+		ns2_summit = {
+			map = "ns2_summit",
+			chance = 0.5,
+			percent = 10
+		},
+		ns2_eclipse = {
+			map = "ns2_eclipse",
+			chance = 0.2,
+			percent = 50
+		}
+	}, MapVote.MapOptions )
+end )
+
+function MapVote:GetCurrentMap()
+	return "ns2_veil"
+end
+
+UnitTest:Test( "GetNextMap - Returns next map vote winner if present", function( Assert )
+	MapVote.NextMap.Winner = "ns2_tram"
+	Assert.Equals( "Should return the map vote winner", "ns2_tram", MapVote:GetNextMap() )
+end )
+
+MapVote.NextMap.Winner = nil
+
+UnitTest:Test( "GetNextMap - Returns the first valid map after the current map", function( Assert )
+	MapVote.MapChoices = {
+		"ns2_summit",
+		"ns2_tram",
+		{ map = "ns2_veil" },
+		{ map = "ns2_derelict", max = 0 },
+		"ns2_biodome"
+	}
+	MapVote.Config.IgnoreAutoCycle = {
+		ns2_biodome = true,
+		ns2_summit = true
+	}
+	-- Derelict is invalid due to player count, and biodome and summit are ignored, so tram must be next.
+	Assert.Equals(
+		"Should return the first valid map after ns2_veil",
+		"ns2_tram",
+		MapVote:GetNextMap()
+	)
+end )
+
+UnitTest:Test( "GetNextMap - Returns the first map not in IgnoreAutoCycle when no maps are valid", function( Assert )
+	MapVote.MapChoices = {
+		{ map = "ns2_summit", max = 0 },
+		{ map = "ns2_tram", max = 0 },
+		{ map = "ns2_veil" },
+		{ map = "ns2_derelict", max = 0 },
+		{ map = "ns2_biodome", max = 0 }
+	}
+	MapVote.Config.IgnoreAutoCycle = {
+		ns2_derelict = true,
+		ns2_biodome = true
+	}
+	-- All maps are invalid due to player count except the current map, but only derelict and biodome are
+	-- ignored, thus the next map should be summit.
+	Assert.Equals(
+		"Should return the first map after ns2_veil not in IgnoreAutoCycle",
+		"ns2_summit",
+		MapVote:GetNextMap()
+	)
+end )
+
 MapVote.MaxNominations = 5
 MapVote.Config.Nominations.MaxTotalType = MapVote.MaxNominationsType.AUTO
 
@@ -710,6 +889,7 @@ end )
 
 MapVote.ForcedMapCount = 0
 MapVote.Config.ForcedMaps = {}
+MapVote.MapOptions = {}
 
 MapVote.Vote.Nominated = { "ns2_tram", "ns2_summit", "ns2_veil", "ns2_biodome", "ns2_eclipse" }
 function MapVote:IsValidMapChoice( Map, PlayerCount ) return Map ~= "ns2_eclipse" end

--- a/test/extensions/mapvote.lua
+++ b/test/extensions/mapvote.lua
@@ -187,6 +187,30 @@ UnitTest:Test( "GetNextMap - Returns the first map not in IgnoreAutoCycle when n
 	)
 end )
 
+function MapVote:GetCurrentMap()
+	return "ns2_unearthed"
+end
+
+UnitTest:Test( "GetNextMap - Handles current map being outside the current cycle", function( Assert )
+	MapVote.MapChoices = {
+		"ns2_summit",
+		"ns2_tram",
+		{ map = "ns2_veil" },
+		{ map = "ns2_derelict", max = 0 },
+		"ns2_biodome"
+	}
+	MapVote.Config.IgnoreAutoCycle = {
+		ns2_biodome = true,
+		ns2_summit = true
+	}
+	-- When outside the cycle, the current map index is 0, so should start from the first map.
+	Assert.Equals(
+		"Should return the first valid map in the cycle",
+		"ns2_tram",
+		MapVote:GetNextMap()
+	)
+end )
+
 MapVote.MaxNominations = 5
 MapVote.Config.Nominations.MaxTotalType = MapVote.MaxNominationsType.AUTO
 

--- a/test/lib/colour.lua
+++ b/test/lib/colour.lua
@@ -1,0 +1,122 @@
+--[[
+	Tests for colour helpers.
+]]
+
+local UnitTest = Shine.UnitTest
+
+Shine.GUI = Shine.GUI or {}
+local SGUI = Shine.GUI
+
+Script.Load( "lua/shine/lib/colour.lua" )
+
+local function AssertColoursEqual( Assert, A, B )
+	Assert.Equals( "Red values must match", A.r, B.r )
+	Assert.Equals( "Green values must match", A.g, B.g )
+	Assert.Equals( "Blue values must match", A.b, B.b )
+	Assert.Equals( "Alpha values must match", A.a, B.a )
+end
+
+UnitTest:Test( "ColourSum should add values component-wise", function( Assert )
+	local Red = Colour( 1, 0, 0 )
+	local Green = Colour( 0, 1, 0 )
+
+	AssertColoursEqual( Assert, Colour( 1, 1, 0, 2 ), SGUI.ColourSum( Red, Green ) )
+end )
+
+UnitTest:Test( "ColourSub should subtract values component-wise", function( Assert )
+	local White = Colour( 1, 1, 1 )
+	local Red = Colour( 1, 0, 0 )
+
+	AssertColoursEqual( Assert, Colour( 0, 1, 1, 0 ), SGUI.ColourSub( White, Red ) )
+end )
+
+UnitTest:Test( "CopyColour should return an exact copy", function( Assert )
+	local Orange = Colour( 1, 0.4, 0 )
+	local Copy = SGUI.CopyColour( Orange )
+
+	AssertColoursEqual( Assert, Orange, Copy )
+	Assert.NotSame( "Should have returned a new colour object", Orange, Copy )
+end )
+
+UnitTest:Test( "ColourLerp should interpolate linearly", function( Assert )
+	local ColourToLerp = Colour( 0, 0, 0 )
+	local Start = Colour( 0, 0, 0 )
+	local Diff = Colour( 1, 0.5, 0.25, 0 )
+
+	SGUI.ColourLerp( ColourToLerp, Start, 0.5, Diff )
+
+	AssertColoursEqual( Assert, Colour( 0.5, 0.25, 0.125 ), ColourToLerp )
+end )
+
+UnitTest:Test( "ColourWithAlpha should return a copy with the given alpha", function( Assert )
+	local Orange = Colour( 1, 0.4, 0 )
+	local Copy = SGUI.ColourWithAlpha( Orange, 0.5 )
+
+	AssertColoursEqual( Assert, Colour( 1, 0.4, 0, 0.5 ), Copy )
+	Assert:NotSame( Orange, Copy )
+end )
+
+UnitTest:Test( "RGBToHSV should convert colours as expected", function( Assert )
+	local H, S, V = SGUI.RGBToHSV( 1, 0, 0 )
+
+	Assert:Equals( 0, H )
+	Assert:Equals( 1, S )
+	Assert:Equals( 1, V )
+
+	H, S, V = SGUI.RGBToHSV( 0, 1, 0 )
+
+	Assert:Equals( 120 / 360, H )
+	Assert:Equals( 1, S )
+	Assert:Equals( 1, V )
+
+	H, S, V = SGUI.RGBToHSV( 0, 0, 1 )
+
+	Assert:Equals( 240 / 360, H )
+	Assert:Equals( 1, S )
+	Assert:Equals( 1, V )
+
+	H, S, V = SGUI.RGBToHSV( 0.1, 0.1, 0.1 )
+
+	Assert:Equals( 0, H )
+	Assert:Equals( 0, S )
+	Assert:Equals( 0.1, V )
+end )
+
+UnitTest:Test( "HSVToRGB should convert colours as expected", function( Assert )
+	local R, G, B = SGUI.HSVToRGB( 0, 1, 1 )
+
+	Assert:Equals( 1, R )
+	Assert:Equals( 0, G )
+	Assert:Equals( 0, B )
+
+	R, G, B = SGUI.HSVToRGB( 120 / 360, 1, 1 )
+
+	Assert:Equals( 0, R )
+	Assert:Equals( 1, G )
+	Assert:Equals( 0, B )
+
+	R, G, B = SGUI.HSVToRGB( 240 / 360, 1, 1 )
+
+	Assert:Equals( 0, R )
+	Assert:Equals( 0, G )
+	Assert:Equals( 1, B )
+
+	R, G, B = SGUI.HSVToRGB( 0, 0, 0.1 )
+
+	Assert:Equals( 0.1, R )
+	Assert:Equals( 0.1, G )
+	Assert:Equals( 0.1, B )
+end )
+
+UnitTest:Test( "SaturateColour should apply saturation multiplier as expected", function( Assert )
+	local Orange = Colour( 1, 0.4, 0 )
+	local H1, S1, V1 = SGUI.RGBToHSV( Orange.r, Orange.g, Orange.b )
+
+	local DesaturatedOrange = SGUI.SaturateColour( Orange, 0.5 )
+
+	local H2, S2, V2 = SGUI.RGBToHSV( DesaturatedOrange.r, DesaturatedOrange.g, DesaturatedOrange.b )
+
+	Assert.EqualsWithTolerance( "Hue should be unchanged", H1, H2 )
+	Assert.EqualsWithTolerance( "Saturation should be havled", S1 * 0.5, S2 )
+	Assert.EqualsWithTolerance( "Value should be unchanged", V1, V2 )
+end )

--- a/test/lib/player.lua
+++ b/test/lib/player.lua
@@ -61,6 +61,14 @@ UnitTest:Test( "SteamIDToNS2", function( Assert )
 	Assert:Equals( 2000, Shine.SteamIDToNS2( "[U:1:2000]" ) )
 end )
 
+UnitTest:Test( "NS2IDTo64", function( Assert )
+	Assert:Equals( "76561197960267728", Shine.NS2IDTo64( 2000 ) )
+end )
+
+UnitTest:Test( "SteamID64ToNS2ID", function( Assert )
+	Assert:Equals( 2000, Shine.SteamID64ToNS2ID( "76561197960267728" ) )
+end )
+
 UnitTest:Test( "CoerceToID", function( Assert )
 	Assert.Equals( "Should accept numbers", 2000, Shine.CoerceToID( 2000 ) )
 	Assert.Equals( "Should accept base-10 numbers as strings", 2000, Shine.CoerceToID( "2000" ) )

--- a/test/lib/table.lua
+++ b/test/lib/table.lua
@@ -25,6 +25,15 @@ UnitTest:Test( "Add", function( Assert )
 	Assert:ArrayEquals( { 1, 2, 3, 4, 5 , 6 }, Destination )
 end )
 
+UnitTest:Test( "Slice", function( Assert )
+	local Source = { 1, 2, 3, 4, 5, 6 }
+	local Slice = table.Slice( Source, 5 )
+	Assert:ArrayEquals( { 5, 6 }, Slice )
+
+	Slice = table.Slice( Source, 2, 4 )
+	Assert:ArrayEquals( { 2, 3, 4 }, Slice )
+end )
+
 UnitTest:Test( "Mixin", function( Assert )
 	local Source = {
 		Cake = true,

--- a/test/test_init.lua
+++ b/test/test_init.lua
@@ -18,6 +18,7 @@ Shine.UnitTest = {}
 local UnitTest = Shine.UnitTest
 UnitTest.Results = {}
 
+local Abs = math.abs
 local assert = assert
 local DebugTraceback = debug.traceback
 local getmetatable = getmetatable
@@ -214,6 +215,18 @@ end
 UnitTest.Assert = {
 	Equals = function( A, B ) return A == B, StringFormat( "Expected %s to equal %s", B, A ) end,
 	NotEquals = function( A, B ) return A ~= B, StringFormat( "Expected %s to not equal %s", B, A ) end,
+
+	Same = function( A, B )
+		return rawequal( A, B ), StringFormat( "Expected %s to be raw-equal to %s", B, A )
+	end,
+	NotSame = function( A, B ) return
+		not rawequal( A, B ), StringFormat( "Expected %s to not be raw-equal to %s", B, A )
+	end,
+
+	EqualsWithTolerance = function( A, B, Tolerance )
+		Tolerance = Tolerance or 1e-5
+		return Abs( A - B ) < Tolerance, StringFormat( "Expected %s to equal %s within %s", B, A, Tolerance )
+	end,
 
 	TableEquals = function( A, B )
 		for Key, Value in pairs( A ) do


### PR DESCRIPTION
#### Map Vote
* Fixed the map vote opening on top of other menus (such as NS2+'s end of round stats). The vote menu will now wait until all other menus are closed before opening automatically.

#### Vote Shuffle
* Fixed a script error that occurred when assigning players to teams caused by build 328 changes.

#### Misc
* Fixed various issues with SGUI:
  * Skins now work as expected, and a new light theme skin has been added.
  * Fixed hidden windows capturing mouse focus.
  * Fixed scrolling behaviour when a panel can be scrolled both horizontally and vertically.
  * Fixed inconsistent layout invalidation behaviour.
* Translucent web pages no longer show the "Loading..." text when they have finished loading in the standard web page viewer.
* Fixed a few other minor script errors.