### PR TITLE
Fix ClientConnect hook order, improve OnScriptDisconnect hook

### DIFF
--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -630,7 +630,8 @@ if Client then
 	return
 end
 
-do
+-- Need to ensure connection events fire after Gamerules sees them, otherwise no player is assigned to the client.
+local function HookConnectionEvents()
 	local function ClientConnect( Client )
 		Call( "ClientConnect", Client )
 	end
@@ -640,7 +641,10 @@ do
 		Call( "ClientDisconnect", Client )
 	end
 	Event.Hook( "ClientDisconnect", ClientDisconnect )
+end
+Add( "MapPostLoad", HookConnectionEvents, HookConnectionEvents, MAX_PRIORITY )
 
+do
 	local function MapLoadEntity( MapName, GroupName, Values )
 		Call( "MapLoadEntity", MapName, GroupName, Values )
 	end

--- a/lua/shine/extensions/afkkick/server.lua
+++ b/lua/shine/extensions/afkkick/server.lua
@@ -4,6 +4,7 @@
 
 local Shine = Shine
 
+local assert = assert
 local Clamp = math.Clamp
 local Floor = math.floor
 local GetHumanPlayerCount = Shine.GetHumanPlayerCount
@@ -333,7 +334,7 @@ function Plugin:ClientConnect( Client )
 	if not Client or Client:GetIsVirtual() then return end
 
 	local Player = Client:GetControllingPlayer()
-	if not Player then return end
+	assert( Player, "No player assigned to non-virtual client in ClientConnect event!" )
 
 	local Now = SharedTime()
 	local MeasureStartTime = Now + ( self.Config.Delay * 60 )


### PR DESCRIPTION
* Fixed `ClientConnect` event being hooked too early after changes in the last update, which meant plugins such as AFK kick would fail to handle connection events properly.
* Prevented welcome messages plugin from handling bad calls to `Server.DIsconnectClient()`.