### PR TITLE
Minor bug fixes in the chatbox, logger config and SGUI

### DIFF
--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -61,7 +61,6 @@ Plugin.CheckConfigTypes = true
 Plugin.HandlesVoteConfig = true
 
 Shine.LoadPluginModule( "vote.lua", Plugin )
-Shine.LoadPluginModule( "logger.lua", Plugin )
 Shine.LoadPluginFile( PluginName, "gamerules.lua", Plugin )
 
 Plugin.ConfigMigrationSteps = {
@@ -257,6 +256,7 @@ do
 
 	-- Load after default validator to ensure validators merge.
 	Shine.LoadPluginFile( PluginName, "rates.lua", Plugin )
+	Shine.LoadPluginModule( "logger.lua", Plugin )
 end
 
 function Plugin:Initialise()

--- a/lua/shine/extensions/chatbox/chatline.lua
+++ b/lua/shine/extensions/chatbox/chatline.lua
@@ -98,7 +98,6 @@ function ChatLine:SetupTag( Tag, TagData )
 	Tag:SetColour( TagData.Colour )
 	Tag:SetFont( self.Font )
 	Tag:SetTextScale( self.TextScale )
-	Tag:SetupStencil()
 end
 
 do
@@ -235,7 +234,6 @@ function ChatLine:GetWrappedLabel()
 	WrappedLabel:SetFont( self.Font )
 	WrappedLabel:SetTextScale( self.TextScale )
 	WrappedLabel:SetColour( self.MessageLabel:GetColour() )
-	WrappedLabel:SetupStencil()
 
 	return WrappedLabel
 end

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -1482,7 +1482,15 @@ function ControlMeta:GetTooltipOffset( MouseX, MouseY, Tooltip )
 end
 
 function ControlMeta:ShowTooltip( MouseX, MouseY )
-	local Tooltip = SGUI.IsValid( self.Tooltip ) and self.Tooltip or SGUI:Create( "Tooltip" )
+	local Tooltip = self.Tooltip
+	if not SGUI.IsValid( Tooltip ) then
+		Tooltip = SGUI:Create( "Tooltip" )
+
+		-- As the Tooltip element is not a child of this element, the skin must be set manually.
+		if self.PropagateSkin then
+			Tooltip:SetSkin( self:GetSkin() )
+		end
+	end
 
 	local W, H = SGUI.GetScreenSize()
 	local Font

--- a/lua/shine/lib/gui/objects/button.lua
+++ b/lua/shine/lib/gui/objects/button.lua
@@ -247,6 +247,11 @@ function Button:AddMenu( Size, MenuPos )
 	end
 
 	local Menu = SGUI:Create( "Menu" )
+	-- As the Menu element is not a child of the button, the skin must be set manually.
+	if self.PropagateSkin then
+		Menu:SetSkin( self:GetSkin() )
+	end
+
 	Menu:SetPos( Pos )
 	Menu:SetButtonSize( Size or self:GetSize() )
 

--- a/lua/shine/lib/objects/logger.lua
+++ b/lua/shine/lib/objects/logger.lua
@@ -27,11 +27,12 @@ function Logger:Init( Level, Writer )
 end
 
 function Logger:SetLevel( Level )
+	local ProvidedLevel = Level
 	if Shine.IsType( Level, "string" ) then
 		Level = Logger.LogLevel[ Level ]
 	end
 
-	Shine.Assert( Logger.LogLevel[ Level ], "Unrecognised log level" )
+	Shine.AssertAtLevel( Logger.LogLevel[ Level ], "Unrecognised log level: %s", 3, ProvidedLevel )
 
 	self.Level = Level
 

--- a/lua/shine/modules/logger.lua
+++ b/lua/shine/modules/logger.lua
@@ -10,8 +10,19 @@ local TableConcat = table.concat
 local Module = {}
 
 Module.DefaultConfig = {
-	LogLevel = "Info"
+	LogLevel = "INFO"
 }
+
+do
+	local Validator = Shine.Validator()
+
+	Validator:AddFieldRule(
+		"LogLevel",
+		Validator.InEnum( Shine.Objects.Logger.LogLevel, Module.DefaultConfig.LogLevel )
+	)
+
+	Module.ConfigValidator = Validator
+end
 
 function Module:Initialise()
 	self.Logger = Shine.Objects.Logger( StringUpper( self.Config.LogLevel ), function( Text )


### PR DESCRIPTION
#### Chatbox
* Fixed some labels (commander/rookie tags and wrapped lines) being invisible in the chatbox.

#### Misc
* Fixed an error being thrown when a plugin that uses a logger has an invalid `LogLevel` in its configuration file. Invalid levels are now replaced with `INFO` and a warning is logged.
* Fixed tooltips and menus not inheriting styling from their parent element.