### PR TITLE
Improved logging, SGUI fixes, minor bug fixes

### DIFF
--- a/lua/shine/core/server/logging.lua
+++ b/lua/shine/core/server/logging.lua
@@ -10,6 +10,7 @@ local Floor = math.floor
 local Notify = Shared.Message
 local StringFormat = string.format
 local TableConcat = table.concat
+local TableEmpty = table.Empty
 local type = type
 
 --Geez what was I thinking with that old method...
@@ -63,7 +64,7 @@ function Shine:SaveLog()
 	local String = TableConcat( LogMessages, "\n" )
 	local CurrentLogFile = GetCurrentLogFile()
 
-	--This is dumb, but append mode appears to be broken.
+	-- This is dumb, but append mode appears to be broken.
 	local OldLog, Err = io.open( CurrentLogFile, "r" )
 
 	local Data = ""
@@ -84,10 +85,7 @@ function Shine:SaveLog()
 	LogFile:write( Data, String, "\n" )
 	LogFile:close()
 
-	--Empty the logging table.
-	for i = 1, #LogMessages do
-		LogMessages[ i ] = nil
-	end
+	TableEmpty( LogMessages )
 
 	return true
 end

--- a/lua/shine/core/shared/base_plugin/config.lua
+++ b/lua/shine/core/shared/base_plugin/config.lua
@@ -6,11 +6,19 @@ local Shine = Shine
 
 local IsType = Shine.IsType
 local Notify = Shared.Message
+local select = select
 local rawget = rawget
 local StringFormat = string.format
 
 local function Print( ... )
 	return Notify( StringFormat( ... ) )
+end
+local function PrintToLog( Message, ... )
+	if Server then
+		Shine:Print( Message, select( "#", ... ) > 0, ... )
+	else
+		Print( Message, ... )
+	end
 end
 
 local ConfigModule = {}
@@ -28,7 +36,7 @@ function ConfigModule:GenerateDefaultConfig( Save )
 		local Success, Err = Shine.SaveJSONFile( self.Config, Path )
 
 		if not Success then
-			Print( "Error writing %s config file: %s", self.__Name, Err )
+			PrintToLog( "[Error] Error writing %s config file: %s", self.__Name, Err )
 
 			return
 		end
@@ -44,8 +52,7 @@ function ConfigModule:SaveConfig( Silent )
 	local Success, Err = Shine.SaveJSONFile( self.Config, Path )
 
 	if not Success then
-		Print( "Error writing %s config file: %s", self.__Name, Err )
-
+		PrintToLog( "[Error] Error writing %s config file: %s", self.__Name, Err )
 		return
 	end
 
@@ -65,7 +72,7 @@ function ConfigModule:LoadConfig()
 	if Server then
 		local Gamemode = Shine.GetGamemode()
 
-		--Look for gamemode specific config file.
+		-- Look for gamemode specific config file.
 		if Gamemode ~= Shine.BaseGamemode then
 			local Paths = {
 				StringFormat( "%s%s/%s", Shine.Config.ExtensionDir, Gamemode, self.ConfigName ),
@@ -97,7 +104,7 @@ function ConfigModule:LoadConfig()
 		if IsType( Pos, "string" ) then
 			self:GenerateDefaultConfig( true )
 		else
-			Print( "Invalid JSON for %s plugin config. Error: %s. Loading default...", self.__Name, Err )
+			PrintToLog( "[Error] Invalid JSON for %s plugin config. Error: %s. Loading default...", self.__Name, Err )
 
 			self.Config = self.DefaultConfig
 		end
@@ -163,7 +170,10 @@ function ConfigModule:MigrateConfig( Config )
 		"Configuration on disk (%s) is a newer version than the loaded plugin (%s).", 0,
 		CurrentConfigVersion, OurVersion )
 
-	Print( "Updating %s config from version %s to %s...", self.__Name, CurrentConfigVersion, self.Version or "1.0" )
+	PrintToLog(
+		"Updating %s config from version %s to %s...",
+		self.__Name, CurrentConfigVersion, self.Version or "1.0"
+	)
 
 	Config.__Version = self.Version or "1.0"
 

--- a/lua/shine/core/shared/misc.lua
+++ b/lua/shine/core/shared/misc.lua
@@ -36,6 +36,9 @@ if Server then
 			4. Reliable - Whether to send reliably.
 	]]
 	function Shine:ApplyNetworkMessage( Target, MessageName, MessageTable, Reliable )
+		-- Avoid silly argument type checking error as the engine treats nil and no value differently.
+		Reliable = not not Reliable
+
 		if not Target then
 			self.SendNetworkMessage( MessageName, MessageTable, Reliable )
 			return

--- a/lua/shine/core/shared/misc.lua
+++ b/lua/shine/core/shared/misc.lua
@@ -33,11 +33,13 @@ if Server then
 			or nil to send to all.
 			2. MessageName - The name of the network message.
 			3. MessageTable - The data to send.
-			4. Reliable - Whether to send reliably.
+			4. Reliable - Whether to send reliably (default = true).
 	]]
 	function Shine:ApplyNetworkMessage( Target, MessageName, MessageTable, Reliable )
-		-- Avoid silly argument type checking error as the engine treats nil and no value differently.
-		Reliable = not not Reliable
+		-- Default to reliable sending as it's usually the intention.
+		if Reliable == nil then
+			Reliable = true
+		end
 
 		if not Target then
 			self.SendNetworkMessage( MessageName, MessageTable, Reliable )

--- a/lua/shine/extensions/ban/client.lua
+++ b/lua/shine/extensions/ban/client.lua
@@ -33,6 +33,8 @@ local function GetDurationLabel( self, Permanent, UnbanTime )
 end
 
 function Plugin:SetupAdminMenu()
+	self.BanMenuOpen = false
+
 	local Units = SGUI.Layout.Units
 	local HighResScaled = Units.HighResScaled
 	local Percentage = Units.Percentage
@@ -543,7 +545,7 @@ function Plugin:ReceiveBanData( Data )
 end
 
 function Plugin:ReceiveBanPage( PageData )
-	if not self.BanMenuOpen then return end
+	if not SGUI.IsValid( self.BanList ) then return end
 
 	self.BanList:Clear()
 

--- a/lua/shine/init.lua
+++ b/lua/shine/init.lua
@@ -32,3 +32,4 @@ Shine.BaseGamemode = "ns2"
 Shine.LoadScripts( Scripts )
 
 Shine:Print( "Shine started up successfully." )
+Shine:SaveLog()

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -94,9 +94,11 @@ do
 
 			self[ Name ] = Value
 
-			if OldValue == Value then return end
+			if OldValue == Value then return false end
 
 			self:OnPropertyChanged( Name, Value )
+
+			return true
 		end
 
 		Table[ TableGetter ] = function( self )
@@ -113,9 +115,10 @@ do
 
 		local Old = Table[ TableSetter ]
 		Table[ TableSetter ] = function( self, Value )
-			Old( self, Value )
-			for i = 1, NumModifiers do
-				RealModifiers[ i ]( self, Value )
+			if Old( self, Value ) then
+				for i = 1, NumModifiers do
+					RealModifiers[ i ]( self, Value )
+				end
 			end
 		end
 	end
@@ -173,9 +176,11 @@ do
 				BoundFields[ i ]( self, Value )
 			end
 
-			if OldValue == Value then return end
+			if OldValue == Value then return false end
 
 			self:OnPropertyChanged( Name, Value )
+
+			return true
 		end
 
 		if not Modifiers then return end
@@ -184,9 +189,10 @@ do
 
 		local Old = Table[ TableSetter ]
 		Table[ TableSetter ] = function( self, Value )
-			Old( self, Value )
-			for i = 1, NumModifiers do
-				RealModifiers[ i ]( self, Value )
+			if Old( self, Value ) then
+				for i = 1, NumModifiers do
+					RealModifiers[ i ]( self, Value )
+				end
 			end
 		end
 	end

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -1203,6 +1203,7 @@ local Easers = {
 			EasingData.Colour.a = EasingData.CurValue
 		end,
 		Setter = function( self, Element, Alpha, EasingData )
+			EasingData.Colour.a = Alpha
 			Element:SetColor( EasingData.Colour )
 		end,
 		Getter = function( self, Element )
@@ -1247,7 +1248,7 @@ function ControlMeta:GetEasing( Type, Element )
 	local Easers = self.EasingProcesses:Get( Easers[ Type ] )
 	if not Easers then return end
 
-	return Easers:Get( Element or self )
+	return Easers:Get( Element or self.Background )
 end
 
 function ControlMeta:StopEasing( Element, EasingHandler )

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -1525,7 +1525,7 @@ function ControlMeta:HideTooltip()
 end
 
 function ControlMeta:SetHighlighted( Highlighted, SkipAnim )
-	if ( Highlighted or false ) == ( self.Highlighted or false ) then return end
+	if not not Highlighted == not not self.Highlighted then return end
 
 	if Highlighted then
 		self.Highlighted = true

--- a/lua/shine/lib/gui/objects/button.lua
+++ b/lua/shine/lib/gui/objects/button.lua
@@ -205,6 +205,7 @@ function Button:SetActiveCol( Col )
 	self.ActiveCol = Col
 
 	if self.Highlighted then
+		self:StopFade( self.Background )
 		self.Background:SetColor( Col )
 	end
 end
@@ -213,6 +214,7 @@ function Button:SetInactiveCol( Col )
 	self.InactiveCol = Col
 
 	if not self.Highlighted then
+		self:StopFade( self.Background )
 		self.Background:SetColor( Col )
 	end
 end

--- a/lua/shine/lib/gui/objects/label.lua
+++ b/lua/shine/lib/gui/objects/label.lua
@@ -29,10 +29,12 @@ function Label:Initialise()
 	self.TextScale = Vector2( 1, 1 )
 	self.TextAlignmentX = GUIItem.Align_Min
 	self.TextAlignmentY = GUIItem.Align_Min
+	self.NeedsTextSizeRefresh = true
 
 	local function MarkSizeDirty()
 		self.CachedTextWidth = nil
 		self.CachedTextHeight = nil
+		self.NeedsTextSizeRefresh = true
 	end
 	self:AddPropertyChangeListener( "Text", MarkSizeDirty )
 	self:AddPropertyChangeListener( "Font", MarkSizeDirty )
@@ -171,6 +173,16 @@ function Label:SetShadow( Params )
 	self.Label:SetDropShadowEnabled( true )
 	self.Label:SetDropShadowOffset( self.ShadowOffset )
 	self.Label:SetDropShadowColor( Params.Colour )
+end
+
+function Label:Think( DeltaTime )
+	if self.NeedsTextSizeRefresh then
+		self.NeedsTextSizeRefresh = false
+		-- When cropped, the label may be invisible due to the cropping logic not evaluating this...
+		self.Label:ForceUpdateTextSize()
+	end
+
+	return self.BaseClass.ThinkWithChildren( self, DeltaTime )
 end
 
 SGUI:AddMixin( Label, "AutoSizeText" )

--- a/lua/shine/lib/gui/objects/label.lua
+++ b/lua/shine/lib/gui/objects/label.lua
@@ -19,7 +19,7 @@ SGUI.AddBoundProperty( Label, "TextAlignmentY", "Label" )
 SGUI.AddBoundProperty( Label, "TextScale", "Label:SetScale", { "InvalidatesParent" } )
 
 -- Auto-wrapping allows labels to automatically word-wrap based on a given auto-width (or fill size).
-SGUI.AddProperty( Label, "AutoWrap", { "InvalidatesParent" } )
+SGUI.AddProperty( Label, "AutoWrap", false, { "InvalidatesParent" } )
 
 function Label:Initialise()
 	self.BaseClass.Initialise( self )

--- a/lua/shine/lib/gui/objects/textentry.lua
+++ b/lua/shine/lib/gui/objects/textentry.lua
@@ -800,7 +800,7 @@ function TextEntry:GetColumnFromMouse( X )
 
 		if Pos > X then
 			local Dist = Pos - X
-			local PrevWidth = TextObj:GetTextWidth( Chars[ i - 1 ] or "" ) * self.WidthScale
+			local PrevWidth = TextObj:GetTextWidth( Chars[ i ] or "" ) * self.WidthScale
 
 			if Dist < PrevWidth * 0.5 then
 				return i

--- a/lua/shine/lib/gui/skins/default_light.lua
+++ b/lua/shine/lib/gui/skins/default_light.lua
@@ -46,9 +46,7 @@ local Skin = {
 			InactiveCol = Colour( 0.5, 0.2, 0.2, 1 ),
 			TextColour = White
 		},
-		MenuButton = {
-			InactiveCol = WindowBackground
-		},
+		MenuButton = {},
 		CategoryPanelButton = {
 			Font = Fonts.kAgencyFB_Small,
 			ActiveCol = OrangeButtonHighlight,


### PR DESCRIPTION
#### AFK Kick
* Improved debug log output to better explain what the plugin is attempting to do when applying warning actions.

#### Chatbox
* Fixed labels at the top of the chat history sometimes being invisible until scrolled into view.

#### Commander Bans
* Fixed script error that could occur when switching between the bans and commander bans tabs in quick succession.

#### Misc
* Fixed off-by-one error in `TextEntry` mouse to cursor translation which meant clicking near the start of a character would put the caret at the end of it.
* `Label` controls now ensure they render properly when they are beneath a cropped element.
* Sending network messages using `Shine:ApplyNetworkMessage` (e.g. through the plugin `SendNetworkMessage` method) now defaults to setting the reliable flag to `true` when omitted rather than throwing an error.