### PR TITLE
Minor bug fixes and improvements

### DIFF
--- a/lua/shine/core/client/config.lua
+++ b/lua/shine/core/client/config.lua
@@ -77,7 +77,7 @@ local Options = {
 			"Web page display has been", "disabled", "enabled"
 		},
 		MessageState = false,
-		Message = "Shine is set to display web pages from plugins. If you wish to globally disable web page display, then enter \"sh_disableweb 1\" into the console."
+		Message = "Shine is set to display web pages from plugins. If you wish to globally disable web page display, then enter \"sh_disableweb 1\" into the console or use the config menu."
 	},
 	{
 		Type = "Boolean",
@@ -89,7 +89,7 @@ local Options = {
 			"Web page display set to", "Steam browser", "in game window"
 		},
 		MessageState = true,
-		Message = "Shine is set to display web pages in the Steam overlay. If you wish to show them using the in game browser, then enter \"sh_viewwebinsteam 0\" into the console."
+		Message = "Shine is set to display web pages in the Steam overlay. If you wish to show them using the in game browser, then enter \"sh_viewwebinsteam 0\" into the console or use the config menu."
 	},
 	{
 		Type = "Boolean",
@@ -101,7 +101,7 @@ local Options = {
 			"Error reporting has been", "enabled", "disabled"
 		},
 		MessageState = true,
-		Message = "Shine is set to report any errors it causes on your client when you disconnect. If you do not wish it to do so, then enter \"sh_errorreport 0\" into the console."
+		Message = "Shine is set to report any errors it causes on your client. If you do not wish it to do so, then enter \"sh_errorreport 0\" into the console or use the config menu."
 	},
 	{
 		Type = "Boolean",
@@ -111,9 +111,7 @@ local Options = {
 		Data = {
 			"sh_animateui", "AnimateUI",
 			"UI animations have been", "enabled", "disabled"
-		},
-		AlwaysShowMessage = true,
-		Message = "You can enable/disable UI animations by entering \"sh_animateui\" into the console."
+		}
 	}
 }
 Shine.ClientSettings = Options
@@ -130,6 +128,9 @@ do
 		end
 	end
 end
+
+Shine.AddStartupMessage( "You can configure various client-side options using the config menu. To access it, either "..
+	"use the sh_clientconfigmenu command in the console, or use the button in the vote menu." )
 
 for i = 1, #Options do
 	local Option = Options[ i ]

--- a/lua/shine/core/client/votemenu.lua
+++ b/lua/shine/core/client/votemenu.lua
@@ -42,15 +42,20 @@ do
 		for Button, Data in pairs( Binds ) do
 			if IsType( Data, "table" ) and IsType( Data.command, "string" )
 			and Data.command:find( Command ) then
-				Candidates[ #Candidates + 1 ] = Button
+				local Binding = TableFindByField( MenuBinds, "current", Button )
 
 				-- Have to also make sure the button isn't bound in the menu's binds,
 				-- as console binds and menu binds don't check each other. Even worse,
 				-- it's completely arbitrary whether the menu bind will stop the input
 				-- reaching the console binds or not, so we just have to assume it will.
-				if not TableFindByField( MenuBinds, "current", Button ) then
+				if not Binding then
 					return true, Button
 				end
+
+				Candidates[ #Candidates + 1 ] = {
+					Button = Button,
+					Bind = Binding.detail
+				}
 			end
 		end
 

--- a/lua/shine/extensions/basecommands/client.lua
+++ b/lua/shine/extensions/basecommands/client.lua
@@ -603,7 +603,7 @@ function Plugin:UpdateAllTalk( State )
 				-- of the screen, and the inventory position doesn't account for ammo text).
 				self.SetupForVisibleInventory = true
 				self:SetIsVisible( true )
-				self:SetScaledPos( self.x, 0.05 )
+				self:SetScaledPos( self.x, 0.075 )
 			elseif not IsAlwaysVisible and self.SetupForVisibleInventory then
 				-- Inventory is only visible when in use, so we'll hide the text.
 				self.SetupForVisibleInventory = false

--- a/lua/shine/extensions/basecommands/client.lua
+++ b/lua/shine/extensions/basecommands/client.lua
@@ -92,8 +92,6 @@ function Plugin:ReceiveChangeTeam( Data )
 end
 
 function Plugin:SetupClientConfig()
-	Shine.AddStartupMessage( "You can choose to enable/disable local all talk for yourself by entering sh_alltalklocal_cl true/false." )
-
 	if self.Config.DisableLocalAllTalk then
 		self:SendNetworkMessage( "EnableLocalAllTalk", { Enabled = false }, true )
 	end

--- a/lua/shine/extensions/chatbox/client.lua
+++ b/lua/shine/extensions/chatbox/client.lua
@@ -1421,7 +1421,8 @@ EnableCommand:AddParam{ Type = "boolean", Optional = true,
 	Default = function() return not Plugin.Enabled end }
 
 Shine.Hook.Add( "OnMapLoad", "NotifyAboutChatBox", function()
-	Shine.AddStartupMessage( "Shine has a chatbox that you can enable/disable by entering \"sh_chatbox\" into the console." )
+	Shine.AddStartupMessage( "Shine has a chatbox that you can enable/disable by entering \"sh_chatbox\" into the "..
+		"console or using the config menu." )
 end )
 
 return Plugin

--- a/lua/shine/extensions/mapvote/client.lua
+++ b/lua/shine/extensions/mapvote/client.lua
@@ -49,9 +49,6 @@ function Plugin:Initialise()
 end
 
 function Plugin:SetupClientConfig()
-	Shine.AddStartupMessage( StringFormat( "You can choose whether to automatically open the map vote"
-		.." by entering sh_mapvote_onvote <%s> into the console.", TableConcat( self.VoteAction, "|" ) ) )
-
 	self:BindCommand( "sh_mapvote_onvote", function( Choice )
 		if not Choice then
 			local Explanations = {

--- a/lua/shine/extensions/mapvote/client.lua
+++ b/lua/shine/extensions/mapvote/client.lua
@@ -368,8 +368,13 @@ local function GetMapVoteText( self, NextMap, VoteButton, Maps, InitialText, Vot
 
 	if VoteButtonCandidates then
 		-- Some menu binds are conflicting with the vote menu button.
+		local Binds = {}
+		for i = 1, #VoteButtonCandidates do
+			local Binding = VoteButtonCandidates[ i ]
+			Binds[ i ] = StringFormat( "%s (%s)", Binding.Button, Binding.Bind or "UNKNOWN BIND" )
+		end
 		VoteMessage = StringFormat( "%s\n%s", VoteMessage, self:GetInterpolatedPhrase( "VOTE_BUTTON_CONFLICT", {
-			Buttons = TableConcat( VoteButtonCandidates, ", " )
+			Buttons = "\n* "..TableConcat( Binds, "\n* " )
 		} ) )
 	end
 

--- a/lua/shine/extensions/mapvote/cycle.lua
+++ b/lua/shine/extensions/mapvote/cycle.lua
@@ -260,6 +260,13 @@ function Plugin:GetNextMap()
 	return NextMap
 end
 
+local function LogMissingNextMapError( self )
+	self.Logger:Error(
+		"Unable to find a valid map to advance to! Verify the map cycle and IgnoreAutoCycle "..
+		"configuration do not exclude every possible map!"
+	)
+end
+
 function Plugin:SetupEmptyCheckTimer()
 	if not self.Config.CycleOnEmpty then return end
 
@@ -276,10 +283,7 @@ function Plugin:SetupEmptyCheckTimer()
 
 			local NextMap = self:GetNextMap()
 			if not NextMap then
-				self.Logger:Error(
-					"Unable to find a valid map to advance to! Verify the map cycle and IgnoreAutoCycle "..
-					"configuration do not exclude every possible map!"
-				)
+				LogMissingNextMapError( self )
 			else
 				MapCycle_ChangeMap( NextMap )
 			end
@@ -392,7 +396,13 @@ function Plugin:ShouldCycleMap()
 end
 
 function Plugin:OnCycleMap()
-	MapCycle_ChangeMap( self:GetNextMap() )
+	local NextMap = self:GetNextMap()
+	if not NextMap then
+		LogMissingNextMapError( self )
+		return
+	end
+
+	MapCycle_ChangeMap( NextMap )
 
 	return false
 end

--- a/lua/shine/extensions/voterandom/client.lua
+++ b/lua/shine/extensions/voterandom/client.lua
@@ -66,8 +66,6 @@ local FRIEND_GROUP_HINT_NAME = "ShuffleFriendGroupHint"
 local FRIEND_GROUP_INVITE_HINT_NAME = "ShuffleFriendGroupInviteHint"
 
 function Plugin:SetupClientConfig()
-	Shine.AddStartupMessage( "You can choose a preferred team for shuffling by entering sh_shuffle_teampref <team> into the console." )
-
 	local function SendTeamPreference( PreferredTeam )
 		self:SendNetworkMessage( "TeamPreference", { PreferredTeam = PreferredTeam }, true )
 	end


### PR DESCRIPTION
#### Map Vote
* Buttons that conflict with the vote menu binding are now listed with the action they are bound to during a map vote.
* Fixed benign error when no map can be found in the map cycle that passes the configured restrictions when cycling the map.

#### Misc
* Moved all talk text down below the team HUD when it's displayed at the top of the screen.
* Removed old startup console messages.