### PR TITLE
Add feature to increase shuffle percentage after seconds into round

### DIFF
--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -1209,7 +1209,7 @@ end
 function Plugin:GetVotesNeeded()
 	local PlayerCount = self:GetPlayerCountForVote()
 	
-	if self.VoteIncreaseTime and self.VoteIncreaseTime > SharedTime() then
+	if self.VoteIncreaseTime and SharedTime() > self.VoteIncreaseTime then
 		return Ceil ( PlayerCount * self.Config.PercentNeededAfter )	
 	end
 	

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -86,7 +86,7 @@ Plugin.ModeStrings = ModeStrings
 
 Plugin.DefaultConfig = {
 	MinPlayers = 10, -- Minimum number of players on the server to enable voting.
-	PercentNeededBefore = 0.6, -- Percentage of the server population needing to vote for it to succeed before timer.
+	PercentNeeded = 0.6, -- Percentage of the server population needing to vote for it to succeed before timer.
 	PercentNeededAfter = 0.75, -- Percentage of the server population needing to vote for it to succeed after timer.
 	PercentAfterRoundTimeInSeconds = 0, -- Time in seconds after round start to increase vote percentage. 0 to disable feature.
 
@@ -269,7 +269,6 @@ Plugin.ConfigMigrationSteps = {
 	{
 		VersionTo = "2.9",
 		Apply = Shine.Migrator()
-			:RenameField( "PercentNeeded", "PercentNeededBefore" )
 			:AddField( "PercentNeededAfter", 0.75 )
 			:AddField( "PercentAfterRoundTimeInSeconds", 0 )
 	},
@@ -1213,7 +1212,7 @@ function Plugin:GetVotesNeeded()
 		return Ceil ( PlayerCount * self.Config.PercentNeededAfter )	
 	end
 	
-	return Ceil( PlayerCount * self.Config.PercentNeededBefore )
+	return Ceil( PlayerCount * self.Config.PercentNeeded )
 end
 
 function Plugin:GetStartFailureMessage()


### PR DESCRIPTION
@Person8880 Players are abusing shuffle to reset the round when a vote reset fails. Most server operators prefer to run shuffle around 40%. This feature allows server operators to resolve this issue, by increasing the vote percentage required after a defined number of seconds into the round.