### PR TITLE
Add player count based configuration options, shuffle improvements

### DIFF
--- a/lua/shine/core/server/permissions.lua
+++ b/lua/shine/core/server/permissions.lua
@@ -303,7 +303,7 @@ do
 	local GameID = 0
 
 	Shine.Hook.Add( "ClientConnect", "AssignGameID", function( Client )
-		--I have a suspicion that this event is being called again for a client that never disconnected.
+		-- Make sure the same client isn't seen twice.
 		if GameIDs:Get( Client ) then return true end
 
 		GameID = GameID + 1
@@ -311,7 +311,7 @@ do
 	end, Shine.Hook.MAX_PRIORITY )
 
 	Shine.Hook.Add( "ClientDisconnect", "AssignGameID", function( Client )
-		GameIDs:Remove( Client )
+		if not GameIDs:Remove( Client ) then return true end
 	end, Shine.Hook.MAX_PRIORITY )
 end
 

--- a/lua/shine/core/server/permissions.lua
+++ b/lua/shine/core/server/permissions.lua
@@ -297,10 +297,14 @@ end )
 ]]
 do
 	local GameIDs = Shine.Map()
-
 	Shine.GameIDs = GameIDs
 
 	local GameID = 0
+	local HumanPlayerCount = 0
+	local function GetHumanPlayerCount()
+		return HumanPlayerCount
+	end
+	Shine.GetHumanPlayerCount = GetHumanPlayerCount
 
 	Shine.Hook.Add( "ClientConnect", "AssignGameID", function( Client )
 		-- Make sure the same client isn't seen twice.
@@ -308,10 +312,14 @@ do
 
 		GameID = GameID + 1
 		GameIDs:Add( Client, GameID )
+
+		HumanPlayerCount = HumanPlayerCount + ( Client:GetIsVirtual() and 0 or 1 )
 	end, Shine.Hook.MAX_PRIORITY )
 
 	Shine.Hook.Add( "ClientDisconnect", "AssignGameID", function( Client )
 		if not GameIDs:Remove( Client ) then return true end
+
+		HumanPlayerCount = HumanPlayerCount - ( Client:GetIsVirtual() and 0 or 1 )
 	end, Shine.Hook.MAX_PRIORITY )
 end
 

--- a/lua/shine/core/shared/config.lua
+++ b/lua/shine/core/shared/config.lua
@@ -572,6 +572,14 @@ do
 		return self
 	end
 
+	function Migrator:CopyField( FromName, ToName )
+		self.Actions[ #self.Actions + 1 ] = function( Config )
+			local OldValue = TableGetField( Config, FromName )
+			TableSetField( Config, ToName, OldValue )
+		end
+		return self
+	end
+
 	function Migrator:RemoveField( FieldName )
 		self.Actions[ #self.Actions + 1 ] = function( Config )
 			TableSetField( Config, FieldName, nil )

--- a/lua/shine/core/shared/config.lua
+++ b/lua/shine/core/shared/config.lua
@@ -10,6 +10,7 @@ local xpcall = xpcall
 local setmetatable = setmetatable
 local StringFormat = string.format
 local StringUpper = string.upper
+local TableCopy = table.Copy
 local TableGetField = table.GetField
 local TableSetField = table.SetField
 local TableToJSON = table.ToJSON
@@ -575,6 +576,10 @@ do
 	function Migrator:CopyField( FromName, ToName )
 		self.Actions[ #self.Actions + 1 ] = function( Config )
 			local OldValue = TableGetField( Config, FromName )
+			if IsType( OldValue, "table" ) then
+				-- Avoid copying by reference so later actions don't mutate both the old and new field.
+				OldValue = TableCopy( OldValue )
+			end
 			TableSetField( Config, ToName, OldValue )
 		end
 		return self

--- a/lua/shine/core/shared/config.lua
+++ b/lua/shine/core/shared/config.lua
@@ -298,13 +298,14 @@ do
 		}
 	end
 
-	function Validator.ValidateField( Name, Predicate, FixFunc, MessageFunc )
-		-- Preserve backwards compatibiity in case anyone passed in their own functions here.
-		if IsType( Predicate, "table" ) then
-			FixFunc = Predicate.Fix
-			MessageFunc = Predicate.Message
-			Predicate = Predicate.Check
-		end
+	function Validator.ValidateField( Name, Rule, Options )
+		Shine.TypeCheck( Rule, "table", 2, "ValidateField" )
+		Shine.TypeCheck( Options, { "table", "nil" }, 3, "ValidateField" )
+
+		local FixFunc = Rule.Fix
+		local MessageFunc = Rule.Message
+		local Predicate = Rule.Check
+		local DeleteIfFieldInvalid = Options and Options.DeleteIfFieldInvalid
 
 		return {
 			Check = function( Value )
@@ -330,7 +331,12 @@ do
 					return nil
 				end
 
-				Value[ Name ] = FixFunc( Value[ Name ] )
+				local FixedValue = FixFunc( Value[ Name ] )
+				if FixedValue == nil and DeleteIfFieldInvalid then
+					return nil
+				end
+
+				Value[ Name ] = FixedValue
 
 				return Value
 			end,

--- a/lua/shine/extensions/adverts/advert_stream.lua
+++ b/lua/shine/extensions/adverts/advert_stream.lua
@@ -175,7 +175,7 @@ function AdvertStream:OnPlayerCountChanged( PlayerCount )
 
 	if not self:CanStart( PlayerCount ) then
 		self:Stop()
-	elseif not self:IsStartedByTrigger() then
+	elseif not self:IsStartedByTrigger() and ( self.MinPlayers or self.MaxPlayers ) then
 		self:Start()
 	end
 end

--- a/lua/shine/extensions/adverts/advert_stream.lua
+++ b/lua/shine/extensions/adverts/advert_stream.lua
@@ -41,6 +41,9 @@ function AdvertStream:Init( Plugin, AdvertsList, Options )
 	self.RequiresGameStateFiltering = Options.RequiresGameStateFiltering
 	self.RandomiseOrder = Options.RandomiseOrder
 	self.Loop = Options.Loop
+	self.MinPlayers = Options.MinPlayers
+	self.MaxPlayers = Options.MaxPlayers
+	self.PlayerCount = 0
 
 	self.StartingTriggers = Options.StartingTriggers or {}
 	self.StoppingTriggers = Options.StoppingTriggers or {}
@@ -133,7 +136,7 @@ function AdvertStream:WillStartOnTrigger( TriggerName )
 end
 
 function AdvertStream:OnTrigger( TriggerName )
-	if self.StartingTriggers[ TriggerName ] then
+	if self.StartingTriggers[ TriggerName ] and self:CanStart( self.PlayerCount ) then
 		self:Start()
 	end
 	if self.StoppingTriggers[ TriggerName ] then
@@ -155,6 +158,28 @@ function AdvertStream:OnGameStateChanged( NewState )
 	end
 end
 
+function AdvertStream:CanStart( PlayerCount )
+	if self.MinPlayers and PlayerCount < self.MinPlayers then
+		return false
+	end
+
+	if self.MaxPlayers and PlayerCount > self.MaxPlayers then
+		return false
+	end
+
+	return true
+end
+
+function AdvertStream:OnPlayerCountChanged( PlayerCount )
+	self.PlayerCount = PlayerCount
+
+	if not self:CanStart( PlayerCount ) then
+		self:Stop()
+	elseif not self:IsStartedByTrigger() then
+		self:Start()
+	end
+end
+
 function AdvertStream:QueueNextAdvert( DelayOverride )
 	self:StopTimer()
 
@@ -172,16 +197,42 @@ function AdvertStream:QueueNextAdvert( DelayOverride )
 	end
 end
 
-function AdvertStream:DisplayAndAdvance()
-	local Message = self.CurrentMessageIndex
+local function GetNextMessageIndex( self, MessageIndex )
+	return ( MessageIndex % #self.CurrentAdvertsList ) + 1
+end
+
+function AdvertStream:GetNextAdvert()
+	local MessageIndex = self.CurrentMessageIndex
 	-- Back to the start, randomise the order again.
-	if Message == 1 and self.RandomiseOrder then
+	if MessageIndex == 1 and self.RandomiseOrder then
 		TableQuickShuffle( self.CurrentAdvertsList )
 	end
 
-	self.Plugin:DisplayAdvert( self.CurrentAdvertsList[ Message ] )
+	-- Infinite looping should be detected by the config validation, but just in case, make sure to stop checking
+	-- adverts if all of them fail the player count check.
+	local NumAdverts = #self.CurrentAdvertsList
+	local Attempts = 1
+	local Advert = self.CurrentAdvertsList[ MessageIndex ]
+	while not self.IsValidForPlayerCount( Advert, self.PlayerCount ) and Attempts < NumAdverts do
+		MessageIndex = GetNextMessageIndex( self, MessageIndex )
+		Advert = self.CurrentAdvertsList[ MessageIndex ]
+		Attempts = Attempts + 1
+	end
 
-	self.CurrentMessageIndex = ( Message % #self.CurrentAdvertsList ) + 1
+	if self.IsValidForPlayerCount( Advert, self.PlayerCount ) then
+		return Advert, MessageIndex
+	end
+
+	return nil, MessageIndex
+end
+
+function AdvertStream:DisplayAndAdvance()
+	local Advert, MessageIndex = self:GetNextAdvert()
+	if Advert then
+		self.Plugin:DisplayAdvert( Advert )
+	end
+
+	self.CurrentMessageIndex = GetNextMessageIndex( self, MessageIndex )
 
 	if self.CurrentMessageIndex == 1 and not self.Loop then
 		self.Logger:Debug( "%s is stopping due to completing a cycle.", self )
@@ -243,6 +294,18 @@ function AdvertStream.FilterAdvertListForState( Adverts, CurrentAdverts, GameSta
 	end
 
 	return OutputAdverts, HasChanged
+end
+
+function AdvertStream.IsValidForPlayerCount( Advert, PlayerCount )
+	if Advert.MinPlayers and PlayerCount < Advert.MinPlayers then
+		return false
+	end
+
+	if Advert.MaxPlayers and PlayerCount > Advert.MaxPlayers then
+		return false
+	end
+
+	return true
 end
 
 function AdvertStream:__tostring()

--- a/lua/shine/extensions/afkkick/server.lua
+++ b/lua/shine/extensions/afkkick/server.lua
@@ -352,6 +352,10 @@ function Plugin:OnPlayerCountChanged()
 	self.CurrentMarkPlayersAFK = self:GetConfigValueWithRules( "MarkPlayersAFK" )
 end
 
+function Plugin:GetWarnTimeInSeconds()
+	return self.CurrentWarnTimeInSeconds
+end
+
 function Plugin:GetConfigValueWithRules( Key )
 	local Default = self.Config[ Key ]
 	local Rules = self.Config.PlayerCountRules

--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -758,24 +758,23 @@ function Plugin:CreateInfoCommands()
 
 	local function ListMaps( Client )
 		local Cycle = MapCycle_GetMapCycle()
-
-		if not Cycle or not Cycle.maps then
+		if not IsType( Cycle, "table" ) or not IsType( Cycle.maps, "table" ) then
 			Shine.PrintToConsole( Client, "Unable to load map cycle list." )
-
 			return
 		end
 
-		local Maps = Cycle.maps
+		Shine.PrintToConsole( Client, "Available maps:" )
 
-		Shine.PrintToConsole( Client, "Installed maps:" )
+		local Maps = Cycle.maps
 		for i = 1, #Maps do
 			local Map = Maps[ i ]
 			local MapName = IsType( Map, "table" ) and Map.map or Map
-
-			Shine.PrintToConsole( Client, StringFormat( "- %s", MapName ) )
+			if IsType( MapName, "string" ) then
+				Shine.PrintToConsole( Client, StringFormat( "- %s", MapName ) )
+			end
 		end
 	end
-	local ListMapsCommand = self:BindCommand( "sh_listmaps", nil, ListMaps )
+	local ListMapsCommand = self:BindCommand( "sh_listmaps", nil, ListMaps, true )
 	ListMapsCommand:Help( "Lists all installed maps on the server." )
 
 	local function ListPlugins( Client )

--- a/lua/shine/extensions/mapvote/server.lua
+++ b/lua/shine/extensions/mapvote/server.lua
@@ -531,7 +531,7 @@ function Plugin:ForcePlayersIntoReadyRoom()
 
 	local function CollectPlayer( Player )
 		local Client = Player:GetClient()
-		if not Client:GetIsVirtual() then
+		if Shine:IsValidClient( Client ) and not Client:GetIsVirtual() then
 			PlayersToMove[ #PlayersToMove + 1 ] = Player
 		end
 	end

--- a/lua/shine/extensions/readyroom.lua
+++ b/lua/shine/extensions/readyroom.lua
@@ -210,8 +210,8 @@ function Plugin:ProcessClient( Client, Time )
 		local Enabled, AFKKick = Shine:IsExtensionEnabled( "afkkick" )
 
 		if Enabled then
-			--Ignore AFK players.
-			if AFKKick:IsAFKFor( Client, AFKKick.Config.WarnTime * 60 ) then
+			-- Ignore AFK players.
+			if AFKKick:IsAFKFor( Client, AFKKick:GetWarnTimeInSeconds() ) then
 				return
 			end
 		end

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -332,7 +332,9 @@ do
 			"VotePassActions.InGame.EnforcementPolicy"
 		},
 		Validator.AllValuesSatisfy(
-			Validator.ValidateField( "Type", Validator.InEnum( Plugin.EnforcementPolicyType ) ),
+			Validator.ValidateField( "Type", Validator.InEnum( Plugin.EnforcementPolicyType ), {
+				DeleteIfFieldInvalid = true
+			} ),
 			Validator.ValidateField( "MinPlayers", Validator.IsType( "number", 0 ) ),
 			Validator.ValidateField( "MaxPlayers", Validator.IsType( "number", 0 ) )
 		)

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -91,6 +91,7 @@ Plugin.DefaultConfig = {
 	VoteTimeoutInSeconds = 60, -- Time after the last vote before the vote resets.
 	NotifyOnVote = true, --  Should all players be told through the chat when a vote is cast?
 	ApplyToBots = false, --  Should bots be shuffled, or removed?
+	BlockBotsAfterShuffle = true, -- Whether filler bots should be blocked after a shuffle removes them.
 
 	BalanceMode = Plugin.ShuffleMode.HIVE, -- How should teams be balanced?
 	FallbackMode = Plugin.ShuffleMode.KDR, -- Which method should be used if Elo/Hive fails?
@@ -302,6 +303,7 @@ Plugin.ConfigMigrationSteps = {
 			)
 			:RenameField( "AlwaysEnabled", "AutoShuffleAtRoundStart" )
 			:AddField( "EndOfRoundShuffleDelayInSeconds", Plugin.DefaultConfig.EndOfRoundShuffleDelayInSeconds )
+			:AddField( "BlockBotsAfterShuffle", Plugin.DefaultConfig.BlockBotsAfterShuffle )
 	}
 }
 

--- a/lua/shine/extensions/voterandom/team_balance.lua
+++ b/lua/shine/extensions/voterandom/team_balance.lua
@@ -323,7 +323,9 @@ end
 
 function BalanceModule:UpdateBots()
 	if self.OptimisingTeams then return false end
-	if self.HasShuffledThisRound and not self.Config.ApplyToBots then return false end
+	if self.HasShuffledThisRound and not self.Config.ApplyToBots and self.Config.BlockBotsAfterShuffle then
+		return false
+	end
 end
 
 local function DebugLogTeamMembers( Logger, self, TeamMembers )

--- a/lua/shine/lib/player.lua
+++ b/lua/shine/lib/player.lua
@@ -187,22 +187,6 @@ do
 	end
 end
 
-do
-	local HumanPlayerCount = 0
-	local function GetHumanPlayerCount()
-		return HumanPlayerCount
-	end
-	Shine.GetHumanPlayerCount = GetHumanPlayerCount
-
-	Hook.Add( "ClientConnect", GetHumanPlayerCount, function( Client )
-		HumanPlayerCount = HumanPlayerCount + ( Client:GetIsVirtual() and 0 or 1 )
-	end )
-
-	Hook.Add( "ClientDisconnect", GetHumanPlayerCount, function( Client )
-		HumanPlayerCount = HumanPlayerCount - ( Client:GetIsVirtual() and 0 or 1 )
-	end )
-end
-
 --[[
 	Returns a table of all players.
 ]]

--- a/lua/shine/lib/player.lua
+++ b/lua/shine/lib/player.lua
@@ -50,6 +50,8 @@ end
 
 if Client then return end
 
+local Hook = Shine.Hook
+
 local Abs = math.abs
 local Floor = math.floor
 local GetOwner = Server.GetOwner
@@ -108,7 +110,6 @@ function Shine.EqualiseTeamCounts( TeamMembers )
 end
 
 do
-	local Hook = Shine.Hook
 	local OnJoinError = Shine.BuildErrorHandler( "EvenlySpreadTeams team join error" )
 
 	local function MoveToTeam( Gamerules, Players, TeamNumber )
@@ -186,21 +187,20 @@ do
 	end
 end
 
---[[
-	Returns the number of human players (clients).
-]]
-function Shine.GetHumanPlayerCount()
-	local Count = 0
-
-	local GameIDs = Shine.GameIDs
-
-	for Client, ID in GameIDs:Iterate() do
-		if Client.GetIsVirtual and not Client:GetIsVirtual() then
-			Count = Count + 1
-		end
+do
+	local HumanPlayerCount = 0
+	local function GetHumanPlayerCount()
+		return HumanPlayerCount
 	end
+	Shine.GetHumanPlayerCount = GetHumanPlayerCount
 
-	return Count
+	Hook.Add( "ClientConnect", GetHumanPlayerCount, function( Client )
+		HumanPlayerCount = HumanPlayerCount + ( Client:GetIsVirtual() and 0 or 1 )
+	end )
+
+	Hook.Add( "ClientDisconnect", GetHumanPlayerCount, function( Client )
+		HumanPlayerCount = HumanPlayerCount - ( Client:GetIsVirtual() and 0 or 1 )
+	end )
 end
 
 --[[

--- a/test/core/shared/config.lua
+++ b/test/core/shared/config.lua
@@ -40,7 +40,9 @@ UnitTest:Test( "Validator", function( Assert )
 		Validator.ValidateField( "ShouldBeNumber", Validator.IsType( "number", 1 ) ),
 		Validator.ValidateField( "CanBeNilOrNumber", Validator.IsAnyType( { "number", "nil" }, 5 ) ),
 		Validator.ValidateField( "CanBeNilOrNumber", Validator.IfType( "number", Validator.Min( 5 ) ) ),
-		Validator.ValidateField( "Enum", Validator.InEnum( Enum, Enum.A ) )
+		Validator.ValidateField( "Enum", Validator.InEnum( Enum, Enum.A ) ),
+		Validator.ValidateField( "SecondEnum", Validator.InEnum( Enum ), { DeleteIfFieldInvalid = true } ),
+		Validator.ValidateField( "ThirdEnum", Validator.InEnum( Enum ) )
 	) )
 
 	Validator:CheckTypesAgainstDefault( "TypeCheckedChild", {
@@ -60,8 +62,10 @@ UnitTest:Test( "Validator", function( Assert )
 		SingleEnum = "a",
 		AnotherEnum = "C",
 		ListOfTables = {
-			{ ShouldBeNumber = 0, Enum = "b" },
-			{ ShouldBeNumber = "1", CanBeNilOrNumber = true }
+			{ ShouldBeNumber = 0, Enum = "b", SecondEnum = "A", ThirdEnum = 123 },
+			{ ShouldBeNumber = "1", CanBeNilOrNumber = true, SecondEnum = "B", ThirdEnum = "a" },
+			-- This should be deleted due to the DeleteIfFieldInvalid flag.
+			{ SecondEnum = "C" }
 		},
 		TypeCheckedChild = {
 			A = true,
@@ -95,8 +99,8 @@ UnitTest:Test( "Validator", function( Assert )
 		AnotherEnum = "B",
 		ListOfTables = {
 			-- Should correct each entry in the list.
-			{ ShouldBeNumber = 0, Enum = "B" },
-			{ ShouldBeNumber = 1, CanBeNilOrNumber = 5, Enum = "A" }
+			{ ShouldBeNumber = 0, Enum = "B", SecondEnum = "A" },
+			{ ShouldBeNumber = 1, CanBeNilOrNumber = 5, Enum = "A", SecondEnum = "B", ThirdEnum = "A" }
 		},
 		TypeCheckedChild = {
 			-- Should ensure all fields have the same type as the default config.

--- a/test/core/shared/config.lua
+++ b/test/core/shared/config.lua
@@ -38,7 +38,8 @@ UnitTest:Test( "Validator", function( Assert )
 
 	Validator:AddFieldRule( "ListOfTables", Validator.AllValuesSatisfy(
 		Validator.ValidateField( "ShouldBeNumber", Validator.IsType( "number", 1 ) ),
-		Validator.ValidateField( "CanBeNilOrNumber", Validator.IsAnyType( { "number", "nil" }, 0 ) ),
+		Validator.ValidateField( "CanBeNilOrNumber", Validator.IsAnyType( { "number", "nil" }, 5 ) ),
+		Validator.ValidateField( "CanBeNilOrNumber", Validator.IfType( "number", Validator.Min( 5 ) ) ),
 		Validator.ValidateField( "Enum", Validator.InEnum( Enum, Enum.A ) )
 	) )
 
@@ -95,7 +96,7 @@ UnitTest:Test( "Validator", function( Assert )
 		ListOfTables = {
 			-- Should correct each entry in the list.
 			{ ShouldBeNumber = 0, Enum = "B" },
-			{ ShouldBeNumber = 1, CanBeNilOrNumber = 0, Enum = "A" }
+			{ ShouldBeNumber = 1, CanBeNilOrNumber = 5, Enum = "A" }
 		},
 		TypeCheckedChild = {
 			-- Should ensure all fields have the same type as the default config.

--- a/test/core/shared/config.lua
+++ b/test/core/shared/config.lua
@@ -36,11 +36,10 @@ UnitTest:Test( "Validator", function( Assert )
 	Validator:AddFieldRules( { "SingleEnum", "AnotherEnum" }, Validator.InEnum( Enum, Enum.B ) )
 	Validator:AddFieldRule( "SingleEnum", Validator.IsType( "string", 1 ) )
 
-	Validator:AddFieldRule( "ListOfTables", Validator.Each(
-		Validator.ValidateField( "ShouldBeNumber", Validator.IsType( "number", 1 ) )
-	) )
-	Validator:AddFieldRule( "ListOfTables", Validator.Each(
-		Validator.ValidateField( "CanBeNilOrNumber", Validator.IsAnyType( { "number", "nil" }, 0 ) )
+	Validator:AddFieldRule( "ListOfTables", Validator.AllValuesSatisfy(
+		Validator.ValidateField( "ShouldBeNumber", Validator.IsType( "number", 1 ) ),
+		Validator.ValidateField( "CanBeNilOrNumber", Validator.IsAnyType( { "number", "nil" }, 0 ) ),
+		Validator.ValidateField( "Enum", Validator.InEnum( Enum, Enum.A ) )
 	) )
 
 	Validator:CheckTypesAgainstDefault( "TypeCheckedChild", {
@@ -60,7 +59,7 @@ UnitTest:Test( "Validator", function( Assert )
 		SingleEnum = "a",
 		AnotherEnum = "C",
 		ListOfTables = {
-			{ ShouldBeNumber = 0 },
+			{ ShouldBeNumber = 0, Enum = "b" },
 			{ ShouldBeNumber = "1", CanBeNilOrNumber = true }
 		},
 		TypeCheckedChild = {
@@ -95,8 +94,8 @@ UnitTest:Test( "Validator", function( Assert )
 		AnotherEnum = "B",
 		ListOfTables = {
 			-- Should correct each entry in the list.
-			{ ShouldBeNumber = 0 },
-			{ ShouldBeNumber = 1, CanBeNilOrNumber = 0 }
+			{ ShouldBeNumber = 0, Enum = "B" },
+			{ ShouldBeNumber = 1, CanBeNilOrNumber = 0, Enum = "A" }
 		},
 		TypeCheckedChild = {
 			-- Should ensure all fields have the same type as the default config.

--- a/test/core/shared/config.lua
+++ b/test/core/shared/config.lua
@@ -212,6 +212,7 @@ UnitTest:Test( "Migrator", function( Assert )
 		:RenameField( "A", "B" )
 		:RenameField( "C", { "Child", "C" } )
 		:RenameField( { "Nested", "Value" }, { "Child", "Value" } )
+		:CopyField( "Child", "CopiedChild" )
 		:RemoveField( "Nested" )
 		:UseEnum( "Mode", { "Mode1", "Mode2", "Mode3" } )
 		:RenameEnums( {
@@ -235,6 +236,10 @@ UnitTest:Test( "Migrator", function( Assert )
 	Assert.DeepEquals( "Migrator should apply actions as expected", {
 		B = "Value for A",
 		Child = {
+			C = "Value for C",
+			Value = true
+		},
+		CopiedChild = {
 			C = "Value for C",
 			Value = true
 		},

--- a/test/extensions/adverts.lua
+++ b/test/extensions/adverts.lua
@@ -598,6 +598,17 @@ UnitTest:Test( "AdvertStream:OnPlayerCountChanged - Starts stream is player coun
 	Assert.Equals( "The timer should have a 10 second delay", 10, Timers[ 1 ].Delay )
 end )
 
+UnitTest:Test( "AdvertStream:OnPlayerCountChanged - Does not start stream if no player count restrictions are set", function( Assert )
+	Assert.False( "Stream should not have started yet", Stream.Started )
+
+	Stream.MinPlayers = nil
+	Stream.MaxPlayers = nil
+	Stream:OnPlayerCountChanged( 8 )
+
+	Assert.False( "Stream should not start when not configured with player count restrictions", Stream.Started )
+	Assert.Equals( "Should not have queued the first advert", 0, #Timers )
+end )
+
 UnitTest:Test( "AdvertStream:OnPlayerCountChanged - Stops stream is player count is out of range", function( Assert )
 	Stream:Start()
 	Assert.True( "Stream should have started", Stream.Started )

--- a/test/extensions/afkkick.lua
+++ b/test/extensions/afkkick.lua
@@ -79,8 +79,10 @@ Shine.GetClientInfo = function() return "" end
 AFKKick.CanKickForConnectingClient = function() return true end
 
 UnitTest:Test( "KickOnConnect", function( Assert )
+	AFKKick.Config.TimeRules = {}
 	AFKKick.Config.KickOnConnect = true
 	AFKKick.Config.KickTimeInMinutes = 2
+	AFKKick:OnPlayerCountChanged()
 
 	AFKKick.Users = Shine.Map( {
 		[ 1 ] = {
@@ -101,15 +103,16 @@ UnitTest:Test( "KickOnConnect", function( Assert )
 		Kicked = true
 	end
 
-	Assert:Nil( AFKKick:CheckConnectionAllowed( 123456 ) )
-	Assert:True( Kicked )
+	Assert.Nil( "Should return nil from event", AFKKick:CheckConnectionAllowed( 123456 ) )
+	Assert.True( "Should kick AFK player to make room", Kicked )
 
 	-- Should now not kick anyone.
 	AFKKick.Config.KickTimeInMinutes = 10
+	AFKKick:OnPlayerCountChanged()
 	Kicked = false
 
-	Assert:Nil( AFKKick:CheckConnectionAllowed( 123456 ) )
-	Assert:False( Kicked )
+	Assert.Nil( "Should return nil from event", AFKKick:CheckConnectionAllowed( 123456 ) )
+	Assert.False( "Should not kick anyone as none are AFK longer than the kick time", Kicked )
 end, function()
 	AFKKick.Config.KickOnConnect = false
 end )

--- a/test/extensions/afkkick.lua
+++ b/test/extensions/afkkick.lua
@@ -79,7 +79,7 @@ Shine.GetClientInfo = function() return "" end
 AFKKick.CanKickForConnectingClient = function() return true end
 
 UnitTest:Test( "KickOnConnect", function( Assert )
-	AFKKick.Config.TimeRules = {}
+	AFKKick.Config.PlayerCountRules = {}
 	AFKKick.Config.KickOnConnect = true
 	AFKKick.Config.KickTimeInMinutes = 2
 	AFKKick:OnPlayerCountChanged()
@@ -120,11 +120,13 @@ end )
 Shine.GetClientInfo = OldGetClientInfo
 
 AFKKick.Config.WarnTimeInMinutes = 1
-AFKKick.Config.TimeRules = {
+AFKKick.Config.MarkPlayersAFK = true
+AFKKick.Config.PlayerCountRules = {
 	{
 		MinPlayers = 4,
 		MaxPlayers = 8,
-		WarnTimeInMinutes = 2
+		WarnTimeInMinutes = 2,
+		MarkPlayersAFK = false
 	},
 	{
 		MinPlayers = 9,
@@ -138,14 +140,14 @@ function AFKKick:GetPlayerCount()
 	return PlayerCount
 end
 
-UnitTest:Test( "GetTimeValueWithRules - Returns default when no rule matches", function( Assert )
+UnitTest:Test( "GetConfigValueWithRules - Returns default when no rule matches", function( Assert )
 	for i = 1, 3 do
 		PlayerCount = i
 
 		Assert.Equals(
 			StringFormat( "Warn time should be the default when no time rule matches (with %d player(s))", i ),
 			1,
-			AFKKick:GetTimeValueWithRules( "WarnTimeInMinutes" )
+			AFKKick:GetConfigValueWithRules( "WarnTimeInMinutes" )
 		)
 	end
 
@@ -155,19 +157,19 @@ UnitTest:Test( "GetTimeValueWithRules - Returns default when no rule matches", f
 		Assert.Equals(
 			StringFormat( "Warn time should be the default when no time rule matches (with %d player(s))", i ),
 			1,
-			AFKKick:GetTimeValueWithRules( "WarnTimeInMinutes" )
+			AFKKick:GetConfigValueWithRules( "WarnTimeInMinutes" )
 		)
 	end
 end )
 
-UnitTest:Test( "GetTimeValueWithRules - Returns first matching rule value", function( Assert )
+UnitTest:Test( "GetConfigValueWithRules - Returns first matching rule value", function( Assert )
 	for i = 4, 8 do
 		PlayerCount = i
 
 		Assert.Equals(
 			StringFormat( "Warn time should be taken from the first matching rule (with %d player(s))", i ),
 			2,
-			AFKKick:GetTimeValueWithRules( "WarnTimeInMinutes" )
+			AFKKick:GetConfigValueWithRules( "WarnTimeInMinutes" )
 		)
 	end
 
@@ -177,7 +179,18 @@ UnitTest:Test( "GetTimeValueWithRules - Returns first matching rule value", func
 		Assert.Equals(
 			StringFormat( "Warn time should be taken from the first matching rule (with %d player(s))", i ),
 			1.5,
-			AFKKick:GetTimeValueWithRules( "WarnTimeInMinutes" )
+			AFKKick:GetConfigValueWithRules( "WarnTimeInMinutes" )
+		)
+	end
+end )
+
+UnitTest:Test( "GetConfigValueWithRules - Maintains false values from rules", function( Assert )
+	for i = 4, 8 do
+		PlayerCount = i
+
+		Assert.False(
+			StringFormat( "MarkPlayersAFK should be taken from the first matching rule (with %d player(s))", i ),
+			AFKKick:GetConfigValueWithRules( "MarkPlayersAFK" )
 		)
 	end
 end )

--- a/test/extensions/mapvote.lua
+++ b/test/extensions/mapvote.lua
@@ -144,7 +144,7 @@ do
 		function( Assert )
 			MapVote.RoundLimit = 0
 			-- ForceChangeWhenSecondsLeft = 60 means at <= 1 minute left the next map vote should start.
-			MapVote.MapCycle.time = Shared.GetTime() / 60 + 1
+			MapVote.MapCycle.time = math.floor( Shared.GetTime() / 60 ) + 1
 
 			MapVote:CheckMapLimitsAfterRoundEnd()
 

--- a/test/extensions/voterandom/voterandom.lua
+++ b/test/extensions/voterandom/voterandom.lua
@@ -366,6 +366,18 @@ UnitTest:Test( "IsRoundActive - Returns true if the game state is for an active 
 	end
 end )
 
+UnitTest:Test( "IsRoundActive - Returns true if the game state is for an active round and grace time has not expired but is ignored", function( Assert )
+	MockShuffle.InGameStateChangeTime = Shared.GetTime() + 60
+
+	local States = { "Countdown", "Started" }
+	for i = 1, #States do
+		Assert.True(
+			StringFormat( "Should return true for the %s state", States[ i ] ),
+			MockShuffle:IsRoundActive( kGameState[ States[ i ] ], true )
+		)
+	end
+end )
+
 UnitTest:Test( "IsRoundActive - Returns false if the game state is for an active round but grace time has not expired", function( Assert )
 	MockShuffle.InGameStateChangeTime = Shared.GetTime() + 60
 

--- a/test/extensions/voterandom/voterandom.lua
+++ b/test/extensions/voterandom/voterandom.lua
@@ -11,6 +11,7 @@ local MockShuffle = UnitTest.MockOf( VoteShuffle )
 
 VoteShuffle.Config.IgnoreCommanders = false
 
+local StringFormat = string.format
 local TableSort = table.sort
 
 UnitTest:Test( "AssignPlayers", function( Assert )
@@ -339,6 +340,52 @@ end
 
 UnitTest:Test( "GetVotesNeeded - Returns current constraint fraction * number of players", function( Assert )
 	Assert.Equals( "Should return player count * fraction", 15, MockShuffle:GetVotesNeeded() )
+end )
+
+UnitTest:Test( "IsRoundActive - Returns true if the game state is for an active round with no grace time", function( Assert )
+	MockShuffle.InGameStateChangeTime = false
+
+	local States = { "Countdown", "Started" }
+	for i = 1, #States do
+		Assert.True(
+			StringFormat( "Should return true for the %s state", States[ i ] ),
+			MockShuffle:IsRoundActive( kGameState[ States[ i ] ] )
+		)
+	end
+end )
+
+UnitTest:Test( "IsRoundActive - Returns true if the game state is for an active round and grace time has expired", function( Assert )
+	MockShuffle.InGameStateChangeTime = Shared.GetTime() - 60
+
+	local States = { "Countdown", "Started" }
+	for i = 1, #States do
+		Assert.True(
+			StringFormat( "Should return true for the %s state", States[ i ] ),
+			MockShuffle:IsRoundActive( kGameState[ States[ i ] ] )
+		)
+	end
+end )
+
+UnitTest:Test( "IsRoundActive - Returns false if the game state is for an active round but grace time has not expired", function( Assert )
+	MockShuffle.InGameStateChangeTime = Shared.GetTime() + 60
+
+	local States = { "Countdown", "Started" }
+	for i = 1, #States do
+		Assert.False(
+			StringFormat( "Should return false for the %s state", States[ i ] ),
+			MockShuffle:IsRoundActive( kGameState[ States[ i ] ] )
+		)
+	end
+end )
+
+UnitTest:Test( "IsRoundActive - Returns false if the game state is for an inactive round", function( Assert )
+	local States = { "NotStarted", "PreGame", "WarmUp", "Team1Won", "Team2Won", "Draw" }
+	for i = 1, #States do
+		Assert.False(
+			StringFormat( "Should return false for the %s state", States[ i ] ),
+			MockShuffle:IsRoundActive( kGameState[ States[ i ] ] )
+		)
+	end
 end )
 
 UnitTest:Test( "EvaluateConstraints - Number of players too low", function( Assert )

--- a/test/lib/utf8.lua
+++ b/test/lib/utf8.lua
@@ -5,9 +5,16 @@
 local UnitTest = Shine.UnitTest
 local StringByte = string.byte
 local StringChar = string.char
+local StringFormat = string.format
 
 UnitTest:Test( "GetUTF8Bytes", function( Assert )
-	Assert:ArrayEquals( { 0x24 }, { string.GetUTF8Bytes( "$" ) } )
+	for i = 0, 0x7F do
+		Assert.ArrayEquals(
+			StringFormat( "Expected 0x%x for ASCII byte value", i ),
+			{ i },
+			{ string.GetUTF8Bytes( StringChar( i ) ) }
+		)
+	end
 	Assert:ArrayEquals( { 0xC2, 0xA2 }, { string.GetUTF8Bytes( "¢" ) } )
 	Assert:ArrayEquals( { 0xE2, 0x82, 0xAC }, { string.GetUTF8Bytes( "€" ) } )
 	Assert:ArrayEquals( { 0xF0, 0x90, 0x8D, 0x88 }, { string.GetUTF8Bytes( "𐍈" ) } )
@@ -17,8 +24,12 @@ UnitTest:Test( "GetUTF8Bytes", function( Assert )
 	end
 
 	-- 1 byte sequence, invalid first byte
-	Assert:Nil( GetBytesForChar( 0x80 ) )
-	Assert:Nil( GetBytesForChar( 0xF5 ) )
+	for i = 0x80, 0xC1 do
+		Assert.Nil( StringFormat( "Expected invalid byte for 0x%x", i ), GetBytesForChar( i ) )
+	end
+	for i = 0xF5, 0xFF do
+		Assert.Nil( StringFormat( "Expected invalid byte for 0x%x", i ), GetBytesForChar( i ) )
+	end
 
 	-- 2 byte sequence, invalid second byte
 	Assert:Nil( GetBytesForChar( 0xC2, 0x1 ) )


### PR DESCRIPTION
#### Adverts
* Advert streams and individual adverts can now specify a `MinPlayers` and/or `MaxPlayers` constraint to prevent them displaying if the player count is not in bounds.
  * Streams with no trigger will automatically start/stop as the player count changes.
  * Streams with a trigger will stop if the player count is no longer in range, but will **not** automatically start if the player count changes to be in range. The player count conditions are evaluated when the stream's trigger fires only.
  * A stream with adverts with their own player count range will skip each advert that is not valid for the current player count until one is found that is.

#### AFK Kick
* Warning time, kick time and marking players AFK can now be configured based on player count using an array of intervals in the `PlayerCountRules` field.

#### Base Commands
* The `sh_listmaps` command is now allowed for all players by default.

#### Map Vote
* Fixed occasional script error when moving players back to the ready room.

#### Shuffle
* Enforcement policies can now specify `MinPlayers` and `MaxPlayers` to decide when they apply.
* Starting and passing conditions for the shuffle vote can now be configured depending on the current game state (`PreGame` or `InGame`) in the same way as `VotePassActions`.
  * A grace time can be specified (`StartOfRoundGraceTimeInSeconds`) to delay the transition to `InGame` to allow votes to use more lenient pass conditions at the very start of a round.
* Added `BlockBotsAfterShuffle` option to configure whether bots should be prevented from being added to teams after a shuffle vote (applies only if `ApplyToBots` is `false`).
* Improved behaviour of automatic shuffling:
  * Auto-shuffling now occurs after a reset round is started again.
  * Shuffling due to previous votes now has a configurable delay time (`EndOfRoundShuffleDelayInSeconds`) after a round ends before it is applied.