### PR TITLE
Better default values for shuffle

### DIFF
--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -112,7 +112,7 @@ Plugin.DefaultConfig = {
 			MinPlayers = 10,
 
 			-- Fraction of players that need to vote before a shuffle is performed.
-			FractionNeededToPass = 0.75,
+			FractionNeededToPass = 0.6,
 
 			-- When the number of players on playing teams is greater-equal this fraction
 			-- of the total players on the server, apply skill difference constraints.
@@ -130,7 +130,7 @@ Plugin.DefaultConfig = {
 			MinPlayers = 10,
 			FractionNeededToPass = 0.75,
 			MinPlayerFractionToConstrainSkillDiff = 0.9,
-			MinAverageDiffToAllowShuffle = 75,
+			MinAverageDiffToAllowShuffle = 125,
 			MinStandardDeviationDiffToAllowShuffle = 0,
 
 			-- How long to wait after the round starts before transitioning vote constraints/pass actions to "InGame".


### PR DESCRIPTION
1) The pregame pass threshold is too high by default. It's almost impossible to use.

2) The ingame average difference is too low by default to warrant shuffling after round start. 125 is still conservatively low. I don't think anybody would want any lower, that understands hive skill.