### PR TITLE
Improve KickOnConnect, vote options, logging and minor bug fixes

### DIFF
--- a/locale/shine/extensions/mapvote/enGB.json
+++ b/locale/shine/extensions/mapvote/enGB.json
@@ -68,6 +68,8 @@
 	"SET_MAP_ROUNDS": "set the round limit to {Duration} {Duration:Pluralise:round|rounds}.",
 	"NOTIFY_PREFIX": "[Map Vote]",
 	"PLUGIN_DISABLED": "Map vote plugin disabled. Current vote cancelled.",
+	"ERROR_CANNOT_VOTE_IN_SPECTATE": "Spectators are not allowed to vote to change the map.",
+
 	"ON_VOTE_ACTION": "When a map vote starts:",
 	"USE_SERVER_SETTINGS": "Use server settings to decide whether to open the menu",
 	"OPEN_MENU": "Open the vote menu automatically",

--- a/locale/shine/extensions/votealltalk/enGB.json
+++ b/locale/shine/extensions/votealltalk/enGB.json
@@ -8,6 +8,7 @@
 	"ERROR_ALREADY_VOTED_DISABLE": "You have already voted to disable global all talk.",
 	"ERROR_MUST_WAIT_ENABLE": "You must wait for {SecondsToWait:Duration} before voting to enable global all talk.",
 	"ERROR_MUST_WAIT_DISABLE": "You must wait for {SecondsToWait:Duration} before voting to disable global all talk.",
+	"ERROR_CANNOT_VOTE_IN_SPECTATE": "Spectators are not allowed to vote to toggle global all talk.",
 	"DISABLE_ALLTALK": "Disable All Talk",
 	"ENABLE_ALLTALK": "Enable All Talk"
 }

--- a/locale/shine/extensions/voterandom/enGB.json
+++ b/locale/shine/extensions/voterandom/enGB.json
@@ -4,6 +4,7 @@
 	"ERROR_NOT_ENOUGH_PLAYERS": "There are not enough players to start a vote.",
 	"ERROR_ROUND_TOO_FAR": "It is too far into the current round to start a vote.",
 	"ERROR_NOT_HIVE_BASED": "Hive balancing is not currently enabled.",
+	"ERROR_CANNOT_VOTE_IN_SPECTATE": "Spectators are not allowed to vote to shuffle teams.",
 	"NOTIFY_PREFIX": "[Shuffle]",
 	"AUTO_SHUFFLE_SHUFFLE_HIVE": "Shuffling teams based on Hive skill rating due to server settings.",
 	"AUTO_SHUFFLE_SHUFFLE_KDR": "Shuffling teams based on KDR due to server settings.",

--- a/lua/shine/core/client/votemenu_gui.lua
+++ b/lua/shine/core/client/votemenu_gui.lua
@@ -715,24 +715,11 @@ VoteMenu:AddPage( "Main", function( self )
 		self:ForceHide()
 	end )
 
-	if self.RequestedAdminMenu == nil then
-		self.RequestedAdminMenu = true
-
-		Shine.SendNetworkMessage( "Shine_AuthAdminMenu", {}, true )
-
-		return
-	end
-
 	if not self.CanViewAdminMenu then return end
 
 	self:AddAdminMenuButton()
 end )
 
 Client.HookNetworkMessage( "Shine_AuthAdminMenu", function( Data )
-	VoteMenu.CanViewAdminMenu = true
-
-	if VoteMenu.Visible and VoteMenu.ActivePage == "Main" then
-		VoteMenu:AddAdminMenuButton()
-		VoteMenu:SortSideButtons( true )
-	end
+	VoteMenu.CanViewAdminMenu = Data.CanUseAdminMenu
 end )

--- a/lua/shine/core/shared/votemenu.lua
+++ b/lua/shine/core/shared/votemenu.lua
@@ -14,4 +14,6 @@ local PluginMessage = {
 
 Shared.RegisterNetworkMessage( "Shine_PluginData", PluginMessage )
 Shared.RegisterNetworkMessage( "Shine_RequestPluginData", {} )
-Shared.RegisterNetworkMessage( "Shine_AuthAdminMenu", {} )
+Shared.RegisterNetworkMessage( "Shine_AuthAdminMenu", {
+	CanUseAdminMenu = "boolean"
+} )

--- a/lua/shine/extensions/afkkick/server.lua
+++ b/lua/shine/extensions/afkkick/server.lua
@@ -393,8 +393,12 @@ function Plugin:KickClient( Client )
 	Server.DisconnectClient( Client, "AFK for too long." )
 end
 
+function Plugin:CanCheckInCurrentGameState( Gamerules )
+	return not self.Config.OnlyCheckOnStarted or ( Gamerules and Gamerules:GetGameStarted() )
+end
+
 function Plugin:CanKickForConnectingClient()
-	return GetNumPlayersTotal() >= GetMaxPlayers()
+	return GetNumPlayersTotal() >= GetMaxPlayers() and self:CanCheckInCurrentGameState( GetGamerules() )
 end
 
 --[[
@@ -607,9 +611,7 @@ end
 
 function Plugin:EvaluatePlayers()
 	local Gamerules = GetGamerules()
-	local Started = Gamerules and Gamerules:GetGameStarted()
-
-	if self.Config.OnlyCheckOnStarted and not Started then return end
+	if not self:CanCheckInCurrentGameState( Gamerules ) then return end
 
 	local NumPlayers = self:GetPlayerCount()
 	if NumPlayers < self.Config.WarnMinPlayers then return end

--- a/lua/shine/extensions/afkkick/server.lua
+++ b/lua/shine/extensions/afkkick/server.lua
@@ -9,7 +9,8 @@ local Clamp = math.Clamp
 local Floor = math.floor
 local GetHumanPlayerCount = Shine.GetHumanPlayerCount
 local GetMaxPlayers = Server.GetMaxPlayers
-local GetNumPlayersTotal = Server.GetNumPlayersTotal
+local GetMaxSpectators = Server.GetMaxSpectators
+local GetNumClientsTotal = Server.GetNumClientsTotal
 local GetOwner = Server.GetOwner
 local Max = math.max
 local Random = math.random
@@ -335,6 +336,7 @@ do
 		end
 
 		self.SampleInterval = self.Config.SampleIntervalInSeconds
+		self.MinPlayersToKickOnConnect = self:GetMinPlayersToKickOnConnect( GetMaxPlayers(), GetMaxSpectators() )
 
 		self.Enabled = true
 
@@ -397,8 +399,12 @@ function Plugin:CanCheckInCurrentGameState( Gamerules )
 	return not self.Config.OnlyCheckOnStarted or ( Gamerules and Gamerules:GetGameStarted() )
 end
 
+function Plugin:GetMinPlayersToKickOnConnect( MaxPlayers, MaxSpectators )
+	return Clamp( self.Config.MinPlayers, MaxPlayers, MaxPlayers + MaxSpectators )
+end
+
 function Plugin:CanKickForConnectingClient()
-	return GetNumPlayersTotal() >= GetMaxPlayers() and self:CanCheckInCurrentGameState( GetGamerules() )
+	return GetNumClientsTotal() >= self.MinPlayersToKickOnConnect and self:CanCheckInCurrentGameState( GetGamerules() )
 end
 
 --[[
@@ -549,11 +555,10 @@ function Plugin:EvaluatePlayer( Client, DataTable, Params )
 			DataTable.Warn = true
 
 			if not IsPartiallyImmune then
-				local WillKickWhenTimeReached = NumPlayers >= self.Config.MinPlayers
 				if not self.Config.KickOnConnect then
 					local AFKTime = Time - DataTable.LastMove
 
-					if WillKickWhenTimeReached then
+					if NumPlayers >= self.Config.MinPlayers then
 						self:SendTranslatedNotify( Client, "WARN_WILL_BE_KICKED", {
 							AFKTime = Floor( WarnTime ),
 							KickTime = KickTime
@@ -566,7 +571,7 @@ function Plugin:EvaluatePlayer( Client, DataTable, Params )
 							MinPlayers = self.Config.MinPlayers
 						} )
 					end
-				elseif WillKickWhenTimeReached then
+				elseif Params.WillKickOnConnect then
 					-- Only warn players if there's actually a possibity they'll be kicked.
 					self:SendTranslatedNotify( Client, "WARN_KICK_ON_CONNECT", {
 						AFKTime = Floor( WarnTime )
@@ -621,7 +626,8 @@ function Plugin:EvaluatePlayers()
 		KickTime = self.CurrentKickTimeInSeconds,
 		WarnTime = self.Config.Warn and self.CurrentWarnTimeInSeconds,
 		NumPlayers = NumPlayers,
-		Gamerules = Gamerules
+		Gamerules = Gamerules,
+		WillKickOnConnect = self.Config.KickOnConnect and self:CanKickForConnectingClient()
 	}
 
 	for Client, DataTable in self.Users:Iterate() do

--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -172,7 +172,8 @@ do
 					return OldGetNumVotingPlayers()
 				end
 
-				return Plugin:GetNumNonAFKHumans( tonumber( Settings.AFKTimeInSeconds ) or 60 )
+				-- Never skip spectators as the game allows them to vote...
+				return Plugin:GetNumNonAFKHumans( tonumber( Settings.AFKTimeInSeconds ) or 60, false )
 			end
 		end
 		Shine.JoinUpValues( VoteUpdateFunc, OverrideVoteCount, {
@@ -208,17 +209,17 @@ end
 
 do
 	local Validator = Shine.Validator()
-	Validator:AddFieldRule( "EjectVotesNeeded", Validator.Each(
-		Validator.ValidateField( "FractionOfTeamToPass", Validator.IsType( "number" ) )
-	) )
-	Validator:AddFieldRule( "EjectVotesNeeded", Validator.Each(
-		Validator.ValidateField( "FractionOfTeamToPass", Validator.Clamp( 0, 1 ) )
-	) )
-	Validator:AddFieldRule( "EjectVotesNeeded", Validator.Each(
-		Validator.ValidateField( "MaxSecondsAsCommander", Validator.IsAnyType( { "number", "nil" } ) )
-	) )
-	Validator:AddFieldRule( "EjectVotesNeeded", Validator.Each(
+	Validator:AddFieldRule( "EjectVotesNeeded", Validator.AllValuesSatisfy(
+		Validator.ValidateField( "FractionOfTeamToPass", Validator.IsType( "number" ) ),
+		Validator.ValidateField( "FractionOfTeamToPass", Validator.Clamp( 0, 1 ) ),
+		Validator.ValidateField( "MaxSecondsAsCommander", Validator.IsAnyType( { "number", "nil" } ) ),
 		Validator.ValidateField( "MaxSecondsAsCommander", Validator.Min( 0 ) )
+	) )
+
+	Validator:AddFieldRule( "VoteSettings", Validator.AllKeyValuesSatisfy(
+		Validator.ValidateField( "ConsiderAFKPlayersInVotes", Validator.IsType( "boolean", true ) ),
+		Validator.ValidateField( "AFKTimeInSeconds", Validator.IsType( "number", 60 ) ),
+		Validator.ValidateField( "AFKTimeInSeconds", Validator.Min( 0 ) )
 	) )
 
 	Validator:AddRule( {

--- a/lua/shine/extensions/mapvote/server.lua
+++ b/lua/shine/extensions/mapvote/server.lua
@@ -285,9 +285,6 @@ local function ConvertArrayToLookup( Table )
 	end
 end
 
-Shine.LoadPluginFile( PluginName, "cycle.lua", Plugin )
-Shine.LoadPluginFile( PluginName, "voting.lua", Plugin )
-
 do
 	local StringUpper = string.upper
 
@@ -363,6 +360,9 @@ do
 
 	Plugin.ConfigValidator = Validator
 end
+
+Shine.LoadPluginFile( PluginName, "cycle.lua", Plugin )
+Shine.LoadPluginFile( PluginName, "voting.lua", Plugin )
 
 function Plugin:Initialise()
 	self:BroadcastModuleEvent( "Initialise" )

--- a/lua/shine/extensions/mapvote/voting.lua
+++ b/lua/shine/extensions/mapvote/voting.lua
@@ -234,7 +234,14 @@ end
 	Adds a vote to begin a map vote.
 ]]
 function Plugin:AddStartVote( Client )
-	if not Client then Client = "Console" end
+	if Client then
+		local Success, Err, Args = self:CanClientVote( Client )
+		if not Success then
+			return false, "Client is not eligible to vote.", Err, Args
+		end
+	else
+		Client = "Console"
+	end
 
 	local Allow, Error, Key, Data = Shine.Hook.Call( "OnVoteStart", "rtv" )
 	if Allow == false then
@@ -293,7 +300,14 @@ end
 	Adds a vote for a given map in the map vote.
 ]]
 function Plugin:AddVote( Client, Map, Revote )
-	if not Client then Client = "Console" end
+	if Client then
+		local Success, Err, Args = self:CanClientVote( Client )
+		if not Success then
+			return false, "Client is not eligible to vote.", Err, Args
+		end
+	else
+		Client = "Console"
+	end
 
 	if not self:VoteStarted() then return false, "no vote in progress" end
 	if self.Vote.Voted[ Client ] and not Revote then return false, "already voted" end

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -88,14 +88,14 @@ Plugin.ModeStrings = ModeStrings
 Plugin.DefaultConfig = {
 	BlockUntilSecondsIntoMap = 0, -- Time in seconds to block votes for after a map change.
 	BlockAfterRoundTimeInMinutes = 2, -- Time in minutes after round start to block the vote. 0 to disable blocking.
-	VoteCooldownInMinutes = 15, -- Cooldown time before another vote can be made.
+	VoteCooldownInMinutes = 1, -- Cooldown time before another vote can be made.
 	VoteTimeoutInSeconds = 60, -- Time after the last vote before the vote resets.
-	NotifyOnVote = true, --  Should all players be told through the chat when a vote is cast?
-	ApplyToBots = false, --  Should bots be shuffled, or removed?
+	NotifyOnVote = true, -- Should all players be told through the chat when a vote is cast?
+	ApplyToBots = false, -- Should bots be shuffled, or removed?
 	BlockBotsAfterShuffle = true, -- Whether filler bots should be blocked after a shuffle removes them.
 
 	BalanceMode = Plugin.ShuffleMode.HIVE, -- How should teams be balanced?
-	FallbackMode = Plugin.ShuffleMode.KDR, -- Which method should be used if Elo/Hive fails?
+	FallbackMode = Plugin.ShuffleMode.KDR, -- Which method should be used if Hive fails?
 
 	RemoveAFKPlayersFromTeams = true, -- Should the plugin remove AFK players from teams when shuffling?
 	IgnoreCommanders = true, -- Should the plugin ignore commanders when switching?
@@ -113,7 +113,7 @@ Plugin.DefaultConfig = {
 			MinPlayers = 10,
 
 			-- Fraction of players that need to vote before a shuffle is performed.
-			FractionNeededToPass = 0.75,
+			FractionNeededToPass = 0.6,
 
 			-- When the number of players on playing teams is greater-equal this fraction
 			-- of the total players on the server, apply skill difference constraints.
@@ -131,7 +131,7 @@ Plugin.DefaultConfig = {
 			MinPlayers = 10,
 			FractionNeededToPass = 0.75,
 			MinPlayerFractionToConstrainSkillDiff = 0.9,
-			MinAverageDiffToAllowShuffle = 75,
+			MinAverageDiffToAllowShuffle = 100,
 			MinStandardDeviationDiffToAllowShuffle = 0,
 
 			-- How long to wait after the round starts before transitioning vote constraints/pass actions to "InGame".

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -13,6 +13,7 @@ local DebugGetInfo = debug.getinfo
 local Floor = math.floor
 local GetAllPlayers = Shine.GetAllPlayers
 local GetNumPlayers = Shine.GetHumanPlayerCount
+local GetNumSpectators = Server.GetNumSpectators
 local GetOwner = Server.GetOwner
 local IsType = Shine.IsType
 local Max = math.max
@@ -1400,7 +1401,7 @@ function Plugin:CanStartVote()
 	end
 
 	if self.Config.BalanceMode == self.ShuffleMode.HIVE
-	and not self:EvaluateConstraints( GetNumPlayers(), self:GetTeamStats() ) then
+	and not self:EvaluateConstraints( GetNumPlayers() - GetNumSpectators(), self:GetTeamStats() ) then
 		return false, "ERROR_CONSTRAINTS"
 	end
 

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -1412,10 +1412,13 @@ end
 	Adds a player's vote to the counter.
 ]]
 function Plugin:AddVote( Client )
-	if not Client then Client = "Console" end
-
 	do
-		local Success, Err, Args = self:CanStartVote()
+		local Success, Err, Args = self:CanClientVote( Client )
+		if not Success then
+			return false, Err, Args
+		end
+
+		Success, Err, Args = self:CanStartVote()
 		if not Success then
 			return false, Err, Args
 		end

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -1522,19 +1522,28 @@ Plugin.EnforcementPolicies = {
 	end
 }
 
-function Plugin:BuildEnforcementPolicy( Settings )
-	if #Settings.EnforcementPolicy == 0 then
-		self.Logger:Debug( "No enforcement policies configured, disabling enforcement." )
-		-- No policies configured, so nothing to enforce.
-		return self.EnforcementPolicies[ self.EnforcementDurationType.NONE ]( self, Settings )
+do
+	local function PolicyToString( Policy )
+		return StringFormat( "<%s [%s, %s]>", Policy.Type, Policy.MinPlayers, Policy.MaxPlayers )
 	end
 
-	if self.Logger:IsDebugEnabled() then
-		self.Logger:Debug( "Applying enforcement policies [ %s ] with duration type %s",
-			Shine.Stream( Settings.EnforcementPolicy ):Concat( ", " ), Settings.EnforcementDurationType )
-	end
+	function Plugin:BuildEnforcementPolicy( Settings )
+		if #Settings.EnforcementPolicy == 0 then
+			self.Logger:Debug( "No enforcement policies configured, disabling enforcement." )
+			-- No policies configured, so nothing to enforce.
+			return self.EnforcementPolicies[ self.EnforcementDurationType.NONE ]( self, Settings )
+		end
 
-	return self.EnforcementPolicies[ Settings.EnforcementDurationType ]( self, Settings )
+		if self.Logger:IsDebugEnabled() then
+			self.Logger:Debug(
+				"Applying enforcement policies [ %s ] with duration type %s",
+				Shine.Stream.Of( Settings.EnforcementPolicy ):Map( PolicyToString ):Concat( ", " ),
+				Settings.EnforcementDurationType
+			)
+		end
+
+		return self.EnforcementPolicies[ Settings.EnforcementDurationType ]( self, Settings )
+	end
 end
 
 function Plugin:InitEnforcementPolicy( Settings )

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -1149,13 +1149,11 @@ function ControlMeta:HandleEasing( Time, DeltaTime )
 	for EasingHandler, Easings in self.EasingProcesses:Iterate() do
 		for Element, EasingData in Easings:Iterate() do
 			local Start = EasingData.StartTime
-			local Duration = EasingData.Duration
-
-			EasingData.Elapsed = EasingData.Elapsed + DeltaTime
-
-			local Elapsed = EasingData.Elapsed
-
 			if Start <= Time then
+				EasingData.Elapsed = EasingData.Elapsed + DeltaTime
+
+				local Duration = EasingData.Duration
+				local Elapsed = EasingData.Elapsed
 				if Elapsed <= Duration then
 					local Progress = Elapsed / Duration
 					if EasingData.EaseFunc then

--- a/lua/shine/lib/objects.lua
+++ b/lua/shine/lib/objects.lua
@@ -31,7 +31,8 @@ end
 function Shine.Implements( Value, MetaTable )
 	local ValueMetaTable = getmetatable( Value )
 	while ValueMetaTable ~= nil and ValueMetaTable ~= MetaTable do
-		ValueMetaTable = getmetatable( ValueMetaTable ).__index
+		ValueMetaTable = getmetatable( ValueMetaTable )
+		ValueMetaTable = ValueMetaTable and ValueMetaTable.__index
 	end
 	return ValueMetaTable == MetaTable
 end

--- a/lua/shine/lib/objects/set.lua
+++ b/lua/shine/lib/objects/set.lua
@@ -135,6 +135,8 @@ do
 	end
 
 	function Set:Remove( Value )
+		if not self:Contains( Value ) then return self end
+
 		return self:Filter( IsNotValue, Value )
 	end
 end
@@ -145,6 +147,8 @@ do
 	end
 
 	function Set:RemoveAll( Values )
+		if #Values == 0 then return self end
+
 		return self:Filter( NotInLookup, TableAsSet( Values ) )
 	end
 end

--- a/lua/shine/lib/player.lua
+++ b/lua/shine/lib/player.lua
@@ -187,6 +187,10 @@ do
 	end
 end
 
+function Shine.IterateClients()
+	return Shine.GameIDs:Iterate()
+end
+
 --[[
 	Returns a table of all players.
 ]]
@@ -194,9 +198,7 @@ function Shine.GetAllPlayers()
 	local Players = {}
 	local Count = 0
 
-	local GameIDs = Shine.GameIDs
-
-	for Client, ID in GameIDs:Iterate() do
+	for Client, ID in Shine.IterateClients() do
 		local Player = Client.GetControllingPlayer and Client:GetControllingPlayer()
 
 		if Player then
@@ -252,9 +254,7 @@ function Shine.GetAllClients()
 	local Clients = {}
 	local Count = 0
 
-	local GameIDs = Shine.GameIDs
-
-	for Client, ID in GameIDs:Iterate() do
+	for Client, ID in Shine.IterateClients() do
 		Count = Count + 1
 		Clients[ Count ] = Client
 	end
@@ -276,9 +276,7 @@ end
 	Returns a client matching the given game ID.
 ]]
 function Shine.GetClientByID( ID )
-	local GameIDs = Shine.GameIDs
-
-	for Client, GameID in GameIDs:Iterate() do
+	for Client, GameID in Shine.IterateClients() do
 		if ID == GameID then
 			return Client
 		end
@@ -293,9 +291,7 @@ end
 function Shine.GetClientByNS2ID( ID )
 	if not IsType( ID, "number" ) then return nil end
 
-	local Clients = Shine.GameIDs
-
-	for Client in Clients:Iterate() do
+	for Client in Shine.IterateClients() do
 		if Client:GetUserId() == ID then
 			return Client
 		end
@@ -314,7 +310,7 @@ function Shine.GetClientByName( Name )
 	local SortTable = {}
 	local Count = 0
 
-	for Client in Shine.GameIDs:Iterate() do
+	for Client in Shine.IterateClients() do
 		local Player = Client:GetControllingPlayer()
 		if Player then
 			local PlayerName = StringLower( Player:GetName() )
@@ -433,7 +429,7 @@ function Shine:GetClientsWithAccess( Access )
 	local Ret = {}
 	local Count = 0
 
-	for Client in self.GameIDs:Iterate() do
+	for Client in self.IterateClients() do
 		if self:HasAccess( Client, Access ) then
 			Count = Count + 1
 			Ret[ Count ] = Client
@@ -456,12 +452,10 @@ end
 function Shine:GetClientsByGroup( Group )
 	if Group ~= "guest" and not self.UserData.Groups[ Group ] then return {} end
 
-	local Clients = self.GameIDs
-
 	local Count = 0
 	local Ret = {}
 
-	for Client in Clients:Iterate() do
+	for Client in self.IterateClients() do
 		if self:IsInGroup( Client, Group ) then
 			Count = Count + 1
 			Ret[ Count ] = Client

--- a/lua/shine/modules/sh_vote.lua
+++ b/lua/shine/modules/sh_vote.lua
@@ -90,7 +90,12 @@ if Server then
 		end
 
 		function Module:AddVote( Client )
-			local Success, Err, Args = self:CanStartVote()
+			local Success, Err, Args = self:CanClientVote( Client )
+			if not Success then
+				return false, Err, Args
+			end
+
+			Success, Err, Args = self:CanStartVote()
 			if not Success then
 				return false, Err, Args
 			end

--- a/test/core/shared/config.lua
+++ b/test/core/shared/config.lua
@@ -45,6 +45,15 @@ UnitTest:Test( "Validator", function( Assert )
 		Validator.ValidateField( "ThirdEnum", Validator.InEnum( Enum ) )
 	) )
 
+	Validator:AddFieldRule( "KeyValues", Validator.AllKeyValuesSatisfy(
+		Validator.ValidateField( "ShouldBeNumber", Validator.IsType( "number", 1 ) ),
+		Validator.ValidateField( "CanBeNilOrNumber", Validator.IsAnyType( { "number", "nil" }, 5 ) ),
+		Validator.ValidateField( "CanBeNilOrNumber", Validator.IfType( "number", Validator.Min( 5 ) ) ),
+		Validator.ValidateField( "Enum", Validator.InEnum( Enum, Enum.A ) ),
+		Validator.ValidateField( "SecondEnum", Validator.InEnum( Enum ), { DeleteIfFieldInvalid = true } ),
+		Validator.ValidateField( "ThirdEnum", Validator.InEnum( Enum ) )
+	) )
+
 	Validator:CheckTypesAgainstDefault( "TypeCheckedChild", {
 		A = false,
 		B = "cake",
@@ -66,6 +75,17 @@ UnitTest:Test( "Validator", function( Assert )
 			{ ShouldBeNumber = "1", CanBeNilOrNumber = true, SecondEnum = "B", ThirdEnum = "a" },
 			-- This should be deleted due to the DeleteIfFieldInvalid flag.
 			{ SecondEnum = "C" }
+		},
+		KeyValues = {
+			SomeKey = {
+				ShouldBeNumber = 0,
+				Enum = "b",
+				SecondEnum = "A",
+				ThirdEnum = 123
+			},
+			AnotherKey = {
+				SecondEnum = "C"
+			}
 		},
 		TypeCheckedChild = {
 			A = true,
@@ -101,6 +121,14 @@ UnitTest:Test( "Validator", function( Assert )
 			-- Should correct each entry in the list.
 			{ ShouldBeNumber = 0, Enum = "B", SecondEnum = "A" },
 			{ ShouldBeNumber = 1, CanBeNilOrNumber = 5, Enum = "A", SecondEnum = "B", ThirdEnum = "A" }
+		},
+		KeyValues = {
+			-- Should correct each value under every key.
+			SomeKey = {
+				ShouldBeNumber = 0,
+				Enum = "B",
+				SecondEnum = "A"
+			}
 		},
 		TypeCheckedChild = {
 			-- Should ensure all fields have the same type as the default config.

--- a/test/extensions/afkkick.lua
+++ b/test/extensions/afkkick.lua
@@ -194,3 +194,34 @@ UnitTest:Test( "GetConfigValueWithRules - Maintains false values from rules", fu
 		)
 	end
 end )
+
+UnitTest:Test( "CanCheckInCurrentGameState - Returns true if OnlyCheckOnStarted = false", function( Assert )
+	local GameStarted = false
+	local Gamerules = {
+		GetGameStarted = function() return GameStarted end
+	}
+
+	AFKKick.Config.OnlyCheckOnStarted = false
+	Assert.True( "Should check when round has not started", AFKKick:CanCheckInCurrentGameState( Gamerules ) )
+
+	GameStarted = true
+	Assert.True( "Should check when round has started", AFKKick:CanCheckInCurrentGameState( Gamerules ) )
+end )
+
+UnitTest:Test( "CanCheckInCurrentGameState - Returns false if OnlyCheckOnStarted = true and a round has not started", function( Assert )
+	local Gamerules = {
+		GetGameStarted = function() return false end
+	}
+
+	AFKKick.Config.OnlyCheckOnStarted = true
+	Assert.False( "Should not check when round has not started", AFKKick:CanCheckInCurrentGameState( Gamerules ) )
+end )
+
+UnitTest:Test( "CanCheckInCurrentGameState - Returns true if OnlyCheckOnStarted = true and a round has started", function( Assert )
+	local Gamerules = {
+		GetGameStarted = function() return true end
+	}
+
+	AFKKick.Config.OnlyCheckOnStarted = true
+	Assert.True( "Should check when round has started", AFKKick:CanCheckInCurrentGameState( Gamerules ) )
+end )

--- a/test/extensions/afkkick.lua
+++ b/test/extensions/afkkick.lua
@@ -225,3 +225,28 @@ UnitTest:Test( "CanCheckInCurrentGameState - Returns true if OnlyCheckOnStarted 
 	AFKKick.Config.OnlyCheckOnStarted = true
 	Assert.True( "Should check when round has started", AFKKick:CanCheckInCurrentGameState( Gamerules ) )
 end )
+
+UnitTest:Test( "GetMinPlayersToKickOnConnect - Clamps to MaxPlayers, MaxPlayers + MaxSpectators", function( Assert )
+	AFKKick.Config.MinPlayers = 10
+	Assert.Equals(
+		"Should clamp MinPlayers when below the minimum effective value",
+		20,
+		AFKKick:GetMinPlayersToKickOnConnect( 20, 6 )
+	)
+
+	for i = 21, 26 do
+		AFKKick.Config.MinPlayers = i
+		Assert.Equals(
+			"Should use MinPlayers when within the valid range",
+			i,
+			AFKKick:GetMinPlayersToKickOnConnect( 20, 6 )
+		)
+	end
+
+	AFKKick.Config.MinPlayers = 27
+	Assert.Equals(
+		"Should clamp MinPlayers when above the maximum effective value",
+		26,
+		AFKKick:GetMinPlayersToKickOnConnect( 20, 6 )
+	)
+end )

--- a/test/lib/objects.lua
+++ b/test/lib/objects.lua
@@ -39,7 +39,7 @@ UnitTest:Test( "TypeDef inheritance", function( Assert )
 	Assert:True( InitCalled )
 end )
 
-UnitTest:Test( "Implements", function( Assert )
+UnitTest:Test( "Implements - Returns true when the value implements the given metatable", function( Assert )
 	local Base = Shine.TypeDef()
 	Base.Init = function( self ) return self end
 
@@ -48,4 +48,14 @@ UnitTest:Test( "Implements", function( Assert )
 
 	Assert.True( "Object should implement its metatable", Shine.Implements( Value, Child ) )
 	Assert.True( "Object should implement the parent metatable", Shine.Implements( Value, Base ) )
+end )
+
+UnitTest:Test( "Implements - Returns false when the value does not implement the given metatable", function( Assert )
+	local Type1 = Shine.TypeDef()
+	Type1.Init = function( self ) return self end
+
+	local Type2 = Shine.TypeDef()
+	local Value = Type1()
+
+	Assert.False( "Object should not implement the given metatable", Shine.Implements( Value, Type2 ) )
 end )


### PR DESCRIPTION
#### AFK Kick
* Fixed players being kicked when a round is not in progress, `OnlyCheckOnStarted` is `true` and `KickOnConnect` is `true`.
* `MinPlayers` is now used when `KickOnConnect` is `true` providing it is between the number of player slots, and the number of player + spectator slots.

#### Logging
* Added log messages when the Alien commander starts consuming, cancels consuming, and finishes consuming buildings, controlled by the `LogConsuming` config option (defaulting to `true`).
* Added a log message when a Marine commander cancels recycling a building (controlled by the existing `LogRecycling` config option).

#### Map Vote
* Added `VoteSettings.ConsiderSpectatorsInVotes` option to control whether spectators are included in votes.

#### Shuffle
* Spectators are no longer considered part of the total player count for `MinPlayerFractionToConstrainSkillDiff`.
* Added `VoteSettings.ConsiderSpectatorsInVotes` option to control whether spectators are included in votes.

#### Vote All Talk
* Added `VoteSettings.ConsiderSpectatorsInVotes` option to control whether spectators are included in votes.

#### Misc
* The admin menu button in the vote menu no longer pops into view the first time the menu is opened, and it will be added/removed automatically if user data is reloaded and a player's access to the admin menu has changed.