### PR TITLE
Minor shuffle improvements and bug fixes

### DIFF
--- a/locale/shine/extensions/voterandom/enGB.json
+++ b/locale/shine/extensions/voterandom/enGB.json
@@ -97,6 +97,10 @@
 	"TEAM_PREFERENCE_SET_MARINE": "Your team preference is now: Marines.",
 	"TEAM_PREFERENCE_SET_ALIEN": "Your team preference is now: Aliens.",
 	"TEAM_PREFERENCE_SET_NONE": "Your team preference has been reset.",
+	"GROUP_TEAM_PREFERENCE_HINT": "Group Team Preference:",
+	"GROUP_TEAM_PREFERENCE_SET_MARINE": "Your friend group's team preference is now: Marines.",
+	"GROUP_TEAM_PREFERENCE_SET_ALIEN": "Your friend group's team preference is now: Aliens.",
+	"GROUP_TEAM_PREFERENCE_SET_NONE": "Your friend group's team preference has been reset.",
 
 	"DISABLE_AUTO_SHUFFLE": "Disable Shuffle",
 	"ENABLE_AUTO_SHUFFLE": "Enable Shuffle",

--- a/lua/shine/core/client/votemenu_gui.lua
+++ b/lua/shine/core/client/votemenu_gui.lua
@@ -250,7 +250,7 @@ function VoteMenu:PlayerKeyPress( Key, Down )
 	if Down and IsCloseKey then
 		self:ForceHide()
 
-		return
+		return Key == InputKey.Escape or nil
 	end
 end
 

--- a/lua/shine/extensions/voterandom/client.lua
+++ b/lua/shine/extensions/voterandom/client.lua
@@ -64,6 +64,7 @@ Plugin.ConfigGroup = {
 
 local FRIEND_GROUP_HINT_NAME = "ShuffleFriendGroupHint"
 local FRIEND_GROUP_INVITE_HINT_NAME = "ShuffleFriendGroupInviteHint"
+local TEAM_PREFERENCE_CHANGE_HINT_NAME = "ShuffleTeamPreferenceConfigHint"
 
 function Plugin:SetupClientConfig()
 	local function SendTeamPreference( PreferredTeam )
@@ -82,7 +83,6 @@ function Plugin:SetupClientConfig()
 		SendTeamPreference( PreferredTeam )
 	end
 
-	local HasWarnedAboutPref = false
 	self:BindCommand( "sh_shuffle_teampref", function( PreferredTeam )
 		local OldPref = self.Config.PreferredTeam
 		local NewPref = self.TeamType[ PreferredTeam ] or self.TeamType.NONE
@@ -101,12 +101,7 @@ function Plugin:SetupClientConfig()
 
 		Print( "Team preference saved as: %s.%s", self.Config.PreferredTeam, ResetHint )
 
-		if not HasWarnedAboutPref then
-			-- Inform the player that this can be overridden by joining a team.
-			HasWarnedAboutPref = true
-			SGUI.NotificationManager.AddNotification( Shine.NotificationType.INFO,
-				self:GetPhrase( "TEAM_PREFERENCE_CHANGE_HINT" ), 10 )
-		end
+		SGUI.NotificationManager.DisplayHint( TEAM_PREFERENCE_CHANGE_HINT_NAME )
 	end ):AddParam{ Type = "team", Optional = true, Default = 3 }
 
 	self:AddClientSetting( "PreferredTeam", "sh_shuffle_teampref", {
@@ -290,6 +285,12 @@ function Plugin:OnFirstThink()
 				}
 			}
 		}
+	} )
+	SGUI.NotificationManager.RegisterHint( TEAM_PREFERENCE_CHANGE_HINT_NAME, {
+		MaxTimes = 1,
+		MessageSource = self:GetName(),
+		MessageKey = "TEAM_PREFERENCE_CHANGE_HINT",
+		HintDuration = 10
 	} )
 
 	-- Defensive check in case the scoreboard code changes.

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -715,6 +715,17 @@ do
 		Logger:Debug( "Assigned team members:\n%s", table.ToString( TeamMemberOutput ) )
 	end
 
+	function Plugin:IsClientAFK( AFKKick, Client )
+		-- Consider players that have either been stationary for the appropriate amount of time,
+		-- or have never been seen moving as AFK.
+		return AFKKick:IsAFKFor( Client, self.Config.VoteSettings.AFKTimeInSeconds )
+			or not AFKKick:HasClientMoved( Client )
+	end
+
+	function Plugin:IsRookieModeEnabled( Gamerules )
+		return Gamerules.gameInfo and Gamerules.gameInfo:GetRookieMode()
+	end
+
 	--[[
 		Gets all valid targets for sorting.
 	]]
@@ -731,7 +742,7 @@ do
 		}
 
 		local AFKEnabled, AFKKick = Shine:IsExtensionEnabled( "afkkick" )
-		local IsRookieMode = Gamerules.gameInfo and Gamerules.gameInfo:GetRookieMode()
+		local IsRookieMode = self:IsRookieModeEnabled( Gamerules )
 
 		local function AddTeamPreference( Player, Client, Preference )
 			TeamMembers.TeamPreferences[ Player ] = Preference
@@ -796,13 +807,6 @@ do
 			AddTeamPreference( Player, Client, Preference )
 		end
 
-		local function IsClientAFK( Client )
-			-- Consider players that have either been stationary for the appropriate amount of time,
-			-- or have never been seen moving as AFK.
-			return AFKKick:IsAFKFor( Client, self.Config.VoteSettings.AFKTimeInSeconds )
-				or not AFKKick:HasClientMoved( Client )
-		end
-
 		local function AddPlayer( Player, Pass )
 			if not Player then return end
 
@@ -824,7 +828,7 @@ do
 			local IsCommander = Player:isa( "Commander" ) and self.Config.IgnoreCommanders
 
 			if AFKEnabled and self.Config.RemoveAFKPlayersFromTeams then
-				if IsCommander or not IsClientAFK( Client ) then
+				if IsCommander or not self:IsClientAFK( AFKKick, Client ) then
 					-- Player is a commander or is not AFK, add them to the teams.
 					SortPlayer( Player, Client, IsCommander, Pass )
 				elseif Pass == 1 then
@@ -1316,6 +1320,51 @@ function Plugin:GetStartFailureMessage()
 	return "ERROR_CANNOT_START", { ShuffleType = ModeStrings.Mode[ self.Config.BalanceMode ] }
 end
 
+function Plugin:IsPlayerEligibleForShuffle( AFKKick, Player, IsRookieMode )
+	local Client = Player:GetClient()
+	if not Shine:IsValidClient( Client ) then return false end
+
+	if Client:GetIsVirtual() then
+		return self.Config.ApplyToBots
+	end
+
+	if
+		( IsRookieMode and not Player:GetIsRookie() ) or
+		( AFKKick and self:IsClientAFK( AFKKick, Client ) ) or
+		Shine:HasAccess( Client, "sh_randomimmune" )
+	then
+		return false
+	end
+
+	return true
+end
+
+function Plugin:HasEligiblePlayersInReadyRoom()
+	local Gamerules = GetGamerules()
+	if not Gamerules then return false end
+
+	local ReadyRoomTeam = Gamerules:GetTeam( kTeamReadyRoom )
+	if not ReadyRoomTeam then return false end
+
+	local IsRookieMode = self:IsRookieModeEnabled( Gamerules )
+
+	local AFKEnabled, AFKKick = Shine:IsExtensionEnabled( "afkkick" )
+	-- Apply AFK check only if available and configured to do so.
+	AFKKick = AFKEnabled and self.Config.RemoveAFKPlayersFromTeams and AFKKick
+
+	local HasEligiblePlayer = false
+	local function CheckPlayer( Player )
+		if self:IsPlayerEligibleForShuffle( AFKKick, Player, IsRookieMode ) then
+			HasEligiblePlayer = true
+			return false
+		end
+	end
+
+	ReadyRoomTeam:ForEachPlayer( CheckPlayer )
+
+	return HasEligiblePlayer
+end
+
 function Plugin:EvaluateConstraints( NumPlayers, TeamStats )
 	local NumOnTeam1 = #TeamStats[ 1 ].Skills
 	local NumOnTeam2 = #TeamStats[ 2 ].Skills
@@ -1329,7 +1378,14 @@ function Plugin:EvaluateConstraints( NumPlayers, TeamStats )
 		return true
 	end
 
-	if Abs( NumOnTeam1 - NumOnTeam2 ) > 1 then
+	local PlayerSizeDiff = Abs( NumOnTeam1 - NumOnTeam2 )
+	if PlayerSizeDiff == 1 and self:HasEligiblePlayersInReadyRoom() then
+		-- Teams are off by one, and there's at least 1 player that would be moved onto a team if a shuffle happens.
+		self.Logger:Debug( "Permitting vote as there is a player in the ready room that can make team counts even." )
+		return true
+	end
+
+	if PlayerSizeDiff > 1 then
 		-- Imbalanced number of players on teams, permit a shuffle.
 		self.Logger:Debug( "Permitting vote as team counts are uneven: %s vs. %s", NumOnTeam1, NumOnTeam2 )
 		return true

--- a/lua/shine/extensions/voterandom/shared.lua
+++ b/lua/shine/extensions/voterandom/shared.lua
@@ -115,6 +115,7 @@ function Plugin:SetupDataTable()
 
 	self:AddNetworkMessage( "TeamPreference", { PreferredTeam = "integer" }, "Server" )
 	self:AddNetworkMessage( "TemporaryTeamPreference", { PreferredTeam = "integer", Silent = "boolean" }, "Client" )
+	self:AddNetworkMessage( "GroupTeamPreference", { PreferredTeam = "integer", Silent = "boolean" }, "Client" )
 
 	local FriendGroupJoinTypeField = StringFormat( "integer (1 to %d)", #self.FriendGroupJoinType )
 	local FriendGroupLeaderTypeField = StringFormat( "integer (1 to %d)", #self.FriendGroupLeaderType )

--- a/test/extensions/voterandom/voterandom.lua
+++ b/test/extensions/voterandom/voterandom.lua
@@ -334,6 +334,11 @@ function MockShuffle:GetCurrentVoteConstraints()
 	return VoteConstraints
 end
 
+local HasEligiblePlayersInReadyRoom = true
+function MockShuffle:HasEligiblePlayersInReadyRoom()
+	return HasEligiblePlayersInReadyRoom
+end
+
 function MockShuffle:GetPlayerCountForVote()
 	return 20
 end
@@ -409,7 +414,7 @@ UnitTest:Test( "EvaluateConstraints - Number of players too low", function( Asse
 	)
 end )
 
-UnitTest:Test( "EvaluateConstraints - Teams imbalanced", function( Assert )
+UnitTest:Test( "EvaluateConstraints - Teams imbalanced by > 1 player", function( Assert )
 	Assert.True( "Should allow voting as teams are imbalanced",
 		MockShuffle:EvaluateConstraints( 4, {
 			{ Skills = { 1000, 2000, 2000 } },
@@ -454,6 +459,30 @@ UnitTest:Test( "EvaluateConstraints - Teams are balanced", function( Assert )
 		MockShuffle:EvaluateConstraints( 4, {
 			{ Skills = { 1500, 1500 }, Average = 1500, StandardDeviation = 0 },
 			{ Skills = { 1500, 1500 }, Average = 1500, StandardDeviation = 0 }
+		} )
+	)
+end )
+
+VoteConstraints.MinPlayerFractionToConstrainSkillDiff = 0.5
+
+UnitTest:Test( "EvaluateConstraints - Teams imbalanced by 1 player and eligible players in ready room", function( Assert )
+	HasEligiblePlayersInReadyRoom = true
+
+	Assert.True( "Should allow voting as teams are imbalanced",
+		MockShuffle:EvaluateConstraints( 4, {
+			{ Skills = { 1500, 1500 }, Average = 1500, StandardDeviation = 0 },
+			{ Skills = { 1500 }, Average = 1500, StandardDeviation = 0 }
+		} )
+	)
+end )
+
+UnitTest:Test( "EvaluateConstraints - Teams imbalanced by 1 player but no eligible players in ready room", function( Assert )
+	HasEligiblePlayersInReadyRoom = false
+
+	Assert.False( "Should deny voting when teams are sufficiently balanced",
+		MockShuffle:EvaluateConstraints( 4, {
+			{ Skills = { 1500, 1500 }, Average = 1500, StandardDeviation = 0 },
+			{ Skills = { 1500 }, Average = 1500, StandardDeviation = 0 }
 		} )
 	)
 end )


### PR DESCRIPTION
#### Vote Shuffle
* Fixed skill difference constraints preventing a shuffle when team player counts differ by 1 and there is an eligible player in the ready room that could be shuffled to make the teams even.
* Added an indication of the team preference of the friend group a player is in to make it clear when a player's own preference differs from the rest of the group.

#### Misc
* Pressing the escape key when the vote menu is open now only closes the vote menu and does not also open the main menu.
* Improved validation of user data.