### PR TITLE
Fix various minor issues with map vote

### DIFF
--- a/lua/shine/core/client/votemenu_gui.lua
+++ b/lua/shine/core/client/votemenu_gui.lua
@@ -315,8 +315,7 @@ function VoteMenu:OnResolutionChanged( OldX, OldY, NewX, NewY )
 	self:Create()
 
 	if not self.Visible then
-		self.Visible = true
-		self:SetIsVisible( false )
+		self.Background:SetIsVisible( false )
 	end
 end
 

--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -1047,7 +1047,7 @@ function Plugin:CreateAdminCommands()
 				Shine:SendPluginData( nil )
 
 				if Save then
-					SaveEnabledState( Name, PluginTable )
+					SaveEnabledState( Name, Shine.Plugins[ Name ] )
 				end
 			else
 				local Message = StringFormat( "Plugin '%s' failed to load. Error: %s", Name, Err )

--- a/lua/shine/extensions/mapvote/client.lua
+++ b/lua/shine/extensions/mapvote/client.lua
@@ -442,7 +442,6 @@ do
 		end
 
 		if not self.FullVoteMenu:GetIsVisible() then
-			SGUI:EnableMouse( true )
 			self.FullVoteMenu:FadeIn()
 
 			if SGUI.IsValid( self.MapVoteNotification ) then

--- a/lua/shine/extensions/mapvote/cycle.lua
+++ b/lua/shine/extensions/mapvote/cycle.lua
@@ -160,6 +160,31 @@ end
 ]]
 function Plugin:InferMapMods( Maps )
 	self.KnownMapMods = self:LoadMapModsCache() or {}
+	self.KnownVanillaMaps = {}
+	self.MapNameToModID = {}
+
+	-- Check all locally installed maps to find any that are known to be from mods.
+	local Changed = false
+	for i = 1, Server.GetNumMaps() do
+		local ModID = Server.GetMapModId( i )
+		local MapName = Server.GetMapName( i )
+		if ModID and ModID ~= "0" and StringFind( MapName, "^ns[12]?_" ) then
+			if not self.KnownMapMods[ ModID ] then
+				Changed = true
+				self.KnownMapMods[ ModID ] = true
+			end
+
+			self.MapNameToModID[ MapName ] = ModID
+			self.Logger:Debug( "Map %s is installed locally under mod %s.", MapName, ModID )
+		elseif not ModID or ModID == "0" then
+			self.KnownVanillaMaps[ MapName ] = true
+			self.Logger:Debug( "Map %s has no mod associated with it.", MapName )
+		end
+	end
+
+	if Changed then
+		self:SaveMapModsCache( self.KnownMapMods )
+	end
 
 	local Mods = {}
 	local ModToMapName = {}

--- a/lua/shine/extensions/mapvote/ui/map_vote_menu.lua
+++ b/lua/shine/extensions/mapvote/ui/map_vote_menu.lua
@@ -420,6 +420,8 @@ function MapVoteMenu:PlayerKeyPress( Key, Down )
 end
 
 function MapVoteMenu:FadeIn()
+	SGUI:EnableMouse( true, self )
+
 	self.FadingOut = false
 	self:SetIsVisible( true )
 	self:ApplyTransition( {
@@ -466,6 +468,7 @@ function MapVoteMenu:OnClose()
 end
 
 function MapVoteMenu:Close( Callback )
+	SGUI:EnableMouse( false, self )
 	self:PreClose()
 
 	if not self:GetIsVisible() then
@@ -476,7 +479,6 @@ function MapVoteMenu:Close( Callback )
 	end
 
 	self:FadeOut( Callback )
-	SGUI:EnableMouse( false )
 end
 
 function MapVoteMenu:SetCurrentMapName( MapName )

--- a/lua/shine/extensions/mapvote/ui/map_vote_notification.lua
+++ b/lua/shine/extensions/mapvote/ui/map_vote_notification.lua
@@ -242,7 +242,10 @@ end
 
 function MapVoteNotification:GetTeamVariation()
 	local Player = Client.GetLocalPlayer()
-	return Player and Player:isa( "Alien" ) and "Alien" or "Marine", Player and Player:GetTeamNumber() or 0
+	local TeamVariation = Player and Player:isa( "Alien" ) and "Alien" or "Marine"
+	local TeamNumber = Player and Player.GetTeamNumber and Player:GetTeamNumber() or 0
+
+	return TeamVariation, TeamNumber
 end
 
 function MapVoteNotification:UpdateCountdown()

--- a/lua/shine/extensions/mapvote/voting.lua
+++ b/lua/shine/extensions/mapvote/voting.lua
@@ -42,42 +42,85 @@ function Plugin:SendVoteOptions( Client, Options, Duration, NextMap, TimeLeft, S
 	end
 end
 
-function Plugin:SendMapMods( Client )
-	local MapList = self.Vote.MapList
-	if not MapList then return end
+do
+	local function FindBestMatchingModID( self, ModList )
+		local MapMods = Shine.Stream.Of( ModList ):Filter( function( ModID )
+			return self.KnownMapMods[ ModID ]
+		end ):AsTable()
 
-	Shine.Stream( MapList )
-		:Filter( function( Map ) return self.MapOptions[ Map ] and not self.KnownVanillaMaps[ Map ] end )
-		:ForEach( function( Map )
-			local Options = self.MapOptions[ Map ]
-			if not IsType( Options.mods, "table" ) then return end
+		-- If we know which mod is the map, use it.
+		local ModID = MapMods[ 1 ]
+		if not ModID then
+			-- Otherwise assume it's the first mod with an unknown type.
+			MapMods = Shine.Stream.Of( ModList ):Filter( function( ModID )
+				return self.KnownMapMods[ ModID ] ~= false
+			end ):AsTable()
+			ModID = MapMods[ 1 ]
+		end
 
-			local ModID = self.MapNameToModID[ Map ]
-			if not ModID then
-				local MapMods = Shine.Stream.Of( Options.mods ):Filter( function( ModID )
-					return self.KnownMapMods[ ModID ]
-				end ):AsTable()
+		return ModID
+	end
 
-				-- If we know which mod is the map, use it.
-				ModID = MapMods[ 1 ]
+	local function HasMod( ModList, ModID )
+		local ModIDBase10 = tonumber( ModID, 16 )
+		if not ModIDBase10 then return false end
 
-				if not ModID then
-					-- Otherwise assume it's the first mod with an unknown type.
-					MapMods = Shine.Stream.Of( Options.mods ):Filter( function( ModID )
-						return self.KnownMapMods[ ModID ] ~= false
-					end ):AsTable()
-					ModID = MapMods[ 1 ]
-				end
+		for i = 1, #ModList do
+			if tonumber( ModList[ i ], 16 ) == ModIDBase10 then
+				return true
 			end
+		end
 
-			if ModID and tonumber( ModID, 16 ) then
-				self.Logger:Debug( "Map %s has mod ID: %s", Map, ModID )
-				self:SendNetworkMessage( Client, "MapMod", {
-					MapName = Map,
-					ModID = ModID
-				}, true )
-			end
+		return false
+	end
+
+	local function IsModMap( MapName, Index, self )
+		local Options = self.MapOptions[ MapName ]
+		return Options and IsType( Options.mods, "table" ) and not self.KnownVanillaMaps[ MapName ]
+	end
+
+	local function GetModInfo( MapName, Index, self )
+		local Options = self.MapOptions[ MapName ]
+		local ModID = self.MapNameToModID[ MapName ]
+
+		if not ModID or not HasMod( Options.mods, ModID ) then
+			ModID = FindBestMatchingModID( self, Options.mods ) or ModID
+		end
+
+		if ModID and not tonumber( ModID, 16 ) then
+			ModID = nil
+		end
+
+		return {
+			MapName = MapName,
+			ModID = ModID
+		}
+	end
+
+	local function HasModID( Value ) return Value.ModID ~= nil end
+
+	function Plugin:GetMapModsForMapList( MapList )
+		return Shine.Stream( MapList )
+			:Filter( IsModMap, self )
+			:Map( GetModInfo, self )
+			:Filter( HasModID )
+	end
+
+	function Plugin:SendMapMods( Client )
+		local MapList = self.Vote.MapList
+		if not MapList then return end
+
+		self:GetMapModsForMapList( MapList ):ForEach( function( MapInfo )
+			local MapName = MapInfo.MapName
+			local ModID = MapInfo.ModID
+
+			self.Logger:Debug( "Map %s has mod ID: %s", MapName, ModID )
+			self:SendNetworkMessage( Client, "MapMod", {
+				MapName = MapName,
+				ModID = ModID
+			}, true )
 		end )
+	end
 end
 
 function Plugin:ClientConnect( Client )

--- a/lua/shine/extensions/mapvote/voting.lua
+++ b/lua/shine/extensions/mapvote/voting.lua
@@ -55,6 +55,7 @@ do
 			MapMods = Shine.Stream.Of( ModList ):Filter( function( ModID )
 				return self.KnownMapMods[ ModID ] ~= false
 			end ):AsTable()
+
 			ModID = MapMods[ 1 ]
 		end
 
@@ -66,7 +67,7 @@ do
 		if not ModIDBase10 then return false end
 
 		for i = 1, #ModList do
-			if tonumber( ModList[ i ], 16 ) == ModIDBase10 then
+			if IsType( ModList[ i ], "string" ) and tonumber( ModList[ i ], 16 ) == ModIDBase10 then
 				return true
 			end
 		end
@@ -87,7 +88,7 @@ do
 			ModID = FindBestMatchingModID( self, Options.mods ) or ModID
 		end
 
-		if ModID and not tonumber( ModID, 16 ) then
+		if not IsType( ModID, "string" ) or not tonumber( ModID, 16 ) then
 			ModID = nil
 		end
 

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -44,6 +44,7 @@ SGUI.GUIItemType = {
 
 SGUI.Controls = {}
 SGUI.KeyboardFocusControls = Shine.Set()
+SGUI.MouseEnabledControls = {}
 
 SGUI.ActiveControls = Map()
 SGUI.Windows = {}
@@ -533,13 +534,17 @@ do
 		Allow for multiple windows to "enable" the mouse, without
 		disabling it after one closes.
 	]]
-	function SGUI:EnableMouse( Enable )
+	function SGUI:EnableMouse( Enable, Control )
 		if not ShowMouse then
 			ShowMouse = MouseTracker_SetIsVisible
 			IsCommander = CommanderUI_IsLocalPlayerCommander
 		end
 
 		if Enable then
+			if Control and self.MouseEnabledControls[ Control ] then
+				return
+			end
+
 			self.MouseObjects = self.MouseObjects + 1
 
 			if self.MouseObjects == 1 then
@@ -549,7 +554,17 @@ do
 				end
 			end
 
+			if Control then
+				self.MouseEnabledControls[ Control ] = true
+			end
+
 			return
+		end
+
+		if Control then
+			if not self.MouseEnabledControls[ Control ] then return end
+
+			self.MouseEnabledControls[ Control ] = nil
 		end
 
 		if self.MouseObjects <= 0 then return end
@@ -1036,6 +1051,10 @@ do
 
 		self.ActiveControls:Remove( Control )
 		self.KeyboardFocusControls:Remove( Control )
+
+		if self.MouseEnabledControls[ Control ] then
+			SGUI:EnableMouse( false, Control )
+		end
 
 		if self.IsValid( Control.Tooltip ) then
 			Control.Tooltip:Destroy()

--- a/test/extensions/mapvote.lua
+++ b/test/extensions/mapvote.lua
@@ -321,6 +321,62 @@ UnitTest:Test( "SetupMaps - Sets up maps from config and cycle when GetMapsFromM
 	}, MapVote.MapOptions )
 end )
 
+UnitTest:Test( "GetMapModsForMapList - Returns expected map entries", function( Assert )
+	MapVote.MapOptions = {
+		ns2_some_mod_map = {
+			-- "123" is a known mod ID for this map, and is in the map's mods list.
+			mods = { "123", "456" }
+		},
+		ns2_some_other_mod_map = {
+			-- "456" is a known mod ID, overriding the known ID "aaa" as it's not in the list.
+			mods = { "456", "789" }
+		},
+		ns2_another_mod_map = {
+			-- "abc" is a known mod ID and there's no known ID for this specific map.
+			mods = { "789", "abc" }
+		},
+		ns2_another_map_with_no_known_mods = {
+			-- Neither of these IDs are known map mods.
+			mods = { "bbb", "ccc" }
+		}
+	}
+
+	MapVote.MapNameToModID = {
+		ns2_some_mod_map = "123",
+		ns2_some_other_mod_map = "aaa"
+	}
+
+	MapVote.KnownMapMods = {
+		[ "456" ] = true,
+		[ "abc" ] = true,
+		[ "bbb" ] = false,
+		[ "ccc" ] = false
+	}
+
+	local Stream = MapVote:GetMapModsForMapList( {
+		"ns2_some_mod_map",
+		"ns2_some_other_mod_map",
+		"ns2_another_mod_map",
+		"ns2_another_map_with_no_known_mods",
+		"ns2_origin"
+	} )
+
+	Assert.DeepEquals( "Should have assigned mod IDs to all maps with known mods", {
+		{
+			ModID = "123",
+			MapName = "ns2_some_mod_map"
+		},
+		{
+			ModID = "456",
+			MapName = "ns2_some_other_mod_map"
+		},
+		{
+			ModID = "abc",
+			MapName = "ns2_another_mod_map"
+		}
+	}, Stream:AsTable() )
+end )
+
 function MapVote:GetCurrentMap()
 	return "ns2_veil"
 end

--- a/test/extensions/mapvote.lua
+++ b/test/extensions/mapvote.lua
@@ -335,9 +335,17 @@ UnitTest:Test( "GetMapModsForMapList - Returns expected map entries", function( 
 			-- "abc" is a known mod ID and there's no known ID for this specific map.
 			mods = { "789", "abc" }
 		},
+		ns2_another_mod_map_with_an_unknown_mod = {
+			-- "eee" is not known but also not confirmed to not be a map, so it's the only choice.
+			mods = { "eee" }
+		},
 		ns2_another_map_with_no_known_mods = {
 			-- Neither of these IDs are known map mods.
 			mods = { "bbb", "ccc" }
+		},
+		ns2_map_with_non_string_mod = {
+			-- Non-string mod, should be ignored.
+			mods = { 123 }
 		}
 	}
 
@@ -357,7 +365,9 @@ UnitTest:Test( "GetMapModsForMapList - Returns expected map entries", function( 
 		"ns2_some_mod_map",
 		"ns2_some_other_mod_map",
 		"ns2_another_mod_map",
+		"ns2_another_mod_map_with_an_unknown_mod",
 		"ns2_another_map_with_no_known_mods",
+		"ns2_map_with_non_string_mod",
 		"ns2_origin"
 	} )
 
@@ -373,6 +383,10 @@ UnitTest:Test( "GetMapModsForMapList - Returns expected map entries", function( 
 		{
 			ModID = "abc",
 			MapName = "ns2_another_mod_map"
+		},
+		{
+			ModID = "eee",
+			MapName = "ns2_another_mod_map_with_an_unknown_mod"
 		}
 	}, Stream:AsTable() )
 end )


### PR DESCRIPTION
#### Base Commands
* Fixed a script error when permanently enabling a server-side only plugin that was not previously loaded.

#### Map Vote
* Improved behaviour of map preview loading to avoid texture pop-in for maps not loaded from mods.
* Improved map mod detection logic to avoid false positives in certain cases.
* Fixed a rare script error when updating the map vote notification.
