### PR TITLE
Improve performance, add vote draw plugin, minor fixes

### DIFF
--- a/locale/shine/core/enGB.json
+++ b/locale/shine/core/enGB.json
@@ -82,6 +82,7 @@
 
 	"ERROR_INVALID_JSON_IN_BASE_CONFIG": "The base configuration file has invalid JSON: {Context}",
 	"ERROR_INVALID_JSON_IN_PLUGIN_CONFIG": "Configuration file has invalid JSON: {Context}",
+	"ERROR_PLUGIN_INIT_ERROR": "An error occurred while attempting to enable the plugin:\n{Context}",
 	"WARNING_USER_CONFIG_VALIDATION_ERRORS": "Provided user configuration had validation errors which have been corrected.",
 	"WARNING_REMOTE_USER_CONFIG_VALIDATION_ERRORS": "Remote user configuration had validation errors which have been corrected. Check the local UserConfig.json file for the corrected data.",
 	"WARNING_INVALID_JSON_IN_REMOTE_USER_CONFIG": "Remote user configuration has invalid JSON: {Context}. User data has been loaded from locally cached data instead.",

--- a/locale/shine/extensions/votedraw/enGB.json
+++ b/locale/shine/extensions/votedraw/enGB.json
@@ -1,0 +1,10 @@
+{
+	"NOTIFY_PREFIX": "[Draw Vote]",
+	"VOTEMENU_BUTTON": "Vote to Draw",
+	"PLAYER_VOTED": "{PlayerName} voted to end the round as a draw ({VotesNeeded} more {VotesNeeded:Pluralise:vote|votes} needed)",
+	"PLAYER_VOTED_PRIVATE": "You voted to end the round as a draw ({VotesNeeded} more {VotesNeeded:Pluralise:vote|votes} needed)",
+	"ERROR_ALREADY_VOTED": "You have already voted to end the round as a draw.",
+	"ERROR_MUST_WAIT": "You must wait for {SecondsToWait:Duration} before voting to end the round as a draw.",
+	"ERROR_CANNOT_VOTE_ON_CURRENT_TEAM": "You cannot vote to end the round as a draw on your current team.",
+	"ERROR_ROUND_NOT_STARTED": "A round must be started to vote to end it as a draw."
+}

--- a/lua/shine/core/client/votemenu_gui.lua
+++ b/lua/shine/core/client/votemenu_gui.lua
@@ -505,7 +505,9 @@ local function AddButton( self, Pos, Anchor, Text, DoClick )
 		DoClick = DoClick,
 		IsSchemed = false
 	}
-	Button:SetHighlightOnMouseOver( true, 1, true )
+	-- Highlighting buttons is disabled until they are in the correct position. This avoids multiple buttons flashing
+	-- highlighted when the menu is opened or the page is changed.
+	Button.OnAnimationComplete = function() Button:SetHighlightOnMouseOver( true, true ) end
 	Button.ClickDelay = 0
 
 	return Button
@@ -520,9 +522,12 @@ local function HandleButton( Button, Text, DoClick, StartPos, EndPos )
 
 	if Shine.Config.AnimateUI then
 		Button:SetPos( StartPos )
-		Button:MoveTo( nil, nil, EndPos, 0, EasingTime )
+		Button:SetHighlightOnMouseOver( false )
+		Button:MoveTo( nil, nil, EndPos, 0, EasingTime, Button.OnAnimationComplete )
 	else
 		Button:SetPos( EndPos )
+		Button:StopMoving()
+		Button.OnAnimationComplete()
 	end
 end
 
@@ -549,7 +554,9 @@ function VoteMenu:AddTopButton( Text, DoClick )
 	Buttons.Top = TopButton
 
 	if Shine.Config.AnimateUI then
-		TopButton:MoveTo( nil, nil, EndPos, 0, EasingTime )
+		TopButton:MoveTo( nil, nil, EndPos, 0, EasingTime, TopButton.OnAnimationComplete )
+	else
+		TopButton.OnAnimationComplete()
 	end
 
 	return TopButton
@@ -578,7 +585,9 @@ function VoteMenu:AddBottomButton( Text, DoClick )
 	Buttons.Bottom = BottomButton
 
 	if Shine.Config.AnimateUI then
-		BottomButton:MoveTo( nil, nil, EndPos, 0, EasingTime )
+		BottomButton:MoveTo( nil, nil, EndPos, 0, EasingTime, BottomButton.OnAnimationComplete )
+	else
+		BottomButton.OnAnimationComplete()
 	end
 
 	return BottomButton
@@ -669,12 +678,14 @@ function VoteMenu:PositionButton( Button, Index, MaxIndex, Align, IgnoreAnim )
 
 	if not IgnoreAnim and Shine.Config.AnimateUI then
 		local Size = self.Background:GetSize()
+		Button:SetHighlightOnMouseOver( false )
 		Button:SetPos( Vector( Align == GUIItem.Right and -Size.x * 0.5 or 0,
 			Size.y * 0.5, 0 ) )
-		Button:MoveTo( nil, nil, Pos, 0, EasingTime )
+		Button:MoveTo( nil, nil, Pos, 0, EasingTime, Button.OnAnimationComplete )
 	else
 		Button:SetPos( Pos )
 		Button:StopMoving()
+		Button.OnAnimationComplete()
 	end
 end
 

--- a/lua/shine/core/server/config.lua
+++ b/lua/shine/core/server/config.lua
@@ -62,6 +62,7 @@ local DefaultConfig = {
 		unstuck = true,
 		usermanagement = true,
 		votealltalk = false,
+		votedraw = false,
 		voterandom = false,
 		votesurrender = true,
 		welcomemessages = false,

--- a/lua/shine/core/shared/base_plugin/config.lua
+++ b/lua/shine/core/shared/base_plugin/config.lua
@@ -259,18 +259,20 @@ function ConfigModule:MigrateConfig( Config )
 		self.__Name, CurrentConfigVersion, self.Version or "1.0"
 	)
 
-	Shine.SystemNotifications:AddNotification( {
-		Type = Shine.SystemNotifications.Type.INFO,
-		Message = {
-			Source = "Core",
-			TranslationKey = "INFO_PLUGIN_VERSION_UPDATE",
-			Context = tostring( OurVersion )
-		},
-		Source = {
-			Type = Shine.SystemNotifications.Source.PLUGIN,
-			ID = self.__Name
-		}
-	} )
+	if Server then
+		Shine.SystemNotifications:AddNotification( {
+			Type = Shine.SystemNotifications.Type.INFO,
+			Message = {
+				Source = "Core",
+				TranslationKey = "INFO_PLUGIN_VERSION_UPDATE",
+				Context = tostring( OurVersion )
+			},
+			Source = {
+				Type = Shine.SystemNotifications.Source.PLUGIN,
+				ID = self.__Name
+			}
+		} )
+	end
 
 	Config.__Version = self.Version or "1.0"
 

--- a/lua/shine/core/shared/base_plugin/timers.lua
+++ b/lua/shine/core/shared/base_plugin/timers.lua
@@ -15,7 +15,7 @@ local TimerModule = {}
 
 	Inputs: Same as Shine.Timer.Create.
 ]]
-function TimerModule:CreateTimer( Name, Delay, Reps, Func )
+function TimerModule:CreateTimer( Name, Delay, Reps, Func, Data )
 	Shine.TypeCheck( Delay, "number", 2, "CreateTimer" )
 	Shine.TypeCheck( Reps, "number", 3, "CreateTimer" )
 	Shine.TypeCheck( Func, "function", 4, "CreateTimer" )
@@ -23,7 +23,7 @@ function TimerModule:CreateTimer( Name, Delay, Reps, Func )
 	self.Timers = rawget( self, "Timers" ) or setmetatable( {}, { __mode = "v" } )
 
 	local RealName = StringFormat( "%s_%s", self.__Name, Name )
-	local Timer = Shine.Timer.Create( RealName, Delay, Reps, Func )
+	local Timer = Shine.Timer.Create( RealName, Delay, Reps, Func, Data )
 
 	self.Timers[ Name ] = Timer
 
@@ -34,13 +34,13 @@ end
 	Creates a simple timer and adds it to the list of timers associated to the plugin.
 	Inputs: Same as Shine.Timer.Simple.
 ]]
-function TimerModule:SimpleTimer( Delay, Func )
+function TimerModule:SimpleTimer( Delay, Func, Data )
 	Shine.TypeCheck( Delay, "number", 1, "SimpleTimer" )
 	Shine.TypeCheck( Func, "function", 2, "SimpleTimer" )
 
 	self.Timers = rawget( self, "Timers" ) or setmetatable( {}, { __mode = "v" } )
 
-	local Timer = Shine.Timer.Simple( Delay, Func )
+	local Timer = Shine.Timer.Simple( Delay, Func, Data )
 
 	self.Timers[ Timer.Name ] = Timer
 

--- a/lua/shine/core/shared/extensions.lua
+++ b/lua/shine/core/shared/extensions.lua
@@ -500,11 +500,8 @@ do
 	AddPluginHook = function( Plugin, Event )
 		if not IsType( Plugin[ Event ], "function" ) then return end
 
-		local Keys = PluginEventKeys[ Event ] or {}
-		PluginEventKeys[ Event ] = Keys
-
-		local Key = Keys[ Plugin ] or EventKey( Plugin )
-		Keys[ Plugin ] = Key
+		local Key = PluginEventKeys[ Plugin ] or EventKey( Plugin )
+		PluginEventKeys[ Plugin ] = Key
 
 		PluginEvents[ Plugin ]:Add( Event )
 
@@ -512,11 +509,7 @@ do
 	end
 
 	RemovePluginHook = function( Plugin, Event )
-		local Key = PluginEventKeys[ Event ] and PluginEventKeys[ Event ][ Plugin ]
-		if Key then
-			Hook.Remove( Event, Key )
-			PluginEventKeys[ Event ][ Plugin ] = nil
-		end
+		Hook.Remove( Event, PluginEventKeys[ Plugin ] )
 	end
 
 	RemoveAllPluginHooks = function( Plugin )
@@ -526,6 +519,7 @@ do
 			RemovePluginHook( Plugin, Event )
 		end
 
+		PluginEventKeys[ Plugin ] = nil
 		PluginEvents[ Plugin ] = nil
 	end
 end

--- a/lua/shine/core/shared/extensions.lua
+++ b/lua/shine/core/shared/extensions.lua
@@ -482,6 +482,10 @@ do
 		return Callers[ select( "#", ... ) ]( self.Plugin, self.Plugin[ self.Event ], self.Event, ... )
 	end
 
+	function EventCaller:__tostring()
+		return StringFormat( "Shine.Plugins.%s:%s()", self.Plugin:GetName(), self.Event )
+	end
+
 	local PluginEventKeys = {}
 	local PluginEvents = setmetatable( {}, {
 		__index = function( self, Key )
@@ -504,7 +508,7 @@ do
 
 		PluginEvents[ Plugin ]:Add( Event )
 
-		Hook.Add( Event, Key, EventCaller( Plugin, Event ), Hook.MAX_PRIORITY + 1 )
+		Hook.Add( Event, Key, EventCaller( Plugin, Event ), Hook.MAX_PRIORITY + 0.5 )
 	end
 
 	RemovePluginHook = function( Plugin, Event )

--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -10,7 +10,6 @@ local Clamp = math.Clamp
 local DebugGetInfo = debug.getinfo
 local DebugGetMetaTable = debug.getmetatable
 local DebugSetUpValue = debug.setupvalue
-local Floor = math.floor
 local Huge = math.huge
 local IsCallable = Shine.IsCallable
 local IsType = Shine.IsType
@@ -123,7 +122,7 @@ local function Add( Event, Index, Function, Priority )
 		Shine.TypeCheck( Priority, "number", 4, "Add" )
 	end
 
-	Priority = Clamp( Floor( Priority or DEFAULT_PRIORITY ), MAX_PRIORITY, MIN_PRIORITY )
+	Priority = Clamp( Priority or DEFAULT_PRIORITY, MAX_PRIORITY, MIN_PRIORITY )
 
 	-- If this index has already been used, replace it.
 	local Nodes = HookNodes[ Event ]

--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -36,32 +36,30 @@ local HooksByEventAndIndex = {}
 -- Known event names.
 local KnownEvents = Shine.Set()
 
-local OnError = Shine.BuildErrorHandler( "Hook error" )
-local Hooks
-do
-	if not Shine.SetupExtensionEvents then
-		Shine.SetupExtensionEvents = function() end
-	end
-
-	Hooks = setmetatable( {}, {
-		-- On first call/addition of an event, setup the necessary data structures.
-		__index = function( self, Event )
-			KnownEvents:Add( Event )
-
-			local HooksByIndex = LinkedList()
-			HookNodes[ Event ] = {}
-			HooksByEventAndIndex[ Event ] = {}
-
-			-- Save the list on the table to avoid invoking this again.
-			self[ Event ] = HooksByIndex
-
-			-- Allow extensions to setup their own events.
-			Shine:SetupExtensionEvents( Event )
-
-			return HooksByIndex
-		end
-	} )
+-- Placeholder until the extensions file is loaded.
+if not Shine.SetupExtensionEvents then
+	Shine.SetupExtensionEvents = function() end
 end
+
+local OnError = Shine.BuildErrorHandler( "Hook error" )
+local Hooks = setmetatable( {}, {
+	-- On first call/addition of an event, setup the necessary data structures.
+	__index = function( self, Event )
+		KnownEvents:Add( Event )
+
+		local HooksByIndex = LinkedList()
+		HookNodes[ Event ] = {}
+		HooksByEventAndIndex[ Event ] = {}
+
+		-- Save the list on the table to avoid invoking this again.
+		self[ Event ] = HooksByIndex
+
+		-- Allow extensions to setup their own events.
+		Shine:SetupExtensionEvents( Event )
+
+		return HooksByIndex
+	end
+} )
 
 -- Sort nodes by priority. Equal priority nodes will be placed in insertion order
 -- as the linked list will insert before the first node that is strictly after the

--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -181,7 +181,7 @@ do
 	-- See the comment in codegen.lua for the reasoning of this seemingly bizarre way of calling hooks.
 	-- In a nutshell, it's to avoid LuaJIT traces aborting with NYI when handling varargs.
 	local Callers = CodeGen.MakeFunctionGenerator( {
-		Template = [[local Shine, Hooks, OnError, Remove = ...
+		Template = [[local Shine, Hooks, OnError, Remove, ExtensionIndex = ...
 		return function( Event{Arguments} )
 			local Callbacks = Hooks[ Event ]
 
@@ -206,7 +206,7 @@ do
 		-- This should equal the largest number of arguments seen by a hook to avoid lazy-generation which can impact
 		-- compilation results.
 		InitialSize = 10,
-		Args = { Shine, Hooks, OnError, Remove },
+		Args = { Shine, Hooks, OnError, Remove, ExtensionIndex },
 		OnFunctionGenerated = function( NumArguments, Caller )
 			Hook[ StringFormat( "CallWith%dArg%s", NumArguments, NumArguments == 1 and "" or "s" ) ] = Caller
 		end
@@ -228,7 +228,7 @@ Hook.Call = Call
 local Broadcast
 do
 	local Broadcasters = CodeGen.MakeFunctionGenerator( {
-		Template = [[local Shine, Hooks, OnError, Remove = ...
+		Template = [[local Shine, Hooks, OnError, Remove, ExtensionIndex = ...
 		return function( Event{Arguments} )
 			local Callbacks = Hooks[ Event ]
 
@@ -249,7 +249,7 @@ do
 		end]],
 		ChunkName = "@lua/shine/core/shared/hook.lua/Broadcast",
 		InitialSize = 10,
-		Args = { Shine, Hooks, OnError, Remove },
+		Args = { Shine, Hooks, OnError, Remove, ExtensionIndex },
 		OnFunctionGenerated = function( NumArguments, Caller )
 			Hook[ StringFormat( "BroadcastWith%dArg%s", NumArguments, NumArguments == 1 and "" or "s" ) ] = Caller
 		end

--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -134,8 +134,7 @@ local function Add( Event, Index, Function, Priority )
 	local Node = Callbacks:InsertByComparing( {
 		Priority = Priority,
 		Index = Index,
-		Callback = Function,
-		BroadcastCallback = Function
+		Callback = Function
 	}, NodeComparator )
 
 	-- Remember this node for later removal.
@@ -208,7 +207,7 @@ do
 
 			for Node in Callbacks:IterateNodes() do
 				local Entry = Node.Value
-				local Success = xpcall( Entry.BroadcastCallback, OnError{Arguments} )
+				local Success = xpcall( Entry.Callback, OnError{Arguments} )
 				if not Success then
 					-- If the error came from calling extension events, don't remove the hook
 					-- (though it should never happen).

--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -340,6 +340,9 @@ local function AddClassHook( ReplacementFuncTemplate, HookName, Caller, Class, M
 	local NumArguments = GetNumArguments( OldFunc )
 	local ReplacementFunc
 	if not IsType( ReplacementFuncTemplate, "string" ) then
+		-- Allow custom handlers to add extra arguments (taking 1 less as the first argument is OldFunc).
+		NumArguments = Max( NumArguments, GetNumArguments( ReplacementFuncTemplate ) - 1 )
+
 		ReplacementFunc = CodeGen.GenerateFunctionWithArguments(
 			[[local OldFunc, ReplacementFunc = ...
 			return function( {FunctionArguments} )
@@ -394,6 +397,9 @@ local function AddGlobalHook( ReplacementFunc, HookName, Caller, FuncName )
 
 	local NumArguments = GetNumArguments( Func )
 	if not IsType( ReplacementFunc, "string" ) then
+		-- Allow custom handlers to add extra arguments (taking 1 less as the first argument is OldFunc).
+		NumArguments = Max( NumArguments, GetNumArguments( ReplacementFunc ) - 1 )
+
 		-- Maintain backwards compatibility with custom hook handlers while still helping to remove var-args.
 		Prev[ Path[ NumSegments ] ] = CodeGen.GenerateFunctionWithArguments(
 			[[local OldFunc, ReplacementFunc = ...

--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -349,13 +349,14 @@ local function AddClassHook( ReplacementFuncTemplate, HookName, Caller, Class, M
 				return ReplacementFunc( OldFunc{Arguments} )
 			end]],
 			NumArguments,
-			"@lua/shine/core/shared/hook.lua/CustomClassHook",
+			StringFormat( "@lua/shine/core/shared/hook.lua/CustomClassHook/%s:%s", Class, Method ),
 			OldFunc,
 			ReplacementFuncTemplate
 		)
 	else
 		ReplacementFunc = CodeGen.GenerateFunctionWithArguments(
-			ReplacementFuncTemplate, NumArguments, "@lua/shine/core/shared/hook.lua/ClassHook",
+			ReplacementFuncTemplate, NumArguments,
+			StringFormat( "@lua/shine/core/shared/hook.lua/ClassHook/%s:%s", Class, Method ),
 			HookName, Caller, OldFunc
 		)
 	end
@@ -407,13 +408,13 @@ local function AddGlobalHook( ReplacementFunc, HookName, Caller, FuncName )
 				return ReplacementFunc( OldFunc{Arguments} )
 			end]],
 			NumArguments,
-			"@lua/shine/core/shared/hook.lua/CustomGlobalHook",
+			StringFormat( "@lua/shine/core/shared/hook.lua/CustomGlobalHook/%s", FuncName ),
 			Func,
 			ReplacementFunc
 		)
 	else
 		Prev[ Path[ NumSegments ] ] = CodeGen.GenerateFunctionWithArguments(
-			ReplacementFunc, NumArguments, "@lua/shine/core/shared/hook.lua/GlobalHook",
+			ReplacementFunc, NumArguments, StringFormat( "@lua/shine/core/shared/hook.lua/GlobalHook/%s", FuncName ),
 			HookName, Caller, Func
 		)
 	end

--- a/lua/shine/extensions/afkkick/server.lua
+++ b/lua/shine/extensions/afkkick/server.lua
@@ -7,11 +7,11 @@ local Shine = Shine
 local assert = assert
 local Clamp = math.Clamp
 local Floor = math.floor
+local GetClientForPlayer = Shine.GetClientForPlayer
 local GetHumanPlayerCount = Shine.GetHumanPlayerCount
 local GetMaxPlayers = Server.GetMaxPlayers
 local GetMaxSpectators = Server.GetMaxSpectators
 local GetNumClientsTotal = Server.GetNumClientsTotal
-local GetOwner = Server.GetOwner
 local Max = math.max
 local Random = math.random
 local StringContainsNonUTF8Whitespace = string.ContainsNonUTF8Whitespace
@@ -407,7 +407,7 @@ function Plugin:PrePlayerInfoUpdate( PlayerInfo, Player )
 		return
 	end
 
-	local Client = GetOwner( Player )
+	local Client = GetClientForPlayer( Player )
 	local Data = self.Users:Get( Client )
 
 	-- Network the AFK state of the player.
@@ -673,7 +673,7 @@ end
 	and means that as soon as actions should be applied, they will be.
 ]]
 function Plugin:OnProcessMove( Player, Input )
-	local Client = GetOwner( Player )
+	local Client = GetClientForPlayer( Player )
 	if not Client or Client:GetIsVirtual() then return end
 
 	local DataTable = self.Users:Get( Client )
@@ -782,7 +782,7 @@ function Plugin:PlayerSay( Client, MessageTable )
 end
 
 function Plugin:CanPlayerHearPlayer( Gamerules, Listener, Speaker )
-	local Client = GetOwner( Speaker )
+	local Client = GetClientForPlayer( Speaker )
 	if Client then
 		self:SubtractAFKTime( Client, 0.1 )
 	end
@@ -796,7 +796,7 @@ function Plugin:OnConstructInit( Building )
 	Owner = Owner or Team:GetCommander()
 	if not Owner then return end
 
-	local Client = GetOwner( Owner )
+	local Client = GetClientForPlayer( Owner )
 	if not Client then return end
 
 	self:ResetAFKTime( Client )
@@ -809,7 +809,7 @@ function Plugin:OnRecycle( Building, ResearchID )
 	local Commander = Team:GetCommander()
 	if not Commander then return end
 
-	local Client = GetOwner( Commander )
+	local Client = GetClientForPlayer( Commander )
 	if not Client then return end
 
 	self:ResetAFKTime( Client )
@@ -818,7 +818,7 @@ end
 do
 	local function ResetForCommander()
 		return function( self, Commander )
-			local Client = GetOwner( Commander )
+			local Client = GetClientForPlayer( Commander )
 			if not Client then return end
 
 			self:ResetAFKTime( Client )
@@ -918,7 +918,7 @@ function Plugin:OnFirstThink()
 
 	do
 		local function MoveIfNotAFK( Player )
-			local Client = Player and GetOwner( Player )
+			local Client = Player and GetClientForPlayer( Player )
 			if not Client or self:IsAFKFor( Client, 60 ) then return end
 
 			JoinRandomTeam( Player )
@@ -933,7 +933,7 @@ function Plugin:OnFirstThink()
 
 	local function FilterPlayers( Player )
 		local ShouldKeep = true
-		local Client = GetOwner( Player )
+		local Client = GetClientForPlayer( Player )
 
 		if not Client or self:IsAFKFor( Client, 60 ) then
 			ShouldKeep = false

--- a/lua/shine/extensions/basecommands/server.lua
+++ b/lua/shine/extensions/basecommands/server.lua
@@ -6,7 +6,6 @@ local Shine = Shine
 local Hook = Shine.Hook
 local Call = Hook.Call
 
-local GetOwner = Server.GetOwner
 local IsType = Shine.IsType
 local Min = math.min
 local Notify = Shared.Message
@@ -365,6 +364,8 @@ function Plugin:TakeDamage( Ent, Damage, Attacker, Inflictor, Point, Direction, 
 end
 
 do
+	local GetClientForPlayer = Shine.GetClientForPlayer
+
 	function Plugin:IsPregameAllTalk( Gamerules )
 		return self.Config.AllTalkPreGame and Gamerules:GetGameState() < kGameState.PreGame
 	end
@@ -403,7 +404,7 @@ do
 	end
 
 	function Plugin:CanPlayerHearLocalVoice( Gamerules, Listener, Speaker, SpeakerClient )
-		local ListenerClient = GetOwner( Listener )
+		local ListenerClient = GetClientForPlayer( Listener )
 
 		-- Default behaviour for those that have chosen to disable it.
 		if self:IsLocalAllTalkDisabled( ListenerClient )
@@ -429,7 +430,7 @@ do
 		Override voice chat to allow everyone to hear each other with alltalk on.
 	]]
 	function Plugin:CanPlayerHearPlayer( Gamerules, Listener, Speaker, ChannelType )
-		local SpeakerClient = GetOwner( Speaker )
+		local SpeakerClient = GetClientForPlayer( Speaker )
 
 		if SpeakerClient and self:IsClientGagged( SpeakerClient ) then return false end
 		if Listener:GetClientMuted( Speaker:GetClientIndex() ) then return false end

--- a/lua/shine/extensions/commbans/server.lua
+++ b/lua/shine/extensions/commbans/server.lua
@@ -6,7 +6,7 @@ local Plugin = ...
 
 local Shine = Shine
 
-local GetOwner = Server.GetOwner
+local GetClientForPlayer = Shine.GetClientForPlayer
 local Max = math.max
 local StringFormat = string.format
 local Time = os.time
@@ -52,7 +52,7 @@ end
 	Deny commanding if they're banned.
 ]]
 function Plugin:ValidateCommanderLogin( Gamerules, CommandStation, Player )
-	local Client = GetOwner( Player )
+	local Client = GetClientForPlayer( Player )
 	if not Client then
 		self.Logger:Error( "Unable to get client for player %s! Cannot check for commander ban.", Player )
 		return

--- a/lua/shine/extensions/improvedchat/client.lua
+++ b/lua/shine/extensions/improvedchat/client.lua
@@ -136,25 +136,14 @@ Hook.CallAfterFileLoad( "lua/GUIChat.lua", function()
 		MaxChatWidth = Value * 0.01
 	end )
 
-	-- Ensure easing functions are loaded.
-	Script.Load( "lua/tweener/Tweener.lua" )
+	local Easing = require "shine/lib/gui/util/easing"
 
 	-- Fade fast to avoid making text hard to read.
-	local OutExpo = Easing.outExpo
-	local function FadingEase( Progress )
-		return OutExpo( Progress, 0, 1, 1 )
-	end
-
-	local InExpo = Easing.inExpo
-	local function FadingInEase( Progress )
-		return InExpo( Progress, 0, 1, 1 )
-	end
+	local FadingEase = Easing.GetEaser( "OutExpo" )
+	local FadingInEase = Easing.GetEaser( "InExpo" )
 
 	-- Move more smoothly to avoid sudden jumps.
-	local OutSine = Easing.outSine
-	local function MovementEase( Progress )
-		return OutSine( Progress, 0, 1, 1 )
-	end
+	local MovementEase = Easing.GetEaser( "OutSine" )
 
 	local AnimDuration = 0.25
 	local function IsAnimationEnabled( self )

--- a/lua/shine/extensions/logging.lua
+++ b/lua/shine/extensions/logging.lua
@@ -92,7 +92,7 @@ function Plugin:PlayerNameChange( Player, Name, OldName )
 	if Name == kDefaultPlayerName then return end
 	if OldName == kDefaultPlayerName then return end
 
-	local Client = Server.GetOwner( Player )
+	local Client = Shine.GetClientForPlayer( Player )
 	if Client and Client:GetIsVirtual() then return end
 
 	Shine:LogString( StringFormat( "%s changed their name from '%s' to '%s'.",
@@ -103,7 +103,7 @@ function Plugin:PostJoinTeam( Gamerules, Player, OldTeam, NewTeam, Force )
 	if not self.Config.LogTeamJoins then return end
 	if not Player then return end
 
-	local Client = Server.GetOwner( Player )
+	local Client = Shine.GetClientForPlayer( Player )
 	if not Client then return end
 
 	Shine:LogString( StringFormat( "Player %s joined team %s.",
@@ -176,8 +176,8 @@ function Plugin:OnEntityKilled( Gamerules, Victim, Attacker, Inflictor, Point, D
 	local AttackerPos = Attacker:GetOrigin()
 	local VictimPos = Victim:GetOrigin()
 
-	local AttackerClient = Server.GetOwner( Attacker )
-	local VictimClient = Server.GetOwner( Victim )
+	local AttackerClient = Shine.GetClientForPlayer( Attacker )
+	local VictimClient = Shine.GetClientForPlayer( Victim )
 
 	Shine:LogString( StringFormat( "%s killed %s with %s. Attacker location: %s. Victim location: %s.",
 		AttackerClient and self:GetClientInfo( AttackerClient ) or Attacker:GetClassName(),
@@ -198,8 +198,8 @@ function Plugin:CastVoteByPlayer( Gamerules, VoteTechID, Player )
 
 	if not CommPlayer then return end
 
-	local Target = Server.GetOwner( CommPlayer )
-	local Client = Server.GetOwner( Player )
+	local Target = Shine.GetClientForPlayer( CommPlayer )
+	local Client = Shine.GetClientForPlayer( Player )
 
 	if Target and Client then
 		Shine:LogString( StringFormat( "%s voted to eject %s.",
@@ -212,7 +212,7 @@ function Plugin:CommLoginPlayer( Chair, Player )
 	if not Player then return end
 
 	Shine:LogString( StringFormat( "%s became the commander of the %s.",
-		self:GetClientInfo( Server.GetOwner( Player ) ),
+		self:GetClientInfo( Shine.GetClientForPlayer( Player ) ),
 		Shine:GetTeamName( Player:GetTeamNumber(), nil, true )
 	) )
 end
@@ -224,7 +224,7 @@ function Plugin:CommLogout( Chair )
 	if not Commander then return end
 
 	Shine:LogString( StringFormat( "%s stopped commanding the %s.",
-		self:GetClientInfo( Server.GetOwner( Commander ) ),
+		self:GetClientInfo( Shine.GetClientForPlayer( Commander ) ),
 		Shine:GetTeamName( Commander:GetTeamNumber(), nil, true )
 	) )
 end
@@ -239,7 +239,7 @@ do
 		local Commander = Team:GetCommander()
 		if not Commander then return end
 
-		local Client = Server.GetOwner( Commander )
+		local Client = Shine.GetClientForPlayer( Commander )
 		Shine:LogString( StringFormat( "%s %s %s %s[%s].",
 			self:GetClientInfo( Client ), State, RecycleAction, Name, ID ) )
 	end
@@ -307,7 +307,7 @@ function Plugin:OnConstructInit( Building )
 
 	if not Owner then return end
 
-	local Client = Server.GetOwner( Owner )
+	local Client = Shine.GetClientForPlayer( Owner )
 	Shine:LogString( StringFormat( "%s began construction of %s[%s].",
 		self:GetClientInfo( Client ), Name, ID ) )
 end

--- a/lua/shine/extensions/mapvote/client.lua
+++ b/lua/shine/extensions/mapvote/client.lua
@@ -879,6 +879,9 @@ function Plugin:CreateMapVoteNotification( VoteButton )
 end
 
 function Plugin:ReceiveVoteOptions( Message )
+	-- Clear out any previous vote.
+	self:EndVote()
+
 	Shine.CheckVoteMenuBind()
 
 	local Duration = Message.Duration

--- a/lua/shine/extensions/mapvote/client.lua
+++ b/lua/shine/extensions/mapvote/client.lua
@@ -780,19 +780,27 @@ function Plugin:EndVote()
 	TableEmpty( self.MapButtons )
 	Shine.ScreenText.End( "MapVote" )
 
-	if SGUI.IsValid( self.FullVoteMenu ) then
-		self.FullVoteMenu:Close( function()
-			if SGUI.IsValid( self.FullVoteMenu ) then
-				self.FullVoteMenu:Destroy()
+	local FullVoteMenu = self.FullVoteMenu
+	if SGUI.IsValid( FullVoteMenu ) then
+		FullVoteMenu:Close( function()
+			if not SGUI.IsValid( FullVoteMenu ) then return end
+
+			FullVoteMenu:Destroy()
+
+			if FullVoteMenu == self.FullVoteMenu then
 				self.FullVoteMenu = nil
 			end
 		end )
 	end
 
-	if SGUI.IsValid( self.MapVoteNotification ) then
-		self.MapVoteNotification:Hide( function()
-			if SGUI.IsValid( self.MapVoteNotification ) then
-				self.MapVoteNotification:Destroy()
+	local MapVoteNotification = self.MapVoteNotification
+	if SGUI.IsValid( MapVoteNotification ) then
+		MapVoteNotification:Hide( function()
+			if not SGUI.IsValid( MapVoteNotification ) then return end
+
+			MapVoteNotification:Destroy()
+
+			if MapVoteNotification == self.MapVoteNotification then
 				self.MapVoteNotification = nil
 			end
 		end )

--- a/lua/shine/extensions/mapvote/client.lua
+++ b/lua/shine/extensions/mapvote/client.lua
@@ -400,7 +400,7 @@ do
 					MapName = MapName,
 					NiceName = self:GetNiceMapName( MapName ),
 					ModID = self.MapMods and self.MapMods[ MapName ] and tostring( self.MapMods[ MapName ] ),
-					IsSelected = MapName == self.ChosenMap,
+					IsSelected = self:IsMapSelected( MapName ),
 					NumVotes = self.MapVoteCounts[ MapName ]
 				}
 			end ):AsTable()

--- a/lua/shine/extensions/mapvote/server.lua
+++ b/lua/shine/extensions/mapvote/server.lua
@@ -7,7 +7,7 @@ local Shine = Shine
 local Ceil = math.ceil
 local Clamp = math.Clamp
 local Floor = math.floor
-local GetOwner = Server.GetOwner
+local GetClientForPlayer = Shine.GetClientForPlayer
 local IsType = Shine.IsType
 local Max = math.max
 local Notify = Shared.Message
@@ -668,7 +668,7 @@ function Plugin:JoinTeam( Gamerules, Player, NewTeam, Force, ShineForce )
 	if ShineForce then return end
 	if NewTeam == 0 then return end
 
-	if Shine:CanNotify( GetOwner( Player ) ) then
+	if Shine:CanNotify( GetClientForPlayer( Player ) ) then
 		self:SendTranslatedNotify( Player, "TeamSwitchFail", {
 			IsEndVote = IsEndVote or false
 		} )

--- a/lua/shine/extensions/mapvote/ui/map_vote_menu.lua
+++ b/lua/shine/extensions/mapvote/ui/map_vote_menu.lua
@@ -487,22 +487,25 @@ function MapVoteMenu:FadeIn()
 	end
 end
 
+local function OnFadeOutComplete( self )
+	self:SetIsVisible( false )
+	self.FadingOut = false
+	self:OnClose()
+	if self.FadeOutCallback then
+		-- Call after Think exits to avoid destroying GUIItems that are in use.
+		SGUI:AddPostEventAction( self.FadeOutCallback )
+	end
+end
+
 function MapVoteMenu:FadeOut( Callback )
 	self.FadingOut = true
+	self.FadeOutCallback = Callback
 
 	self:ApplyTransition( {
 		Type = "Alpha",
 		EndValue = 0,
 		Duration = 0.3,
-		Callback = function()
-			self:SetIsVisible( false )
-			self.FadingOut = false
-			self:OnClose()
-			if Callback then
-				-- Call after Think exits to avoid destroying GUIItems that are in use.
-				SGUI:AddPostEventAction( Callback )
-			end
-		end
+		Callback = OnFadeOutComplete
 	} )
 end
 

--- a/lua/shine/extensions/mapvote/ui/map_vote_menu.lua
+++ b/lua/shine/extensions/mapvote/ui/map_vote_menu.lua
@@ -606,24 +606,24 @@ function MapVoteMenu:SetMaps( Maps )
 	for i = 1, #Maps do
 		local Entry = Maps[ i ]
 		local Tile = SGUI:CreateFromDefinition( MapTile, self.Elements.MapTileGrid )
+		Tile:SetMapVoteMenu( self )
 		Tile:SetSkin( Skin )
 		Tile:SetMap( Entry.ModID, Entry.MapName )
 
 		if Entry.MapName == Shared.GetMapName() then
-			Tile:SetText(
+			Tile:SetMapNameText(
 				Locale:GetInterpolatedPhrase( "mapvote", "MAP_VOTE_MENU_EXTEND_MAP", {
 					MapName = Entry.NiceName
 				} )
 			)
 		else
-			Tile:SetText( Entry.NiceName )
+			Tile:SetMapNameText( Entry.NiceName )
 		end
 
 		Tile:SetSelected( Entry.IsSelected )
 		Tile:SetNumVotes( Entry.NumVotes )
 		Tile:SetInheritsParentAlpha( true )
 		Tile:SetTeamVariation( self:GetTeamVariation() )
-		Tile:SetMapVoteMenu( self )
 
 		if #Maps > 9 then
 			Tile:SetStyleName( "SmallerFonts" )

--- a/lua/shine/extensions/mapvote/ui/map_vote_menu_tile.lua
+++ b/lua/shine/extensions/mapvote/ui/map_vote_menu_tile.lua
@@ -30,9 +30,11 @@ SGUI.AddProperty( MapTile, "Selected", false )
 SGUI.AddProperty( MapTile, "TeamVariation", "Marine" )
 SGUI.AddProperty( MapTile, "WinnerType" )
 
-SGUI.AddBoundProperty( MapTile, "Text", "MapNameLabel:SetText" )
-SGUI.AddBoundProperty( MapTile, "TextColour", { "MapNameLabel:SetColour", "VoteCounterLabel:SetColour" } )
+SGUI.AddBoundProperty( MapTile, "MapNameText", "MapNameLabel:SetText" )
 SGUI.AddBoundProperty( MapTile, "MapNameAutoFont", "MapNameLabel:SetAutoFont" )
+SGUI.AddBoundProperty( MapTile, "TextColour", {
+	"Label:SetColour", "MapNameLabel:SetColour", "VoteCounterLabel:SetColour"
+} )
 SGUI.AddBoundProperty( MapTile, "VoteCounterAutoFont", "VoteCounterLabel:SetAutoFont" )
 
 MapTile.WinnerTypeName = table.AsEnum{
@@ -320,6 +322,8 @@ end
 function MapTile:SetHighlighted( Highlighted, SkipAnim )
 	self.Highlighted = Highlighted
 	self:OnPropertyChanged( "Highlighted", Highlighted )
+
+	if not SGUI.IsValid( self.PreviewImage ) then return end
 
 	local Colour = Highlighted and self.PreviewImage.ActiveCol or self.PreviewImage.InactiveCol
 	if SkipAnim then

--- a/lua/shine/extensions/mapvote/ui/map_vote_notification.lua
+++ b/lua/shine/extensions/mapvote/ui/map_vote_notification.lua
@@ -283,21 +283,24 @@ function MapVoteNotification:FadeIn()
 	self:UpdateTeamVariation()
 end
 
+local function OnFadeOutComplete( self )
+	self:SetIsVisible( false )
+	self.FadingOut = false
+	if self.FadeOutCallback then
+		-- Call after Think exits to avoid destroying GUIItems that are in use.
+		SGUI:AddPostEventAction( self.FadeOutCallback )
+	end
+end
+
 function MapVoteNotification:FadeOut( Callback )
 	self.FadingOut = true
+	self.FadeOutCallback = Callback
 
 	self:ApplyTransition( {
 		Type = "Alpha",
 		EndValue = 0,
 		Duration = 0.3,
-		Callback = function()
-			self:SetIsVisible( false )
-			self.FadingOut = false
-			if Callback then
-				-- Call after Think exits to avoid destroying GUIItems that are in use.
-				SGUI:AddPostEventAction( Callback )
-			end
-		end
+		Callback = OnFadeOutComplete
 	} )
 end
 

--- a/lua/shine/extensions/readyroom.lua
+++ b/lua/shine/extensions/readyroom.lua
@@ -6,7 +6,7 @@
 
 local Shine = Shine
 
-local GetOwner = Server.GetOwner
+local GetClientForPlayer = Shine.GetClientForPlayer
 local pairs = pairs
 local Random = math.random
 local SharedTime = Shared.GetTime
@@ -65,7 +65,7 @@ function Plugin:JoinTeam( Gamerules, Player, NewTeam, Force, ShineForce )
 		return
 	end
 
-	local Client = GetOwner( Player )
+	local Client = GetClientForPlayer( Player )
 
 	if not Client then return end
 	if Client.JoinTeamRRPlugin then return end
@@ -124,7 +124,7 @@ function Plugin:EndGame()
 		local Player = Players[ i ]
 
 		if Player then
-			local Client = GetOwner( Player )
+			local Client = GetClientForPlayer( Player )
 
 			if Client then
 				self.TeamMemory[ Client ] = Player:GetTeamNumber()
@@ -150,7 +150,7 @@ function Plugin:JoinRandomTeam( Player )
 	local Team1 = Gamerules:GetTeam( kTeam1Index ):GetNumPlayers()
 	local Team2 = Gamerules:GetTeam( kTeam2Index ):GetNumPlayers()
 
-	local Client = GetOwner( Player )
+	local Client = GetClientForPlayer( Player )
 
 	if not Client then return end
 

--- a/lua/shine/extensions/tournamentmode/server.lua
+++ b/lua/shine/extensions/tournamentmode/server.lua
@@ -281,8 +281,7 @@ end
 function Plugin:PostJoinTeam( Gamerules, Player, OldTeam, NewTeam, Force )
 	if NewTeam == 0 or NewTeam == 3 then return end
 
-	local Client = Server.GetOwner( Player )
-
+	local Client = Shine.GetClientForPlayer( Player )
 	if not Client then return end
 
 	local ID = Client:GetUserId()

--- a/lua/shine/extensions/votedraw/client.lua
+++ b/lua/shine/extensions/votedraw/client.lua
@@ -1,0 +1,36 @@
+--[[
+	Draw vote client side.
+]]
+
+local Plugin = ...
+
+Plugin.VoteButtonName = "VoteDraw"
+
+do
+	local RichTextFormat = require "shine/lib/gui/richtext/format"
+	local RichTextMessageOptions = {}
+	local VoteMessageOptions = {
+		Colours = {
+			PlayerName = function( Values )
+				return RichTextFormat.GetColourForPlayer( Values.PlayerName )
+			end
+		}
+	}
+
+	RichTextMessageOptions[ "PLAYER_VOTED" ] = VoteMessageOptions
+
+	Plugin.RichTextMessageOptions = RichTextMessageOptions
+end
+
+Shine.VoteMenu:EditPage( "Main", Plugin:WrapCallback( function( VoteMenu )
+	local ButtonText = Plugin:GetPhrase( "VOTEMENU_BUTTON" )
+
+	local Button = VoteMenu:AddSideButton( ButtonText, function()
+		VoteMenu.GenericClick( "sh_votedraw" )
+	end )
+
+	-- Allow the button to be retrieved to have its counter updated.
+	Button.Plugin = Plugin.VoteButtonName
+	Button.DefaultText = ButtonText
+	Button.CheckMarkXScale = 0.75
+end ) )

--- a/lua/shine/extensions/votedraw/server.lua
+++ b/lua/shine/extensions/votedraw/server.lua
@@ -35,6 +35,18 @@ Plugin.DefaultConfig = {
 	}
 }
 
+do
+	local Validator = Shine.Validator()
+
+	Validator:AddFieldRule( "FractionNeededToPass", Validator.Clamp( 0, 1 ) )
+	Validator:AddFieldRule( "EnableAfterRoundStartMinutes", Validator.Min( 0 ) )
+	Validator:AddFieldRule( "VoteTimeoutInSeconds", Validator.Min( 0 ) )
+	Validator:CheckTypesAgainstDefault( "VoteSettings", Plugin.DefaultConfig.VoteSettings )
+	Validator:AddFieldRule( "VoteSettings.AFKTimeInSeconds", Validator.Min( 0 ) )
+
+	Plugin.ConfigValidator = Validator
+end
+
 -- Show all votes to draw the game, even the last that triggers it.
 Plugin.ShowLastVote = true
 Plugin.VoteCommand = {

--- a/lua/shine/extensions/votedraw/server.lua
+++ b/lua/shine/extensions/votedraw/server.lua
@@ -1,0 +1,122 @@
+--[[
+	Vote to draw the current round.
+]]
+
+local Plugin = ...
+
+local assert = assert
+local Ceil = math.ceil
+local SharedTime = Shared.GetTime
+
+Plugin.Version = "1.0"
+
+Plugin.HasConfig = true
+Plugin.ConfigName = "VoteDraw.json"
+Plugin.CheckConfig = true
+Plugin.CheckConfigTypes = true
+
+Plugin.DefaultConfig = {
+	-- How long into a round to wait before allowing a vote to draw the game.
+	EnableAfterRoundStartMinutes = 20,
+
+	-- Whether to notify everyone of votes, or just the voting player (vote menu button updates regardless).
+	NotifyOnVote = true,
+
+	-- The fraction of players on both playing teams needing to vote for it to pass.
+	FractionNeededToPass = 0.9,
+
+	-- How long to wait between votes before the vote is reset.
+	VoteTimeoutInSeconds = 60,
+
+	-- Standard vote settings.
+	VoteSettings = {
+		ConsiderAFKPlayersInVotes = true,
+		AFKTimeInSeconds = 60
+	}
+}
+
+-- Show all votes to draw the game, even the last that triggers it.
+Plugin.ShowLastVote = true
+Plugin.VoteCommand = {
+	ConCommand = "sh_votedraw",
+	ChatCommand = "votedraw",
+	Help = "Votes to end the current round as a draw."
+}
+
+function Plugin:OnVotePassed()
+	local Gamerules = GetGamerules()
+	assert( Gamerules, "Couldn't find the gamerules!" )
+
+	Gamerules:DrawGame()
+end
+
+function Plugin:CanStartVote()
+	local Gamerules = GetGamerules()
+	if not Gamerules or not Gamerules:GetGameStarted() then
+		return false, "ERROR_ROUND_NOT_STARTED"
+	end
+
+	local StartTime = Gamerules:GetGameStartTime()
+	local TimeTillVoteAllowed = StartTime + self.Config.EnableAfterRoundStartMinutes * 60 - SharedTime()
+	if TimeTillVoteAllowed > 0 then
+		return false, "ERROR_MUST_WAIT", {
+			SecondsToWait = Ceil( TimeTillVoteAllowed )
+		}
+	end
+
+	return true
+end
+
+local function GetNumPlayersOnTeam( Team, AFKTime, AFKKick )
+	local Count = 0
+
+	Team:ForEachPlayer( function( Player )
+		local Client = Player:GetClient()
+		if Client and Client:GetIsVirtual() then return end
+
+		if not Client or not ( AFKTime and AFKKick and AFKKick:IsAFKFor( Client, AFKTime ) ) then
+			Count = Count + 1
+		end
+	end )
+
+	return Count
+end
+
+function Plugin:PostJoinTeam( Gamerules, Player, OldTeam, NewTeam )
+	if not Shine.IsPlayingTeam( OldTeam ) or Shine.IsPlayingTeam( NewTeam ) then return end
+
+	-- If a player goes to the ready room or spectate, remove their vote.
+	local Client = Player:GetClient()
+	if self.Vote:RemoveVote( Client ) and not self.Vote:CheckForSuccess() then
+		self:UpdateVoteCounters( self.Vote )
+		self:NotifyVoteReset( Client )
+	end
+end
+
+function Plugin:GetPlayerCountForVote()
+	local Gamerules = GetGamerules()
+	assert( Gamerules, "Cannot get player count without the gamerules!" )
+
+	local AFKTime = not self.Config.VoteSettings.ConsiderAFKPlayersInVotes and self.Config.VoteSettings.AFKTimeInSeconds
+	local Enabled, AFKKick = Shine:IsExtensionEnabled( "afkkick" )
+
+	local Count = 0
+	for i = 1, 2 do
+		Count = Count + GetNumPlayersOnTeam( Gamerules:GetTeam( i ), AFKTime, Enabled and AFKKick )
+	end
+
+	return Count
+end
+
+function Plugin:CanClientVote( Client )
+	if Client:GetIsVirtual() then
+		return false, "ERROR_BOT_CANNOT_VOTE"
+	end
+
+	local Player = Client:GetControllingPlayer()
+	if not Player or not Player.GetTeamNumber or not Shine.IsPlayingTeam( Player:GetTeamNumber() ) then
+		return false, "ERROR_CANNOT_VOTE_ON_CURRENT_TEAM"
+	end
+
+	return true
+end

--- a/lua/shine/extensions/votedraw/shared.lua
+++ b/lua/shine/extensions/votedraw/shared.lua
@@ -1,0 +1,46 @@
+--[[
+	Draw vote shared.
+]]
+
+local Plugin = Shine.Plugin( ... )
+Plugin.NotifyPrefixColour = {
+	224, 255, 210
+}
+Plugin.UseCustomVoteTiming = true
+Plugin.HandlesVoteConfig = true
+Plugin.FractionConfigKey = "FractionNeededToPass"
+
+function Plugin:SetupDataTable()
+	self:CallModuleEvent( "SetupDataTable" )
+
+	local MessageTypes = {
+		PlayerVote  = {
+			PlayerName = self:GetNameNetworkField(),
+			VotesNeeded = "integer"
+		},
+		PrivateVote = {
+			VotesNeeded = "integer"
+		},
+		VoteWaitTime = {
+			SecondsToWait = "integer"
+		}
+	}
+
+	self:AddNetworkMessages( "AddTranslatedNotify", {
+		[ MessageTypes.PlayerVote ] = {
+			"PLAYER_VOTED"
+		},
+		[ MessageTypes.PrivateVote ] = {
+			"PLAYER_VOTED_PRIVATE"
+		}
+	} )
+	self:AddNetworkMessages( "AddTranslatedError", {
+		[ MessageTypes.VoteWaitTime ] = {
+			"ERROR_MUST_WAIT"
+		}
+	} )
+end
+
+Shine.LoadPluginModule( "sh_vote.lua", Plugin, true )
+
+return Plugin

--- a/lua/shine/extensions/voterandom/client.lua
+++ b/lua/shine/extensions/voterandom/client.lua
@@ -465,11 +465,11 @@ local IsPlayingTeam = Shine.IsPlayingTeam
 local pairs = pairs
 
 function Plugin:UpdateTeamMemoryEntry( ClientIndex, TeamNumber, CurTime )
-	local MemoryEntry = self.TeamTracking[ ClientIndex ]
+	local MemoryEntry = self.TeamTracking:Get( ClientIndex )
 	if not MemoryEntry then
 		-- Start with the team they're currently on to avoid everyone flashing on first join.
 		MemoryEntry = { TeamNumber = TeamNumber }
-		self.TeamTracking[ ClientIndex ] = MemoryEntry
+		self.TeamTracking:Add( ClientIndex, MemoryEntry )
 	end
 
 	-- For some reason, spectators are constantly swapped between team 0 and 3.
@@ -485,7 +485,7 @@ function Plugin:UpdateTeamMemoryEntry( ClientIndex, TeamNumber, CurTime )
 end
 
 function Plugin:Initialise()
-	self.TeamTracking = {}
+	self.TeamTracking = Shine.Map()
 	self.FriendGroup = {}
 	self.InFriendGroup = false
 
@@ -508,9 +508,9 @@ function Plugin:Initialise()
 			self:UpdateTeamMemoryEntry( ClientIndex, Entry.EntityTeamNumber, CurTime )
 		end
 
-		for ClientIndex in pairs( self.TeamTracking ) do
+		for ClientIndex in self.TeamTracking:Iterate() do
 			if not Clients[ ClientIndex ] then
-				self.TeamTracking[ ClientIndex ] = nil
+				self.TeamTracking:Remove( ClientIndex )
 			end
 		end
 	end )

--- a/lua/shine/extensions/voterandom/local_stats.lua
+++ b/lua/shine/extensions/voterandom/local_stats.lua
@@ -4,7 +4,7 @@
 
 local Shine = Shine
 
-local GetOwner = Server.GetOwner
+local GetClientForPlayer = Shine.GetClientForPlayer
 local Min = math.min
 local setmetatable = setmetatable
 local tostring = tostring
@@ -64,7 +64,7 @@ do
 			if not self.Config.UseLocalFileStats then return end
 			if not self.StatsStorage:IsInTransaction() then return end
 
-			local Client = GetOwner( Player )
+			local Client = GetClientForPlayer( Player )
 			if not Client or Client:GetIsVirtual() then return end
 
 			self:IncrementStatValue( GetClientUID( Client ), Player, StatValue, Value or 1 )
@@ -127,7 +127,7 @@ function StatsModule:IsRookie( ClientID, Player )
 end
 
 function StatsModule:IsPlayerRookie( Player )
-	local Client = GetOwner( Player )
+	local Client = GetClientForPlayer( Player )
 	if not Client then return false end
 
 	return self:IsRookie( GetClientUID( Client ), Player )
@@ -162,7 +162,7 @@ end
 function StatsModule:GetPlayerKDR( Player )
 	if not self.Config.UseLocalFileStats then return end
 
-	local Client = GetOwner( Player )
+	local Client = GetClientForPlayer( Player )
 	if not Client then return 0 end
 
 	return self:GetKDRStat( GetClientUID( Client ), Player )
@@ -178,7 +178,7 @@ end
 function StatsModule:GetPlayerScorePerMinute( Player )
 	if not self.Config.UseLocalFileStats then return end
 
-	local Client = GetOwner( Player )
+	local Client = GetClientForPlayer( Player )
 	if not Client then return 0 end
 
 	return self:GetScorePerMinuteStat( GetClientUID( Client ), Player )
@@ -222,8 +222,8 @@ function StatsModule:EndGame( Gamerules, WinningTeam, Players )
 
 	for i = 1, #Players do
 		local Player = Players[ i ]
-		local Client = GetOwner( Player )
-		if not Client:GetIsVirtual() and Player.client and Player.GetMarinePlayTime then
+		local Client = GetClientForPlayer( Player )
+		if Client and not Client:GetIsVirtual() and Player.client and Player.GetMarinePlayTime then
 			self:StoreRoundEndData( GetClientUID( Client ), Player, WinningTeamNumber, RoundLength )
 		end
 	end

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -14,7 +14,7 @@ local Floor = math.floor
 local GetAllPlayers = Shine.GetAllPlayers
 local GetNumPlayers = Shine.GetHumanPlayerCount
 local GetNumSpectators = Server.GetNumSpectators
-local GetOwner = Server.GetOwner
+local GetClientForPlayer = Shine.GetClientForPlayer
 local IsType = Shine.IsType
 local Max = math.max
 local Random = math.random
@@ -370,7 +370,7 @@ function EnforcementPolicy:IsPolicyEnforced( Policy, PlayerCount )
 end
 
 function EnforcementPolicy:JoinTeam( Plugin, Gamerules, Player, NewTeam, Force )
-	local Client = GetOwner( Player )
+	local Client = GetClientForPlayer( Player )
 	if not Client then return false end
 
 	local Immune = Shine:HasAccess( Client, "sh_randomimmune" )

--- a/lua/shine/extensions/voterandom/team_balance.lua
+++ b/lua/shine/extensions/voterandom/team_balance.lua
@@ -11,7 +11,7 @@ local BalanceModule = {}
 local Abs = math.abs
 local Ceil = math.ceil
 local Clamp = math.Clamp
-local GetOwner = Server.GetOwner
+local GetClientForPlayer = Shine.GetClientForPlayer
 local IsType = Shine.IsType
 local Max = math.max
 local next = next
@@ -133,12 +133,8 @@ local DebugMode = false
 -- TeamNumber parameter currently unused, but ready for Hive 2.0
 BalanceModule.SkillGetters = {
 	GetHiveSkill = function( Ply, TeamNumber )
-		local Client = GetOwner( Ply )
+		local Client = GetClientForPlayer( Ply )
 		if Client and Client:GetIsVirtual() then
-			if DebugMode then
-				Client.Skill = Client.Skill or Random( 0, 2500 )
-				return Client.Skill
-			end
 			-- Bots are all equal so there's no reason to consider them.
 			return nil
 		end
@@ -152,14 +148,6 @@ BalanceModule.SkillGetters = {
 
 	-- KA/D Ratio.
 	GetKDR = function( Ply, TeamNumber )
-		if DebugMode then
-			local Client = GetOwner( Ply )
-			if Client and Client:GetIsVirtual() then
-				Client.Skill = Client.Skill or Random() * 3
-				return Client.Skill
-			end
-		end
-
 		do
 			local KDR = Plugin:CallModuleEvent( "GetPlayerKDR", Ply, TeamNumber )
 			if KDR then return KDR end
@@ -180,14 +168,6 @@ BalanceModule.SkillGetters = {
 
 	-- Score per minute played.
 	GetScore = function( Ply, TeamNumber )
-		if DebugMode then
-			local Client = GetOwner( Ply )
-			if Client and Client:GetIsVirtual() then
-				Client.Skill = Client.Skill or Random() * 10
-				return Client.Skill
-			end
-		end
-
 		do
 			local ScorePerMinute = Plugin:CallModuleEvent( "GetPlayerScorePerMinute", Ply, TeamNumber )
 			if ScorePerMinute then return ScorePerMinute end
@@ -205,6 +185,38 @@ BalanceModule.SkillGetters = {
 		return Ply.totalScore / ( PlayTime / 60 )
 	end
 }
+
+if DebugMode then
+	local OldGetHiveSkill = BalanceModule.SkillGetters.GetHiveSkill
+	BalanceModule.SkillGetters.GetHiveSkill = function( Ply, TeamNumber )
+		local Client = GetClientForPlayer( Ply )
+		if Client and Client:GetIsVirtual() then
+			Client.Skill = Client.Skill or Random( 0, 2500 )
+			return Client.Skill
+		end
+		return OldGetHiveSkill( Ply, TeamNumber )
+	end
+
+	local OldGetKDR = BalanceModule.SkillGetters.GetKDR
+	BalanceModule.SkillGetters.GetKDR = function( Ply, TeamNumber )
+		local Client = GetClientForPlayer( Ply )
+		if Client and Client:GetIsVirtual() then
+			Client.Skill = Client.Skill or Random() * 3
+			return Client.Skill
+		end
+		return OldGetKDR( Ply, TeamNumber )
+	end
+
+	local OldGetScore = BalanceModule.SkillGetters.GetScore
+	BalanceModule.SkillGetters.GetScore = function( Ply, TeamNumber )
+		local Client = GetClientForPlayer( Ply )
+		if Client and Client:GetIsVirtual() then
+			Client.Skill = Client.Skill or Random() * 10
+			return Client.Skill
+		end
+		return OldGetScore( Ply, TeamNumber )
+	end
+end
 
 BalanceModule.HappinessHistoryFile = "config://shine/temp/shuffle_happiness.json"
 

--- a/lua/shine/extensions/votesurrender/server.lua
+++ b/lua/shine/extensions/votesurrender/server.lua
@@ -4,7 +4,7 @@
 
 local Shine = Shine
 
-local GetOwner = Server.GetOwner
+local GetClientForPlayer = Shine.GetClientForPlayer
 local SharedTime = Shared.GetTime
 local StringFormat = string.format
 
@@ -96,7 +96,7 @@ function Plugin:GetTeamPlayerCount( Team )
 
 	local Count = 0
 	local function CountPlayers( Player )
-		local Client = GetOwner( Player )
+		local Client = GetClientForPlayer( Player )
 		if Shine:IsValidClient( Client ) and self:IsValidVoter( Client ) then
 			Count = Count + 1
 		end
@@ -182,12 +182,11 @@ end
 ]]
 function Plugin:PostJoinTeam( Gamerules, Player, OldTeam, NewTeam, Force, ShineForce )
 	if not Player then return end
-	local Client = GetOwner( Player )
 
+	local Client = GetClientForPlayer( Player )
 	if not Client then return end
 
 	local Vote = self.Votes[ OldTeam ]
-
 	if Vote then
 		Vote:RemoveVote( Client )
 	end

--- a/lua/shine/extensions/welcomemessages/server.lua
+++ b/lua/shine/extensions/welcomemessages/server.lua
@@ -6,7 +6,7 @@ local ChatAPI = require "shine/core/shared/chat/chat_api"
 
 local Shine = Shine
 
-local GetOwner = Server.GetOwner
+local GetClientForPlayer = Shine.GetClientForPlayer
 local IsType = Shine.IsType
 local IsValid = debug.isvalid
 local StringFormat = string.format
@@ -267,7 +267,7 @@ function Plugin:PostJoinTeam( Gamerules, Player, OldTeam, NewTeam, Force, ShineF
 	if NewTeam < 0 then return end
 	if not Player then return end
 
-	local Client = GetOwner( Player )
+	local Client = GetClientForPlayer( Player )
 	if Client then
 		Client.DisconnectTeam = NewTeam
 	end

--- a/lua/shine/lib/class.lua
+++ b/lua/shine/lib/class.lua
@@ -18,9 +18,12 @@ local function RecursivelyReplaceMethod( Class, Method, Func, Original )
 	end
 end
 
-function Shine.ReplaceClassMethod( Class, Method, Func )
-	local Original = _G[ Class ] and _G[ Class ][ Method ]
+function Shine.GetClassMethod( Class, Method )
+	return _G[ Class ] and _G[ Class ][ Method ]
+end
 
+function Shine.ReplaceClassMethod( Class, Method, Func )
+	local Original = Shine.GetClassMethod( Class, Method )
 	if not Original then return nil, "class method does not exist." end
 
 	RecursivelyReplaceMethod( Class, Method, Func, Original )

--- a/lua/shine/lib/codegen.lua
+++ b/lua/shine/lib/codegen.lua
@@ -1,0 +1,140 @@
+--[[
+	Code generation helpers.
+]]
+
+local Huge = math.huge
+local load = load
+local select = select
+local StringFormat = string.format
+local StringGSub = string.gsub
+local TableConcat = table.concat
+local type = type
+local unpack = unpack
+
+local CodeGen = {}
+
+--[[
+	Generates a function from a template with the given number of arguments.
+
+	This is useful to use the same function template to handle varying number of arguments without needing a vararg
+	which can cause traces to abort.
+
+	This is an expensive operation, and thus should be done upfront or lazily where possible. The intention is to
+	spend a bit more time upfront to give the compiler a much easier time later.
+
+	Inputs:
+		1. The function code to be used as a template. This should be a valid Lua string with placeholders for:
+			* FunctionArguments - the generated arguments for the function, without a ", " at the front.
+			* Arguments - the generated arguments, with a ", " at the front to pass in front of known static arguments.
+		   It is expected that the given chunk returns a function.
+		2. The number of arguments to generate the function with. Can be math.huge to indicate a vararg should be used.
+		3. The source to give the loaded function (shown in error tracebacks).
+		... Any values to pass to the chunk (e.g. to provide upvalues).
+	Output:
+		The generated function.
+]]
+local function GenerateFunctionWithArguments( FunctionCode, NumArguments, ChunkName, ... )
+	Shine.TypeCheck( FunctionCode, "string", 1, "GenerateFunctionWithArguments" )
+	Shine.TypeCheck( NumArguments, "number", 2, "GenerateFunctionWithArguments" )
+	Shine.TypeCheck( ChunkName, { "string", "nil" }, 3, "GenerateFunctionWithArguments" )
+
+	local Arguments = { "" }
+	if NumArguments < Huge then
+		for i = 1, NumArguments do
+			Arguments[ i + 1 ] = StringFormat( "Arg%d", i )
+		end
+	else
+		Arguments[ 2 ] = "..."
+	end
+
+	local ArgumentsList = TableConcat( Arguments, ", " )
+	local ArgumentsWithoutPrefix = TableConcat( Arguments, ", ", 2 )
+	local GeneratedFunctionCode = StringGSub( FunctionCode, "{([^}]+)}", {
+		Arguments = ArgumentsList,
+		FunctionArguments = ArgumentsWithoutPrefix
+	} )
+
+	return load( GeneratedFunctionCode, ChunkName )( ... )
+end
+CodeGen.GenerateFunctionWithArguments = GenerateFunctionWithArguments
+
+local NO_ARGS = {}
+
+--[[
+	Provides a simple means of generating functions from a template that expect a specific number of arguments.
+
+	By using more specialised functions, var-args can be translated into a defined number of arguments which avoids
+	an NYI on the VARG bytecode instruction.
+
+	Input: Options table with the following keys:
+	{
+		-- Arguments to be passed to the function template (for use as upvalues in the returned function).
+		Args = { ... },
+
+		-- An optional name to give to each compiled function (used as the source name in error messages).
+		-- If omitted, the chunk's generated content is the source.
+		ChunkName = "...",
+
+		-- The maximum number of argument variations to generate upfront without lazy loading.
+		-- This generates variations for [0, InitialSize] number of arguments.
+		-- Ideally this should cover all expected use cases.
+		InitialSize = 5,
+
+		-- The number of arguments in the Args table. Can usually be omitted unless an argument in the middle is nil.
+		NumArgs = 1,
+
+		-- The Lua code template to be used when generating functions.
+		-- This should return a function which will be the generated function. Arguments are available under "...".
+		-- There are 2 template variables:
+		-- * FunctionArguments - the generated arguments for the function, without a ", " at the front.
+		-- * Arguments - the generated arguments, with a ", " at the front to pass in front of known static arguments.
+		Template = "return function( {FunctionArguments} ) return pcall( Something{Arguments} ) end",
+
+		-- An optional callback that is called whenever a new function is generated.
+		-- This will be called for all of the initial variations, and any later lazily generated versions.
+		-- The third argument will be true for lazily generated variations.
+		OnFunctionGenerated = function( NumArguments, Function, WasLazilyGenerated ) end
+	}
+	Output:
+		A table that provides a variation of the given template taking n arguments for each number key n.
+		If accessing an argument count that has not yet been generated, it is generated automatically.
+]]
+function CodeGen.MakeFunctionGenerator( Options )
+	local Args = Shine.TypeCheckField( Options, "Args", { "table", "nil" }, "Options" ) or NO_ARGS
+	local ChunkName = Shine.TypeCheckField( Options, "ChunkName", { "string", "nil" }, "Options" )
+	local NumArgs = Shine.TypeCheckField( Options, "NumArgs", { "number", "nil" }, "Options" ) or #Args
+	local Template = Shine.TypeCheckField( Options, "Template", "string", "Options" )
+
+	local OnFunctionGenerated = Options.OnFunctionGenerated
+	local HasCallback = Shine.IsCallable( OnFunctionGenerated )
+
+	local Functions = setmetatable( {}, {
+		__index = function( self, NumArguments )
+			if type( NumArguments ) ~= "number" then
+				return nil
+			end
+
+			local Function = GenerateFunctionWithArguments(
+				Template, NumArguments, ChunkName, unpack( Args, 1, NumArgs )
+			)
+
+			self[ NumArguments ] = Function
+
+			if HasCallback then
+				OnFunctionGenerated( NumArguments, Function, true )
+			end
+
+			return Function
+		end
+	} )
+	for i = 0, Options.InitialSize do
+		Functions[ i ] = GenerateFunctionWithArguments( Template, i, ChunkName, unpack( Args, 1, NumArgs ) )
+		if HasCallback then
+			OnFunctionGenerated( i, Functions[ i ], false )
+		end
+	end
+
+	return Functions
+end
+
+return CodeGen

--- a/lua/shine/lib/codegen.lua
+++ b/lua/shine/lib/codegen.lua
@@ -23,6 +23,9 @@ local CodeGen = {}
 		The generated string with all variables substituted.
 ]]
 local function ApplyTemplateValues( FunctionCode, TemplateValues )
+	Shine.TypeCheck( FunctionCode, "string", 1, "ApplyTemplateValues" )
+	Shine.TypeCheck( TemplateValues, "table", 2, "ApplyTemplateValues" )
+
 	return ( StringGSub( FunctionCode, "{([^%s]+)}", TemplateValues ) )
 end
 CodeGen.ApplyTemplateValues = ApplyTemplateValues
@@ -41,6 +44,10 @@ CodeGen.ApplyTemplateValues = ApplyTemplateValues
 		The generated function.
 ]]
 local function GenerateTemplatedFunction( FunctionCode, ChunkName, TemplateValues, ... )
+	Shine.TypeCheck( FunctionCode, "string", 1, "GenerateTemplatedFunction" )
+	Shine.TypeCheck( ChunkName, { "string", "nil" }, 2, "GenerateTemplatedFunction" )
+	Shine.TypeCheck( TemplateValues, "table", 3, "GenerateTemplatedFunction" )
+
 	local GeneratedFunctionCode = ApplyTemplateValues( FunctionCode, TemplateValues )
 	return load( GeneratedFunctionCode, ChunkName )( ... )
 end

--- a/lua/shine/lib/codegen.lua
+++ b/lua/shine/lib/codegen.lua
@@ -76,7 +76,7 @@ CodeGen.GenerateTemplatedFunction = GenerateTemplatedFunction
 local function GenerateFunctionWithArguments( FunctionCode, NumArguments, ChunkName, ... )
 	Shine.TypeCheck( FunctionCode, "string", 1, "GenerateFunctionWithArguments" )
 	Shine.TypeCheck( NumArguments, "number", 2, "GenerateFunctionWithArguments" )
-	Shine.TypeCheck( ChunkName, { "string", "nil" }, 3, "GenerateFunctionWithArguments" )
+	Shine.TypeCheck( ChunkName, { "function", "string", "nil" }, 3, "GenerateFunctionWithArguments" )
 
 	local Arguments = { "" }
 	if NumArguments < Huge then
@@ -89,8 +89,14 @@ local function GenerateFunctionWithArguments( FunctionCode, NumArguments, ChunkN
 
 	local ArgumentsList = TableConcat( Arguments, ", " )
 	local ArgumentsWithoutPrefix = TableConcat( Arguments, ", ", 2 )
+	local FinalChunkName
+	if type( ChunkName ) == "function" then
+		FinalChunkName = ChunkName( NumArguments )
+	else
+		FinalChunkName = ChunkName
+	end
 
-	return GenerateTemplatedFunction( FunctionCode, ChunkName, {
+	return GenerateTemplatedFunction( FunctionCode, FinalChunkName, {
 		Arguments = ArgumentsList,
 		FunctionArguments = ArgumentsWithoutPrefix
 	}, ... )
@@ -140,7 +146,7 @@ local NO_ARGS = {}
 ]]
 function CodeGen.MakeFunctionGenerator( Options )
 	local Args = Shine.TypeCheckField( Options, "Args", { "table", "nil" }, "Options" ) or NO_ARGS
-	local ChunkName = Shine.TypeCheckField( Options, "ChunkName", { "string", "nil" }, "Options" )
+	local ChunkName = Shine.TypeCheckField( Options, "ChunkName", { "function", "string", "nil" }, "Options" )
 	local NumArgs = Shine.TypeCheckField( Options, "NumArgs", { "number", "nil" }, "Options" ) or #Args
 	local Template = Shine.TypeCheckField( Options, "Template", "string", "Options" )
 

--- a/lua/shine/lib/colour.lua
+++ b/lua/shine/lib/colour.lua
@@ -8,18 +8,32 @@ Colour = Color --I'm British, I can't stand writing Color.
 local Colour = Colour
 
 local Floor = math.floor
-local getmetatable = getmetatable
 local Max = math.max
 local Min = math.min
+local type = type
 
-local ColourMetatable = getmetatable( Colour( 0, 0, 0 ) )
+local IsColour
+do
+	local FFILoaded, FFI = pcall( require, "ffi" )
+	if FFILoaded and FFI and FFI.istype then
+		local Success, PassedCheck = pcall( FFI.istype, "Color", Colour( 1, 1, 1 ) )
+		if Success and PassedCheck then
+			local IsType = FFI.istype
+			IsColour = function( Colour ) return IsType( "Color", Colour ) end
+		end
+	end
+
+	if not IsColour then
+		-- This is more risky as cdata can be anything.
+		IsColour = function( Colour ) return Colour:isa( "Color" ) end
+	end
+end
 
 --[[
 	Determines if the passed in object is a colour.
 ]]
 function SGUI.IsColour( Object )
-	-- Apparently vectors and colours share the same metatable...
-	return getmetatable( Object ) == ColourMetatable and Object.r
+	return type( Object ) == "cdata" and IsColour( Object )
 end
 
 --[[

--- a/lua/shine/lib/datatables.lua
+++ b/lua/shine/lib/datatables.lua
@@ -189,7 +189,7 @@ if Server then
 	end
 
 	-- Obey permissions...
-	Shine.Hook.Add( "ClientConfirmConnect", "DataTablesUpdate", function( Client )
+	Shine.Hook.Add( "ClientConnect", "DataTablesUpdate", function( Client )
 		for Table, Data in pairs( RealData ) do
 			if not Table.__Access then
 				Shine.SendNetworkMessage( Client, Table.__Name, Data, true )

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -32,8 +32,9 @@ do
 	local Vector = Vector
 
 	-- A little easier than having to always include that 0 z value.
+	-- The return is wrapped to avoid a tail-call which doesn't compile.
 	function Vector2( X, Y )
-		return Vector( X, Y, 0 )
+		return ( Vector( X, Y, 0 ) )
 	end
 end
 
@@ -1189,12 +1190,13 @@ SGUI.NotifyFocusChange = NotifyFocusChange
 
 local GetCursorPosScreen = Client.GetCursorPosScreen
 function SGUI.GetCursorPos()
-	return GetCursorPosScreen()
+	local X, Y = GetCursorPosScreen()
+	return X, Y
 end
 
 local GetMouseVisible = Client.GetMouseVisible
 function SGUI.IsMouseVisible()
-	return GetMouseVisible()
+	return ( GetMouseVisible() )
 end
 
 local ScrW = Client.GetScreenWidth

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -1078,19 +1078,21 @@ do
 		Input: SGUI control object.
 	]]
 	function SGUI:Destroy( Control )
-		if self.CallingEvent then
-			-- Wait until after the running event to destroy the control. This avoids needing loads of validity checks
-			-- in event code paths.
-			self:AddPostEventAction( DestructionAction( Control ) )
-			return
-		end
-
+		-- Remove the control from its parent immediately regardless of the running event. This avoids it showing
+		-- up in child iterations.
 		if Control.Parent then
 			Control:SetParent( nil )
 		end
 
 		if Control.LayoutParent then
 			Control.LayoutParent:RemoveElement( Control )
+		end
+
+		if self.CallingEvent then
+			-- Wait until after the running event to destroy the control. This avoids needing loads of validity checks
+			-- in event code paths.
+			self:AddPostEventAction( DestructionAction( Control ) )
+			return
 		end
 
 		self.ActiveControls:Remove( Control )

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -87,6 +87,18 @@ SGUI.PropertyModifiers = {
 	end
 }
 do
+	-- This exists to avoid constant concatenation every time properties are set dynamically.
+	local SetterKeys = setmetatable( require "table.new"( 0, 100 ), {
+		__index = function( self, Key )
+			local Setter = "Set"..Key
+
+			self[ Key ] = Setter
+
+			return Setter
+		end
+	} )
+	SGUI.SetterKeys = SetterKeys
+
 	local function GetModifiers( Modifiers )
 		local RealModifiers = {}
 
@@ -101,7 +113,7 @@ do
 		Adds Get and Set functions for a property name, with an optional default value.
 	]]
 	function SGUI.AddProperty( Table, Name, Default, Modifiers )
-		local TableSetter = "Set"..Name
+		local TableSetter = SetterKeys[ Name ]
 		local TableGetter = "Get"..Name
 
 		Table[ TableSetter ] = function( self, Value )
@@ -181,7 +193,7 @@ do
 			return self[ Name ]
 		end
 
-		local TableSetter = "Set"..Name
+		local TableSetter = SetterKeys[ Name ]
 		Table[ TableSetter ] = function( self, Value )
 			local OldValue = self[ Name ]
 

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -1188,15 +1188,15 @@ local function NotifyFocusChange( Element, ClickingOtherElement )
 end
 SGUI.NotifyFocusChange = NotifyFocusChange
 
-local GetCursorPosScreen = Client.GetCursorPosScreen
+local GetCursorPos = MouseTracker_GetCursorPos
 function SGUI.GetCursorPos()
-	local X, Y = GetCursorPosScreen()
-	return X, Y
+	local Pos = GetCursorPos()
+	return Pos.x, Pos.y
 end
 
-local GetMouseVisible = Client.GetMouseVisible
+local GetMouseVisible = MouseTracker_GetIsVisible
 function SGUI.IsMouseVisible()
-	return ( GetMouseVisible() )
+	return GetMouseVisible()
 end
 
 local ScrW = Client.GetScreenWidth
@@ -1255,8 +1255,6 @@ local IsMainMenuOpen = MainMenu_GetIsOpened
 	If we don't load after everything, things aren't registered properly.
 ]]
 Hook.Add( "OnMapLoad", "LoadGUIElements", function()
-	GetCursorPosScreen = Client.GetCursorPosScreen
-	GetMouseVisible = Client.GetMouseVisible
 	ScrW = Client.GetScreenWidth
 	ScrH = Client.GetScreenHeight
 	IsMainMenuOpen = MainMenu_GetIsOpened
@@ -1270,6 +1268,9 @@ Hook.Add( "OnMapLoad", "LoadGUIElements", function()
 end )
 
 Hook.CallAfterFileLoad( "lua/menu/MouseTracker.lua", function()
+	GetCursorPos = MouseTracker_GetCursorPos
+	GetMouseVisible = MouseTracker_GetIsVisible
+
 	local Listener = {
 		OnMouseMove = function( _, LMB )
 			SGUI:CallEvent( false, "OnMouseMove", LMB )

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -1458,7 +1458,7 @@ function ControlMeta:HandleEasing( Time, DeltaTime )
 					Easings:Remove( Element )
 
 					if EasingData.Callback then
-						EasingData.Callback( Element )
+						EasingData.Callback( self, Element )
 					end
 				end
 			end
@@ -1961,12 +1961,16 @@ function ControlMeta:ShowTooltip( MouseX, MouseY )
 	self.Tooltip = Tooltip
 end
 
-function ControlMeta:HideTooltip()
-	if not SGUI.IsValid( self.Tooltip ) then return end
-
-	self.Tooltip:FadeOut( function()
+do
+	local function OnTooltipHidden( self )
 		self.Tooltip = nil
-	end )
+	end
+
+	function ControlMeta:HideTooltip()
+		if not SGUI.IsValid( self.Tooltip ) then return end
+
+		self.Tooltip:FadeOut( OnTooltipHidden, self )
+	end
 end
 
 function ControlMeta:SetHighlighted( Highlighted, SkipAnim )

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -162,9 +162,7 @@ function ControlMeta:GetPropertySource( Name )
 	SourceInstance.Element = self
 
 	self.PropertySources[ Name ] = SourceInstance
-	self:AddPropertyChangeListener( Name, function( self, Value )
-		return SourceInstance( Value )
-	end )
+	self:AddPropertyChangeListener( Name, SourceInstance )
 
 	return SourceInstance
 end

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -830,6 +830,10 @@ function ControlMeta:SetAlpha( Alpha )
 	self.Background:SetColor( Colour )
 end
 
+function ControlMeta:GetAlpha()
+	return self.Background:GetColor().a
+end
+
 function ControlMeta:GetTextureWidth()
 	return self.Background:GetTextureWidth()
 end

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -2100,17 +2100,16 @@ function ControlMeta:EvaluateMouseState()
 		StateChanged = true
 
 		self.MouseHasEntered = true
-		self:HandleHightlighting()
 		self:OnMouseEnter()
 	elseif not IsMouseIn and self.MouseHasEntered then
 		-- Need to let children see the mouse exit themselves too.
 		StateChanged = true
 
 		self.MouseHasEntered = false
-		self:HandleHightlighting()
 		self:OnMouseLeave()
 	end
 
+	self:HandleHightlighting()
 	self.MouseStateIsInvalid = false
 
 	return IsMouseIn, StateChanged

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -24,16 +24,7 @@ local Map = Shine.Map
 local Multimap = Shine.Multimap
 local Source = require "shine/lib/gui/binding/source"
 
--- This exists to avoid constant concatenation every time properties are set dynamically.
-local SetterKeys = setmetatable( TableNew( 0, 100 ), {
-	__index = function( self, Key )
-		local Setter = "Set"..Key
-
-		self[ Key ] = Setter
-
-		return Setter
-	end
-} )
+local SetterKeys = SGUI.SetterKeys
 
 SGUI.AddBoundProperty( ControlMeta, "BlendTechnique", "Background" )
 SGUI.AddBoundProperty( ControlMeta, "InheritsParentAlpha", "Background" )

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -371,6 +371,8 @@ function ControlMeta:SetParent( Control, Element )
 		self.ParentElement:RemoveChild( self.Background )
 	end
 
+	self:InvalidateMouseState()
+
 	if not Control then
 		self.Parent = nil
 		self.ParentElement = nil
@@ -642,6 +644,8 @@ function ControlMeta:SetIsVisible( IsVisible )
 
 	if not IsVisible then
 		self:HideTooltip()
+	else
+		self:InvalidateMouseState()
 	end
 
 	if not SGUI:IsWindow( self ) then return end

--- a/lua/shine/lib/gui/binding/source.lua
+++ b/lua/shine/lib/gui/binding/source.lua
@@ -29,7 +29,7 @@ end
 
 -- Called when a change occurs, internally tracks whether a value has changed
 -- and then calls downstream listeners if it has.
-function Source:__call( Value )
+function Source:__call( _, Value )
 	if self.Value == Value then return end
 
 	-- Update the value before calling listeners to allow them to iterate over

--- a/lua/shine/lib/gui/notification_manager.lua
+++ b/lua/shine/lib/gui/notification_manager.lua
@@ -48,6 +48,18 @@ local MARGIN = HighResScaled( 16 )
 local PADDING = HighResScaled( 16 )
 local FLAIR_WIDTH = HighResScaled( 48 )
 
+local function OnNotificationFadeOut( Notification )
+	for i = #Notifications, 1, -1 do
+		if Notifications[ i ] == Notification then
+			Notification:StopMoving()
+			TableRemove( Notifications, i )
+			-- Move any notifications above this one down to compensate for the gap.
+			OffsetAllNotifications( -Notification:GetSize().y - MARGIN:GetValue(), 1, i - 1 )
+			break
+		end
+	end
+end
+
 --[[
 	Adds a notification to the screen.
 
@@ -85,17 +97,7 @@ function NotificationManager.AddNotification( Type, Message, Duration, Options )
 	Notification.TargetPos = TargetPos
 	Notification:MoveTo( nil, nil, TargetPos, 0, 0.3 )
 	Notification:FadeIn()
-	Notification:FadeOutAfter( Duration, function()
-		for i = #Notifications, 1, -1 do
-			if Notifications[ i ] == Notification then
-				Notification:StopMoving()
-				TableRemove( Notifications, i )
-				-- Move any notifications above this one down to compensate for the gap.
-				OffsetAllNotifications( -Notification:GetSize().y - MARGIN:GetValue(), 1, i - 1 )
-				break
-			end
-		end
-	end )
+	Notification:FadeOutAfter( Duration, OnNotificationFadeOut )
 
 	-- Move all existing notifications up by the notification's size + margin.
 	OffsetAllNotifications( Notification:GetSize().y + MARGIN:GetValue(), 1, #Notifications )

--- a/lua/shine/lib/gui/objects/button.lua
+++ b/lua/shine/lib/gui/objects/button.lua
@@ -70,13 +70,26 @@ local function UpdateIconMargin( self )
 end
 
 function Button:SetText( Text )
-	self:InvalidateParent()
+	if SGUI.IsValid( self.Label ) then
+		if not Text then
+			self.Label:Destroy()
+			self.Label = nil
+			self:InvalidateParent()
+			self:OnPropertyChanged( "Text", nil )
+			return
+		end
 
-	if self.Label then
+		if self.Label:GetText() == Text then return end
+
 		self.Label:SetText( Text )
+		self:InvalidateParent()
 		self:InvalidateLayout()
+		self:OnPropertyChanged( "Text", Text )
+
 		return
 	end
+
+	if not Text then return end
 
 	local Description = SGUI:Create( "Label", self )
 	Description:SetIsSchemed( false )
@@ -125,8 +138,11 @@ function Button:SetText( Text )
 
 	self.Layout:AddElement( Description )
 	self.Label = Description
+	self:InvalidateParent()
 
 	UpdateIconMargin( self )
+
+	self:OnPropertyChanged( "Text", Text )
 end
 
 function Button:GetText()

--- a/lua/shine/lib/gui/objects/chatline.lua
+++ b/lua/shine/lib/gui/objects/chatline.lua
@@ -158,21 +158,33 @@ function ChatLine:MakeVisible()
 	end
 end
 
+local function OnFadeOutDelayPassed( Timer )
+	local Data = Timer.Data
+
+	local ChatLineInstance = Data.ChatLine
+	if not SGUI.IsValid( ChatLineInstance ) then return end
+
+	ChatLineInstance.FadeOutTimer = nil
+
+	if not ChatLineInstance.Parent:GetIsVisible() then
+		-- Skip fading if currently invisible.
+		return Data.OnComplete()
+	end
+
+	ChatLineInstance:FadeOut( Data.Duration, Data.OnComplete, Data.Easer )
+end
+
 function ChatLine:FadeOutIn( Delay, Duration, OnComplete, Easer )
 	if self.FadeOutTimer then
 		self.FadeOutTimer:Destroy()
 	end
 
-	self.FadeOutTimer = Shine.Timer.Simple( Delay, function()
-		self.FadeOutTimer = nil
-
-		if not self.Parent:GetIsVisible() then
-			-- Skip fading if currently invisible.
-			return OnComplete()
-		end
-
-		self:FadeOut( Duration, OnComplete, Easer )
-	end )
+	self.FadeOutTimer = Shine.Timer.Simple( Delay, OnFadeOutDelayPassed, {
+		ChatLine = self,
+		Duration = Duration,
+		OnComplete = OnComplete,
+		Easer = Easer
+	} )
 end
 
 function ChatLine:FadeOut( Duration, OnComplete, Easer )

--- a/lua/shine/lib/gui/objects/checkbox.lua
+++ b/lua/shine/lib/gui/objects/checkbox.lua
@@ -78,9 +78,7 @@ function CheckBox:SetChecked( Value, DontFade )
 		if DontFade then
 			self.Box:SetColor( self.BoxCol )
 		else
-			self:FadeTo( self.Box, self.BoxHideCol, self.BoxCol, 0, 0.1, function( Box )
-				Box:SetColor( self.BoxCol )
-			end )
+			self:FadeTo( self.Box, self.BoxHideCol, self.BoxCol, 0, 0.1 )
 		end
 
 		self:OnChecked( true )
@@ -94,9 +92,7 @@ function CheckBox:SetChecked( Value, DontFade )
 	if DontFade then
 		self.Box:SetColor( self.BoxHideCol )
 	else
-		self:FadeTo( self.Box, self.BoxCol, self.BoxHideCol, 0, 0.1, function( Box )
-			Box:SetColor( self.BoxHideCol )
-		end )
+		self:FadeTo( self.Box, self.BoxCol, self.BoxHideCol, 0, 0.1 )
 	end
 
 	self:OnChecked( false )

--- a/lua/shine/lib/gui/objects/checkbox.lua
+++ b/lua/shine/lib/gui/objects/checkbox.lua
@@ -10,6 +10,8 @@ local RoundTo = math.RoundTo
 
 local CheckBox = {}
 
+SGUI.AddProperty( CheckBox, "LabelPadding", 10, { "InvalidatesLayout" } )
+
 function CheckBox:Initialise()
 	self.BaseClass.Initialise( self )
 
@@ -53,7 +55,7 @@ function CheckBox:SetSize( Vec )
 	Vec.x = RoundTo( Vec.x, 2 )
 	Vec.y = RoundTo( Vec.y, 2 )
 
-	self.Background:SetSize( Vec )
+	self.BaseClass.SetSize( self, Vec )
 
 	local BoxSize = Vec * 0.75
 	BoxSize.x = RoundTo( BoxSize.x, 2 )
@@ -61,8 +63,6 @@ function CheckBox:SetSize( Vec )
 
 	self.Box:SetSize( BoxSize )
 	self.Box:SetPosition( -BoxSize * 0.5 )
-
-	self:InvalidateLayout()
 end
 
 function CheckBox:GetChecked()
@@ -103,6 +103,15 @@ function CheckBox:SetChecked( Value, DontFade )
 	self:OnPropertyChanged( "Checked", false )
 end
 
+-- Include the attached label when checking for mouse entry.
+function CheckBox:GetMouseBounds()
+	local Size = self:GetSize()
+	if SGUI.IsValid( self.Label ) then
+		Size = Size + Vector2( Size.x + self:GetLabelPadding() + self.Label:GetSize().x, 0 )
+	end
+	return Size
+end
+
 function CheckBox:OnMouseDown( Key, DoubleClick )
 	if not self:GetIsVisible() then return end
 	if Key ~= InputKey.MouseButton0 then return end
@@ -127,7 +136,7 @@ end
 function CheckBox:PerformLayout()
 	if self.Label then
 		local Size = self:GetSize().x
-		self.Label:SetPos( Vector( Size + 10, 0, 0 ) )
+		self.Label:SetPos( Vector( Size + self:GetLabelPadding(), 0, 0 ) )
 	end
 end
 
@@ -144,7 +153,7 @@ function CheckBox:AddLabel( Text )
 	Label:SetAnchor( GUIItem.Left, GUIItem.Center )
 	Label:SetTextAlignmentY( GUIItem.Align_Center )
 	Label:SetText( Text )
-	Label:SetPos( Vector( self:GetSize().x + 10, 0, 0 ) )
+	Label:SetPos( Vector( self:GetSize().x + self:GetLabelPadding(), 0, 0 ) )
 
 	if self.Font then
 		Label:SetFont( self.Font )
@@ -162,18 +171,7 @@ function CheckBox:AddLabel( Text )
 		Label.Label:SetInheritsParentStencilSettings( true )
 	end
 
-	if self.TooltipText then
-		Label:SetTooltip( self.TooltipText )
-	end
-
 	self.Label = Label
-end
-
-function CheckBox:SetTooltip( Tooltip )
-	self.BaseClass.SetTooltip( self, Tooltip )
-	if SGUI.IsValid( self.Label ) then
-		self.Label:SetTooltip( Tooltip )
-	end
 end
 
 function CheckBox:OnChecked( Checked )

--- a/lua/shine/lib/gui/objects/colour_label.lua
+++ b/lua/shine/lib/gui/objects/colour_label.lua
@@ -95,6 +95,8 @@ function ColourLabel:SetText( TextContent )
 		Count = Count + 1
 		self.Labels[ Count ] = Label
 	end
+
+	self:InvalidateMouseState()
 end
 
 function ColourLabel:GetSize()

--- a/lua/shine/lib/gui/objects/colour_label.lua
+++ b/lua/shine/lib/gui/objects/colour_label.lua
@@ -19,7 +19,8 @@ function ColourLabel:Initialise()
 	self.IsVertical = false
 
 	self.Background = self:MakeGUIItem()
-	self.Background:SetColor( Colour( 0, 0, 0, 0 ) )
+	self.Background:SetShader( SGUI.Shaders.Invisible )
+	self.Background:SetColor( Colour( 1, 1, 1, 1 ) )
 end
 
 function ColourLabel:MakeVertical()
@@ -60,22 +61,12 @@ function ColourLabel:SetShadow( Params )
 	self:ForEach( "Labels", "SetShadow", Params )
 end
 
-function ColourLabel:AlphaTo( ... )
-	self:ForEach( "Labels", "AlphaTo", ... )
-end
-
 function ColourLabel:SetText( TextContent )
 	local Easing
 	if #self.Labels > 0 then
 		for i = 1, #self.Labels do
 			local Label = self.Labels[ i ]
-			local LabelAlphaEase = Label:GetEasing( "Alpha" )
-			if LabelAlphaEase and not Easing then
-				Easing = LabelAlphaEase
-			end
 			Label:Destroy()
-
-			self.Layout.Elements[ i ] = nil
 			self.Labels[ i ] = nil
 		end
 	end
@@ -98,15 +89,11 @@ function ColourLabel:SetText( TextContent )
 		Label:SetFontScale( self.Font, self.TextScale )
 		Label:SetText( Text )
 		Label:SetColour( SGUI.CopyColour( Colour ) )
+		Label:SetInheritsParentAlpha( true )
 		self.Layout:AddElement( Label )
 
 		Count = Count + 1
 		self.Labels[ Count ] = Label
-	end
-
-	if Easing and Easing.Elapsed < Easing.Duration then
-		self:AlphaTo( nil, Easing.Start, Easing.End, -Easing.Elapsed, Easing.Duration, Easing.Callback,
-			Easing.EaseFunc, Easing.Power )
 	end
 end
 

--- a/lua/shine/lib/gui/objects/dropdown.lua
+++ b/lua/shine/lib/gui/objects/dropdown.lua
@@ -27,38 +27,7 @@ function Dropdown:Initialise()
 
 	self.Options = {}
 
-	self:SetOpenMenuOnClick( function( self )
-		return {
-			MenuPos = self.MenuPos.BOTTOM,
-			Populate = function( Menu )
-				Menu:SetMaxVisibleButtons( Max( self:GetMaxVisibleOptions(), 1 ) )
-				Menu:SetFontScale( self:GetFont(), self:GetTextScale() )
-
-				for i = 1, #self.Options do
-					local Option = self.Options[ i ]
-
-					local function DoClick( Button )
-						local Result = true
-						if Option.DoClick then
-							Result = Option.DoClick( Button )
-						end
-
-						self:SetSelectedOption( Option )
-
-						Menu:Destroy()
-
-						return Result
-					end
-
-					local Button = Menu:AddButton( Option.Text, DoClick, Option.Tooltip )
-					if Option.Icon then
-						Button:SetIcon( Option.Icon, Option.IconFont, Option.IconScale )
-					end
-					Button:SetStyleName( "DropdownButton" )
-				end
-			end
-		}
-	end )
+	self:SetOpenMenuOnClick( self.BuildMenu )
 
 	Binder():FromElement( self, "SelectedOption" )
 		:ToElement( self, "Text", {
@@ -86,6 +55,39 @@ function Dropdown:Initialise()
 			end
 		} )
 		:BindProperty()
+end
+
+function Dropdown:BuildMenu()
+	return {
+		MenuPos = self.MenuPos.BOTTOM,
+		Populate = function( Menu )
+			Menu:SetMaxVisibleButtons( Max( self:GetMaxVisibleOptions(), 1 ) )
+			Menu:SetFontScale( self:GetFont(), self:GetTextScale() )
+
+			for i = 1, #self.Options do
+				local Option = self.Options[ i ]
+
+				local function DoClick( Button )
+					local Result = true
+					if Option.DoClick then
+						Result = Option.DoClick( Button )
+					end
+
+					self:SetSelectedOption( Option )
+
+					Menu:Destroy()
+
+					return Result
+				end
+
+				local Button = Menu:AddButton( Option.Text, DoClick, Option.Tooltip )
+				if Option.Icon then
+					Button:SetIcon( Option.Icon, Option.IconFont, Option.IconScale )
+				end
+				Button:SetStyleName( "DropdownButton" )
+			end
+		end
+	}
 end
 
 function Dropdown:SelectOption( Value )

--- a/lua/shine/lib/gui/objects/label.lua
+++ b/lua/shine/lib/gui/objects/label.lua
@@ -26,6 +26,7 @@ do
 		self.CachedTextWidth = nil
 		self.CachedTextHeight = nil
 		self.NeedsTextSizeRefresh = true
+		self:InvalidateMouseState()
 	end
 
 	local function SetupElementForFontName( self, Font )
@@ -86,8 +87,8 @@ do
 	end
 end
 
-function Label:MouseIn( Element, Mult, MaxX, MaxY )
-	return self:MouseInControl( Mult, MaxX, MaxY )
+function Label:MouseIn( Element, Mult )
+	return self:MouseInControl( Mult )
 end
 
 local AlignmentMultipliers = {

--- a/lua/shine/lib/gui/objects/label.lua
+++ b/lua/shine/lib/gui/objects/label.lua
@@ -115,24 +115,26 @@ function Label:SetupStencil()
 	self.Label:SetStencilFunc( GUIItem.NotEqual )
 end
 
+local WordWrapDummy = {
+	GetTextWidth = function( self, Text )
+		-- Need to account for scale here.
+		return self.Element:GetTextWidth( Text )
+	end,
+	SetText = function( self, Text )
+		self.Element.Label:SetText( Text )
+		self.Element:EvaluateOptionFlags( Text )
+	end
+}
+
 -- Apply word wrapping before the height is computed (assuming height = Units.Auto()).
 function Label:PreComputeHeight( Width )
 	if not self.AutoWrap then return end
 
 	local CurrentText = self.Label:GetText()
+
 	-- Pass in a dummy to avoid mutating the actual text value assigned to this label,
 	-- and instead only update the displayed text on the GUIItem.
-	local WordWrapDummy = {
-		GetTextWidth = function( _, Text )
-			-- Need to account for scale here.
-			return self:GetTextWidth( Text )
-		end,
-		SetText = function( _, Text )
-			self.Label:SetText( Text )
-			self:EvaluateOptionFlags( Text )
-		end
-	}
-
+	WordWrapDummy.Element = self
 	SGUI.WordWrap( WordWrapDummy, self.Text, 0, Width )
 
 	if CurrentText ~= self.Label:GetText() then

--- a/lua/shine/lib/gui/objects/list.lua
+++ b/lua/shine/lib/gui/objects/list.lua
@@ -216,10 +216,9 @@ end
 	Sets the list's size, just a simple vector input.
 ]]
 function List:SetSize( Size )
-	self.Background:SetSize( Size )
+	self.BaseClass.SetSize( self, Size )
 	self.CroppingBox:SetSize( Size )
 	self.Size = Size
-	self:InvalidateLayout()
 end
 
 function List:PerformLayout()
@@ -721,7 +720,7 @@ function List:OnMouseMove( Down )
 		self.Scrollbar:OnMouseMove( Down )
 	end
 
-	self:CallOnChildren( "OnMouseMove", Down )
+	self.BaseClass.OnMouseMove( self, Down )
 end
 
 function List:Think( DeltaTime )

--- a/lua/shine/lib/gui/objects/panel.lua
+++ b/lua/shine/lib/gui/objects/panel.lua
@@ -464,7 +464,7 @@ function Panel:SetMaxWidth( MaxWidth )
 		self.ScrollParentPos = self.ScrollParentPos or Vector2( 0, 0 )
 
 		local function OnScrollChanged()
-			self:OnMouseMove( false )
+			self:InvalidateMouseState( true )
 		end
 
 		function self:OnScrollChangeX( Pos, MaxPos, Smoothed )
@@ -550,7 +550,7 @@ function Panel:SetMaxHeight( MaxHeight, ForceInstantScroll )
 		self.ScrollParentPos = self.ScrollParentPos or Vector2( 0, 0 )
 
 		local function OnScrollChanged()
-			self:OnMouseMove( false )
+			self:InvalidateMouseState( true )
 		end
 
 		function self:OnScrollChange( Pos, MaxPos, Smoothed )

--- a/lua/shine/lib/gui/objects/panel.lua
+++ b/lua/shine/lib/gui/objects/panel.lua
@@ -225,16 +225,7 @@ local function UpdateMaxSize( Child )
 	local Parent = Child.Parent
 	if not Parent.ScrollParent or not Child:GetIsVisible() then return end
 
-	local Size = Parent:GetSize()
-	local NewMaxWidth = ComputeMaxWidth( Child, Size.x )
-	if NewMaxWidth > Parent:GetMaxWidth() then
-		Parent:SetMaxWidth( NewMaxWidth )
-	end
-
-	local NewMaxHeight = ComputeMaxHeight( Child, Size.y )
-	if NewMaxHeight > Parent:GetMaxHeight() then
-		Parent:SetMaxHeight( NewMaxHeight + Parent.BufferAmount )
-	end
+	Parent:InvalidateLayout()
 end
 
 function Panel:Add( Class, Created )

--- a/lua/shine/lib/gui/objects/panel.lua
+++ b/lua/shine/lib/gui/objects/panel.lua
@@ -28,6 +28,21 @@ SGUI.AddProperty( Panel, "StickyScroll" )
 SGUI.AddBoundProperty( Panel, "Colour", "Background:SetColor" )
 SGUI.AddBoundProperty( Panel, "HideHorizontalScrollbar", "HorizontalScrollbar:SetHidden" )
 
+local function OnAutoHideScrollbarChanged( self, AutoHideScrollbar )
+	if AutoHideScrollbar then return end
+
+	-- When the scrollbar is set to no longer auto-hide, make sure it's visible.
+	if SGUI.IsValid( self.Scrollbar ) then
+		self.Scrollbar:SetIsVisible( true )
+		self.Scrollbar:StopFading()
+	end
+
+	if SGUI.IsValid( self.HorizontalScrollbar ) then
+		self.HorizontalScrollbar:SetIsVisible( true )
+		self.HorizontalScrollbar:StopFading()
+	end
+end
+
 function Panel:Initialise()
 	self.BaseClass.Initialise( self )
 
@@ -38,6 +53,8 @@ function Panel:Initialise()
 	self.HorizontalScrollingEnabled = true
 	self.BlockEventsIfFocusedWindow = true
 	self.AlwaysInMouseFocus = false
+
+	self:AddPropertyChangeListener( "AutoHideScrollbar", OnAutoHideScrollbarChanged )
 end
 
 function Panel:SkinColour()

--- a/lua/shine/lib/gui/objects/progressbar.lua
+++ b/lua/shine/lib/gui/objects/progressbar.lua
@@ -49,7 +49,7 @@ function ProgressBar:SetBorderSize( BorderSize )
 end
 
 function ProgressBar:SetSize( Size )
-	self.Background:SetSize( Size )
+	self.BaseClass.SetSize( self, Size )
 
 	local BoxSize = Size - self.BorderSize * 2
 	RefreshInnerSizes( self, BoxSize )

--- a/lua/shine/lib/gui/objects/radio.lua
+++ b/lua/shine/lib/gui/objects/radio.lua
@@ -73,55 +73,60 @@ function Radio:SetOptions( Options )
 	end
 end
 
-function Radio:AddOption( Option )
-	TypeCheck( Option, "table", 1, "AddOption" )
-	TypeCheckField( Option, "Description", "string", "Option" )
-
-	local Index = #self.CheckBoxes + 1
-
-	local CheckBox = SGUI:Create( "CheckBox", self )
-	CheckBox:SetFontScale( self.Font, self.TextScale )
-	CheckBox:AddLabel( Option.Description )
-	CheckBox:SetRadio( not self.MultipleChoice )
-	CheckBox:SetAutoSize( self.CheckBoxAutoSize )
-	CheckBox:SetStyleName( self.CheckBoxStyleName )
-	CheckBox:SetTooltip( Option.Tooltip )
-	CheckBox.RadioOption = Option
-
-	if Index > 1 then
-		CheckBox:SetMargin( self.CheckBoxMargin )
-	end
-
-	CheckBox:AddPropertyChangeListener( "Checked", function( CheckBox, IsChecked )
-		if not self.MultipleChoice then
+do
+	local function OnCheckBoxStateChanged( CheckBox, IsChecked )
+		local Parent = CheckBox.Parent
+		if not Parent.MultipleChoice then
 			if not IsChecked then return end
 
-			for i = 1, #self.CheckBoxes do
-				local Box = self.CheckBoxes[ i ]
+			for i = 1, #Parent.CheckBoxes do
+				local Box = Parent.CheckBoxes[ i ]
 				if Box ~= CheckBox then
 					Box:SetChecked( false )
 				end
 			end
 
-			self:OnPropertyChanged( "SelectedOption", Option )
+			Parent:OnPropertyChanged( "SelectedOption", CheckBox.RadioOption )
 		else
 			local Options = {}
 
-			for i = 1, #self.CheckBoxes do
-				local Box = self.CheckBoxes[ i ]
+			for i = 1, #Parent.CheckBoxes do
+				local Box = Parent.CheckBoxes[ i ]
 				if Box:GetChecked() then
 					Options[ #Options + 1 ] = Box.RadioOption
 				end
 			end
 
-			self:OnPropertyChanged( "SelectedOptions", Options )
+			Parent:OnPropertyChanged( "SelectedOptions", Options )
 		end
-	end )
+	end
 
-	self.CheckBoxes[ Index ] = CheckBox
-	self.CheckBoxes[ Option ] = CheckBox
+	function Radio:AddOption( Option )
+		TypeCheck( Option, "table", 1, "AddOption" )
+		TypeCheckField( Option, "Description", "string", "Option" )
 
-	self.Layout:AddElement( CheckBox )
+		local Index = #self.CheckBoxes + 1
+
+		local CheckBox = SGUI:Create( "CheckBox", self )
+		CheckBox:SetFontScale( self.Font, self.TextScale )
+		CheckBox:AddLabel( Option.Description )
+		CheckBox:SetRadio( not self.MultipleChoice )
+		CheckBox:SetAutoSize( self.CheckBoxAutoSize )
+		CheckBox:SetStyleName( self.CheckBoxStyleName )
+		CheckBox:SetTooltip( Option.Tooltip )
+		CheckBox.RadioOption = Option
+
+		if Index > 1 then
+			CheckBox:SetMargin( self.CheckBoxMargin )
+		end
+
+		CheckBox:AddPropertyChangeListener( "Checked", OnCheckBoxStateChanged )
+
+		self.CheckBoxes[ Index ] = CheckBox
+		self.CheckBoxes[ Option ] = CheckBox
+
+		self.Layout:AddElement( CheckBox )
+	end
 end
 
 function Radio:RemoveOption( Option )

--- a/lua/shine/lib/gui/objects/richtext.lua
+++ b/lua/shine/lib/gui/objects/richtext.lua
@@ -151,8 +151,14 @@ function RichText:PerformWrapping()
 		TextScale = self.TextScale
 	} )
 
+	local OldW, OldH = self.WrappedWidth, self.WrappedHeight
+
 	self:ApplyLines( WrappedLines )
 	self.ComputedWrapping = true
+
+	if OldW ~= self.WrappedWidth or OldH ~= self.WrappedHeight then
+		self:OnPropertyChanged( "Size", Vector2( self.WrappedWidth, self.WrappedHeight ) )
+	end
 end
 
 local function MakeElementFromPool( self, Class )

--- a/lua/shine/lib/gui/objects/richtext.lua
+++ b/lua/shine/lib/gui/objects/richtext.lua
@@ -31,6 +31,7 @@ function RichText:SetFont( Font )
 
 	self.ComputedWrapping = false
 	self:InvalidateLayout()
+	self:InvalidateMouseState()
 end
 
 function RichText:SetTextScale( Scale )
@@ -40,6 +41,7 @@ function RichText:SetTextScale( Scale )
 
 	self.ComputedWrapping = false
 	self:InvalidateLayout()
+	self:InvalidateMouseState()
 end
 
 function RichText:PerformLayout()
@@ -56,6 +58,7 @@ function RichText:SetSize( Size )
 	self.MaxWidth = MaxWidth
 	self.ComputedWrapping = false
 	self:InvalidateLayout()
+	self:InvalidateMouseState()
 end
 
 function RichText:GetComputedSize( Index, ParentSize )
@@ -120,12 +123,14 @@ function RichText:SetContent( Contents )
 	self.Lines = self:ParseContents( Contents )
 	self.ComputedWrapping = false
 	self:InvalidateLayout()
+	self:InvalidateMouseState()
 end
 
 function RichText:RestoreFromLines( Lines )
 	self.Lines = Lines
 	self.ComputedWrapping = false
 	self:InvalidateLayout()
+	self:InvalidateMouseState()
 end
 
 function RichText:HasVisibleElements()

--- a/lua/shine/lib/gui/objects/scrollbar.lua
+++ b/lua/shine/lib/gui/objects/scrollbar.lua
@@ -48,6 +48,19 @@ function Scrollbar:FadeOut( Duration, Callback, EaseFunc )
 	self:AlphaTo( self.Bar, nil, 0, 0, Duration, nil, EaseFunc )
 end
 
+function Scrollbar:StopFading()
+	if not self:GetEasing( "Alpha", self.Bar ) then return end
+
+	self:StopAlpha( self.Background )
+	self:StopAlpha( self.Bar )
+
+	self:SetAlpha( self:GetNormalAlpha( self.Background ) )
+
+	local BarColour = self.Bar:GetColor()
+	BarColour.a = self:GetNormalAlpha( self.Bar )
+	self.Bar:SetColor( BarColour )
+end
+
 function Scrollbar:SetHidden( Hidden )
 	if Hidden then
 		self:HideAndDisableInput()
@@ -150,6 +163,7 @@ function Scrollbar:OnMouseDown( Key, DoubleClick )
 	self.StartingX = X
 	self.StartingY = Y
 
+	self:StopFading()
 	self.Bar:SetColor( self.ActiveCol )
 
 	return true, self

--- a/lua/shine/lib/gui/objects/scrollbar.lua
+++ b/lua/shine/lib/gui/objects/scrollbar.lua
@@ -78,7 +78,7 @@ end
 
 function Scrollbar:SetSize( Size )
 	self.Size = Size
-	self.Background:SetSize( Size )
+	self.BaseClass.SetSize( self, Size )
 
 	self:UpdateScrollBarSize()
 end

--- a/lua/shine/lib/gui/objects/slider.lua
+++ b/lua/shine/lib/gui/objects/slider.lua
@@ -382,7 +382,11 @@ function Slider:OnMouseUp( Key )
 end
 
 function Slider:OnMouseMove( Down )
-	self:CallOnChildren( "OnMouseMove", Down )
+	self.BaseClass.OnMouseMove( self, Down )
+
+	if SGUI.IsValid( self.TextEntry ) then
+		self.TextEntry:OnMouseMove( Down )
+	end
 
 	if not Down then return end
 	if not self.Dragging then return end

--- a/lua/shine/lib/gui/objects/textentry.lua
+++ b/lua/shine/lib/gui/objects/textentry.lua
@@ -6,12 +6,11 @@ local SGUI = Shine.GUI
 local Timer = Shine.Timer
 
 local Clamp = math.Clamp
-local Clock = os.clock
+local Clock = Shared.GetSystemTimeReal
 local Max = math.max
 local Min = math.min
 local StringFind = string.find
 local StringFormat = string.format
-local StringLength = string.len
 local StringLower = string.lower
 local StringSub = string.sub
 local StringUTF8Encode = string.UTF8Encode
@@ -488,10 +487,10 @@ function TextEntry:SelectAll()
 end
 
 local function FindFurthestSpace( Text )
-	local PreviousSpace = StringFind( Text, " " )
-	--Find the furthest along space before the caret.
+	local PreviousSpace = StringFind( Text, " ", 1, true )
+	-- Find the furthest along space before the caret.
 	while PreviousSpace do
-		local NextSpace = StringFind( Text, " ", PreviousSpace + 1 )
+		local NextSpace = StringFind( Text, " ", PreviousSpace + 1, true )
 
 		if NextSpace then
 			PreviousSpace = NextSpace
@@ -520,7 +519,7 @@ function TextEntry:FindWordBounds( CharPos )
 	end
 
 	local After = StringUTF8Sub( Text, CharPos )
-	local NextSpace = StringFind( After, " " ) or ( #After + 1 )
+	local NextSpace = StringFind( After, " ", 1, true ) or ( #After + 1 )
 	NextSpace = StringUTF8Length( Before ) + StringUTF8Length( StringSub( After, 1, NextSpace - 1 ) )
 
 	return PreSpace, NextSpace
@@ -666,9 +665,9 @@ function TextEntry:RemoveWord( Forward )
 
 		After = StringUTF8Sub( self.Text, self.Column + 1 )
 
-		local NextSpace = StringFind( After, " " )
+		local NextSpace = StringFind( After, " ", 1, true )
 		if not NextSpace then
-			NextSpace = StringLength( self.Text )
+			NextSpace = #self.Text
 		end
 
 		Before = StringUTF8Sub( self.Text, 1, self.Column )

--- a/lua/shine/lib/gui/objects/textentry.lua
+++ b/lua/shine/lib/gui/objects/textentry.lua
@@ -128,7 +128,7 @@ function TextEntry:GetContentSizeForAxis( Axis )
 end
 
 function TextEntry:SetSize( SizeVec )
-	self.Background:SetSize( SizeVec )
+	self.BaseClass.SetSize( self, SizeVec )
 
 	local InnerBoxSize = SizeVec - self.BorderSize * 2
 	self.InnerBox:SetSize( InnerBoxSize )
@@ -786,6 +786,24 @@ function TextEntry:OnMouseUp()
 	return true
 end
 
+function TextEntry:OnMouseEnter()
+	self.BaseClass.OnMouseEnter( self )
+
+	if self.Enabled or self.Highlighted then return end
+
+	self:FadeTo( self.InnerBox, self.DarkCol, self.FocusColour, 0, 0.1 )
+	self.Highlighted = true
+end
+
+function TextEntry:OnMouseLeave()
+	self.BaseClass.OnMouseLeave( self )
+
+	if self.Enabled or not self.Highlighted then return end
+
+	self:FadeTo( self.InnerBox, self.FocusColour, self.DarkCol, 0, 0.1 )
+	self.Highlighted = false
+end
+
 function TextEntry:OnMouseMove( Down )
 	if not self:GetIsVisible() then return end
 
@@ -795,19 +813,7 @@ function TextEntry:OnMouseMove( Down )
 		return
 	end
 
-	if not self:MouseIn( self.Background ) then
-		if not self.Enabled and self.Highlighted then
-			self:FadeTo( self.InnerBox, self.FocusColour, self.DarkCol, 0, 0.1 )
-			self.Highlighted = false
-		end
-
-		return
-	end
-
-	if self.Highlighted or self.Enabled then return end
-
-	self:FadeTo( self.InnerBox, self.DarkCol, self.FocusColour, 0, 0.1 )
-	self.Highlighted = true
+	self.BaseClass.OnMouseMove( self, Down )
 end
 
 function TextEntry:GetColumnFromMouse( X )
@@ -1181,8 +1187,12 @@ function TextEntry:OnFocusChange( NewFocus, ClickingOtherElement )
 
 		if self.Enabled then
 			self.Enabled = false
-			self.Highlighted = false
-			self:FadeTo( self.InnerBox, self.FocusColour, self.DarkCol, 0, 0.1 )
+
+			if not self:HasMouseEntered() then
+				self.Highlighted = false
+				self:FadeTo( self.InnerBox, self.FocusColour, self.DarkCol, 0, 0.1 )
+			end
+
 			self:RemoveStylingState( "Focus" )
 		end
 

--- a/lua/shine/lib/gui/objects/tooltip.lua
+++ b/lua/shine/lib/gui/objects/tooltip.lua
@@ -101,20 +101,24 @@ function Tooltip:FadeIn()
 	self:FadeTo( self.Background, Start, End, 0, 0.2 )
 end
 
-function Tooltip:FadeOut( Callback )
+local function OnFadeOutComplete( self )
+	if self.FadeOutCallback then
+		self.FadeOutCallback( self.FadeOutCallbackContext )
+	end
+	self:Destroy()
+end
+
+function Tooltip:FadeOut( Callback, Context )
 	if self.FadingOut then return end
 
 	self.FadingOut = true
+	self.FadeOutCallback = Callback
+	self.FadeOutCallbackContext = Context
 
 	local Start = self.Background:GetColor()
 	local End = SGUI.ColourWithAlpha( Start, 0 )
 
-	self:FadeTo( self.Background, Start, End, 0, 0.2, function()
-		if Callback then
-			Callback()
-		end
-		self:Destroy()
-	end )
+	self:FadeTo( self.Background, Start, End, 0, 0.2, OnFadeOutComplete )
 end
 
 function Tooltip:OnLoseWindowFocus()

--- a/lua/shine/lib/gui/objects/tooltip.lua
+++ b/lua/shine/lib/gui/objects/tooltip.lua
@@ -23,11 +23,6 @@ function Tooltip:Initialise()
 	self.TextPadding = 16
 end
 
-function Tooltip:SetSize( Vec )
-	self.Size = Vec
-	self.Background:SetSize( Vec )
-end
-
 function Tooltip:SetTextColour( Col )
 	self.TextCol = Col
 

--- a/lua/shine/lib/gui/objects/tooltip.lua
+++ b/lua/shine/lib/gui/objects/tooltip.lua
@@ -13,7 +13,6 @@ Tooltip.IgnoreMouseFocus = true
 
 SGUI.AddBoundProperty( Tooltip, "Colour", "Background:SetColor" )
 SGUI.AddBoundProperty( Tooltip, "Texture", "Background:SetTexture" )
-SGUI.AddBoundProperty( Tooltip, "TexturePixelCoordinates", "Background:SetTexturePixelCoordinates" )
 
 function Tooltip:Initialise()
 	self.BaseClass.Initialise( self )

--- a/lua/shine/lib/gui/objects/webpage.lua
+++ b/lua/shine/lib/gui/objects/webpage.lua
@@ -56,7 +56,7 @@ function Webpage:LoadURL( URL, W, H )
 		self.WebView = Client.CreateWebView( W, H )
 		self.WebView:SetTargetTexture( TextureName )
 
-		self.Background:SetSize( Vector( W, H, 0 ) )
+		self.BaseClass.SetSize( self, Vector2( W, H ) )
 		self.Background:SetTexture( TextureName )
 
 		self.WebView:HookJSAlert( function( WebView, AlertText )

--- a/lua/shine/lib/gui/richtext/elements/base.lua
+++ b/lua/shine/lib/gui/richtext/elements/base.lua
@@ -9,17 +9,22 @@ function Base:IsVisibleElement()
 	return false
 end
 
+local function ThinkWithExtra( self, DeltaTime )
+	self:__ExtraThink( DeltaTime )
+	return self:__OldThink( DeltaTime )
+end
+
 function Base.AddThinkFunction( Element, ExtraThink )
 	-- Remove any old override (so Think comes from the metatable).
 	Element.Think = nil
+	Element.__ExtraThink = nil
+	Element.__OldThink = nil
 
 	if not ExtraThink then return end
 
-	local OldThink = Element.Think
-	function Element:Think( DeltaTime )
-		ExtraThink( self, DeltaTime )
-		return OldThink( self, DeltaTime )
-	end
+	Element.__OldThink = Element.Think
+	Element.__ExtraThink = ExtraThink
+	Element.Think = ThinkWithExtra
 end
 
 function Base:Setup( Element )

--- a/lua/shine/lib/gui/util/easing.lua
+++ b/lua/shine/lib/gui/util/easing.lua
@@ -1,0 +1,40 @@
+--[[
+	Easing helpers.
+]]
+
+Script.Load( "lua/tweener/Tweener.lua" )
+
+local EasingFunctions = _G.Easing
+
+local StringCaseFormatType = string.CaseFormatType
+local StringTransformCase = string.TransformCase
+
+local Easing = {}
+local ConvertedEasers = {}
+
+local function ConvertName( Name )
+	return StringTransformCase( Name, StringCaseFormatType.UPPER_CAMEL, StringCaseFormatType.LOWER_CAMEL )
+end
+
+--[[
+	Gets an easer by name (from _G.Easing) for use with SGUI.
+
+	Input: Name of the easer to get.
+	Output: An easing function that can be passed to SGUI easing functions.
+]]
+function Easing.GetEaser( TypeName )
+	local ConvertedEaser = ConvertedEasers[ TypeName ]
+	if not ConvertedEaser then
+		local Easer = EasingFunctions[ ConvertName( TypeName ) ]
+		Shine.AssertAtLevel( Easer, "Unkonwn easer: %s", 3, TypeName )
+
+		ConvertedEaser = function( Progress )
+			return Easer( Progress, 0, 1, 1 )
+		end
+		ConvertedEasers[ TypeName ] = ConvertedEaser
+	end
+
+	return ConvertedEaser
+end
+
+return Easing

--- a/lua/shine/lib/objects/votes.lua
+++ b/lua/shine/lib/objects/votes.lua
@@ -61,7 +61,10 @@ function VoteMeta:RemoveVote( Client )
 	if self.Voted[ Client ] then
 		self.Voted[ Client ] = nil
 		self.Votes = Max( self.Votes - 1, 0 )
+		return true
 	end
+
+	return false
 end
 
 function VoteMeta:ClientDisconnect( Client )
@@ -90,13 +93,17 @@ function VoteMeta:AddVote( Client )
 end
 
 function VoteMeta:CheckForSuccess()
-	if self.Votes <= 0 then return end
+	if self.Votes <= 0 then return false end
 
 	if self.Votes >= self.VotesNeeded() then
 		self.LastSuccessTime = SharedTime()
 		self.OnSuccess()
 		self:Reset()
+
+		return true
 	end
+
+	return false
 end
 
 function VoteMeta:HasSucceededOnLastVote()

--- a/lua/shine/lib/player.lua
+++ b/lua/shine/lib/player.lua
@@ -129,7 +129,6 @@ end
 
 local Abs = math.abs
 local Floor = math.floor
-local GetOwner = Server.GetOwner
 local IsType = Shine.IsType
 local pairs = pairs
 local StringFind = string.find
@@ -149,6 +148,13 @@ local tonumber = tonumber
 ]]
 function Shine:IsValidClient( Client )
 	return Client and self.GameIDs:Get( Client ) ~= nil
+end
+
+--[[
+	Returns the client associated with the given player.
+]]
+function Shine.GetClientForPlayer( Player )
+	return Player.GetClient and Player:GetClient()
 end
 
 function Shine.EqualiseTeamCounts( TeamMembers )
@@ -312,8 +318,7 @@ function Shine.GetTeamClients( Team )
 		local Ply = Players[ i ]
 
 		if Ply then
-			local Client = GetOwner( Ply )
-
+			local Client = Shine.GetClientForPlayer( Ply )
 			if Client then
 				Clients[ Count ] = Client
 				Count = Count + 1

--- a/lua/shine/lib/table.lua
+++ b/lua/shine/lib/table.lua
@@ -380,6 +380,7 @@ do
 	local StringFormat = string.format
 	local StringLower = string.lower
 	local StringRep = string.rep
+	local StringStartsWith = string.StartsWith
 	local TableConcat = table.concat
 	local tonumber = tonumber
 	local tostring = tostring
@@ -429,17 +430,20 @@ do
 			return SafeToString( Value )
 		end,
 		cdata = function( Value )
-			local Success, IsType = pcall( FFIIsType, "Color", Value )
-			if Success and IsType then
-				return StringFormat( "Colour( %s, %s, %s, %s )", Value.r, Value.g, Value.b, Value.a )
+			-- Hack to detect ctypes, which pass the istype call...
+			if not StringStartsWith( SafeToString( Value ), "ctype<" ) then
+				local Success, IsType = pcall( FFIIsType, "Color", Value )
+				if Success and IsType then
+					return StringFormat( "Colour( %s, %s, %s, %s )", Value.r, Value.g, Value.b, Value.a )
+				end
+
+				Success, IsType = pcall( FFIIsType, "Vector", Value )
+				if Success and IsType then
+					return StringFormat( "Vector( %s, %s, %s )", Value.x, Value.y, Value.z )
+				end
 			end
 
-			Success, IsType = pcall( FFIIsType, "Vector", Value )
-			if Success and IsType then
-				return StringFormat( "Vector( %s, %s, %s )", Value.x, Value.y, Value.z )
-			end
-
-			return tostring( Value )
+			return SafeToString( Value )
 		end
 	}
 

--- a/lua/shine/lib/timer.lua
+++ b/lua/shine/lib/timer.lua
@@ -77,10 +77,10 @@ do
 
 	--[[
 		Creates a timer.
-		Inputs: Name, delay in seconds, number of times to repeat, function to run.
+		Inputs: Name, delay in seconds, number of times to repeat, function to run, optional data to attach.
 		Pass a negative number to reps to have it repeat indefinitely.
 	]]
-	local function Create( Name, Delay, Reps, Func )
+	local function Create( Name, Delay, Reps, Func, Data )
 		-- Edit it so it's not destroyed if it's created again inside its old function.
 		local TimerObject = Timers:Get( Name ) or PausedTimers[ Name ]
 		if not TimerObject then
@@ -94,6 +94,7 @@ do
 		TimerObject.Func = Func
 		TimerObject.LastRun = 0
 		TimerObject.NextRun = SharedTime() + Delay
+		TimerObject.Data = Data
 
 		return TimerObject
 	end
@@ -103,14 +104,14 @@ do
 
 	--[[
 		Creates a simple timer.
-		Inputs: Delay in seconds, function to run.
+		Inputs: Delay in seconds, function to run, optional data to attach.
 		Unlike a standard timer, this will only run once.
 	]]
-	function Timer.Simple( Delay, Func )
+	function Timer.Simple( Delay, Func, Data )
 		local Index = "Simple"..SimpleCount
 		SimpleCount = SimpleCount + 1
 
-		return Create( Index, Delay, 1, Func )
+		return Create( Index, Delay, 1, Func, Data )
 	end
 end
 

--- a/lua/shine/startup.lua
+++ b/lua/shine/startup.lua
@@ -8,6 +8,28 @@ local Trace = debug.traceback()
 
 if Trace:find( "Main.lua" ) or Trace:find( "Loading.lua" ) then return end
 
+do
+	local loadfile = loadfile
+	local pcall = pcall
+	local StringFormat = string.format
+	local StringGSub = string.gsub
+
+	-- Allow use of require to load mounted Lua files and indicate errors in loading them.
+	package.loaders[ #package.loaders + 1 ] = function( Name )
+		local FilePath = StringFormat( "lua/%s.lua", ( StringGSub( Name, "%.", "/" ) ) )
+		local Success, Func, Err = pcall( loadfile, FilePath )
+		if Success then
+			if Func then
+				return Func
+			end
+
+			return StringFormat( "\n\tfailed to load '%s' from mounted filesystem: %s", FilePath, Err )
+		end
+
+		return StringFormat( "\n\terror attempting to load file '%s' from mounted filesystem: %s", FilePath, Func )
+	end
+end
+
 -- I have no idea why it's called this.
 Shine = {}
 

--- a/test/core/shared/extensions.lua
+++ b/test/core/shared/extensions.lua
@@ -1,0 +1,163 @@
+--[[
+	Extension system tests.
+]]
+
+local UnitTest = Shine.UnitTest
+local IsType = Shine.IsType
+local Hook = Shine.Hook
+
+local OldDebugPrint = Shine.DebugPrint
+local OldAddErrorReport = Shine.AddErrorReport
+local OldAddNotification = Shine.SystemNotifications.AddNotification
+
+function Shine:DebugPrint() end
+function Shine:AddErrorReport() end
+function Shine.SystemNotifications:AddNotification() end
+
+-- Forget the hook to ensure it's not added immediately.
+Hook.Clear( "OnTestEvent" )
+
+local TestPlugin = Shine.Plugin( "test" )
+Shine:RegisterExtension( "test", TestPlugin )
+Shine.AllPluginsArray[ #Shine.AllPluginsArray + 1 ] = "test"
+
+TestPlugin.HasConfig = true
+TestPlugin.LoadConfig = UnitTest.MockFunction()
+
+local OnTestEvent = UnitTest.MockFunction()
+function TestPlugin:OnTestEvent( Arg1, Arg2, Arg3 )
+	return OnTestEvent( self, Arg1, Arg2, Arg3 )
+end
+
+function TestPlugin:ClientConnect( Client )
+
+end
+
+UnitTest:Before( function()
+	OnTestEvent:Reset()
+
+	TestPlugin.LoadConfig:Reset()
+	TestPlugin.LoadConfig:SetImplementation( nil )
+	TestPlugin.Initialise = nil
+
+	TestPlugin.Conflicts = nil
+	TestPlugin.DependsOnPlugins = nil
+end )
+
+UnitTest:Test( "EnableExtension - Fails if the given plugin does not exist", function( Assert )
+	local Loaded, Err = Shine:EnableExtension( "test2" )
+	Assert.False( "Should not have loaded a non-existent plugin", Loaded )
+	Assert.Equals( "Error should be due to the plugin not existing", "plugin does not exist", Err )
+end )
+
+UnitTest:Test( "EnableExtension - Fails if the plugin has a conflict", function( Assert )
+	TestPlugin.Conflicts = {
+		DisableUs = { "basecommands" }
+	}
+
+	local Loaded, Err = Shine:EnableExtension( "test" )
+	Assert.False( "Should not have loaded due to a conflict", Loaded )
+	Assert.Equals( "Error should be due to the conflict", "unable to load alongside 'basecommands'.", Err )
+	Assert.Nil( "Should not be marked as enabled", TestPlugin.Enabled )
+end )
+
+UnitTest:Test( "EnableExtension - Fails if the plugin is missing a dependency", function( Assert )
+	TestPlugin.DependsOnPlugins = { "test2" }
+
+	local Loaded, Err = Shine:EnableExtension( "test" )
+	Assert.False( "Should not have loaded due to a missing dependency", Loaded )
+	Assert.Equals( "Error should be due to the missing dependency", "plugin depends on 'test2'", Err )
+	Assert.Nil( "Should not be marked as enabled", TestPlugin.Enabled )
+end )
+
+UnitTest:Test( "EnableExtension - Fails if loading the config fails", function( Assert )
+	TestPlugin.LoadConfig:SetImplementation( function() error( "failed to load config", 0 ) end )
+
+	local Loaded, Err = Shine:EnableExtension( "test" )
+	Assert.False( "Should not have loaded due to an error loading config", Loaded )
+	Assert.Equals( "Error should be due to the thrown error", "Error while loading config: failed to load config", Err )
+	Assert.Nil( "Should not be marked as enabled", TestPlugin.Enabled )
+end )
+
+UnitTest:Test( "EnableExtension - Fails if initialising throws an error", function( Assert )
+	TestPlugin.Initialise = function()
+		error( "failed to initialise", 0 )
+	end
+
+	local Loaded, Err = Shine:EnableExtension( "test" )
+	Assert.False( "Should not have loaded due to an error in Initialise", Loaded )
+	Assert.Equals( "Error should be due to the thrown error", "Lua error: failed to initialise", Err )
+	Assert.Nil( "Should not be marked as enabled", TestPlugin.Enabled )
+end )
+
+UnitTest:Test( "EnableExtension - Fails if Initialise returns false", function( Assert )
+	TestPlugin.Initialise = function()
+		return false, "unable to load"
+	end
+
+	local Loaded, Err = Shine:EnableExtension( "test" )
+	Assert.False( "Should not have loaded due to Initialise returning false", Loaded )
+	Assert.Equals( "Error should be the returned failure message", "unable to load", Err )
+	Assert.Nil( "Should not be marked as enabled", TestPlugin.Enabled )
+end )
+
+local function HasPluginHook( Hooks )
+	local Found
+	for Key, Callback in pairs( Hooks ) do
+		if
+			IsType( Key, "table" ) and Key.Plugin == TestPlugin and
+			IsType( Callback, "table" ) and Callback.Plugin == TestPlugin
+		then
+			return true
+		end
+	end
+	return false
+end
+
+UnitTest:Test( "EnableExtension - Adds hooks as expected", function( Assert )
+	local Loaded, Err = Shine:EnableExtension( "test" )
+	Assert.True( Err, Loaded )
+	Assert.True( "Plugin should be marked as enabled", TestPlugin.Enabled )
+	Assert.CalledTimes( "Should have called LoadConfig on the plugin", TestPlugin.LoadConfig, 1 )
+
+	local Hooks = Hook.GetTable()
+	Assert.Nil( "Should not have any hooks for OnTestEvent yet", Hooks.OnTestEvent )
+	Assert.IsType( "Should have ClientConnect hooks", Hooks.ClientConnect, "table" )
+	Assert.True( "Expected ClientConnect hook callback for enabled plugin", HasPluginHook( Hooks.ClientConnect ) )
+end )
+
+UnitTest:Test( "SetupExtensionEvents - Adds hooks as expected", function( Assert )
+	Hook.Broadcast( "OnTestEvent", 1, 2, 3 )
+
+	local Hooks = Hook.GetTable()
+	Assert.IsType( "Should have OnTestEvent hooks", Hooks.OnTestEvent, "table" )
+	Assert.True( "Expected OnTestEvent hook callback for enabled plugin", HasPluginHook( Hooks.OnTestEvent ) )
+	Assert.Called( "Should have invoked the plugin method with expected args", OnTestEvent, TestPlugin, 1, 2, 3 )
+end )
+
+UnitTest:Test( "UnloadExtension - Removes hooks as expected", function( Assert )
+	local Unloaded = Shine:UnloadExtension( "test" )
+	Assert.True( "Should have successfully unloaded the plugin", Unloaded )
+	Assert.False( "Plugin should be marked as disabled", TestPlugin.Enabled )
+
+	Unloaded = Shine:UnloadExtension( "test" )
+	Assert.False( "Should not be able to unload a plugin twice", Unloaded )
+
+	local Hooks = Hook.GetTable()
+	Assert.IsType( "Should have ClientConnect hooks", Hooks.ClientConnect, "table" )
+	Assert.False( "Expected ClientConnect hook callback to be removed", HasPluginHook( Hooks.ClientConnect ) )
+
+	Assert.IsType( "Should have OnTestEvent hooks", Hooks.OnTestEvent, "table" )
+	Assert.False( "Expected OnTestEvent hook callback to be removed", HasPluginHook( Hooks.OnTestEvent ) )
+
+	Hook.Broadcast( "OnTestEvent", 1, 2, 3 )
+	Assert.CalledTimes( "Should not have invoked the plugin method after it is disabled", OnTestEvent, 0 )
+end )
+
+Shine:UnloadExtension( "test" )
+Shine.Plugins.test = nil
+Shine.AllPluginsArray[ #Shine.AllPluginsArray ] = nil
+
+Shine.DebugPrint = OldDebugPrint
+Shine.AddErrorReport = OldAddErrorReport
+Shine.SystemNotifications.AddNotification = OldAddNotification

--- a/test/core/shared/hook.lua
+++ b/test/core/shared/hook.lua
@@ -119,9 +119,7 @@ UnitTest:Test( "SetupGlobalHook - Replaces functions only once", function( Asser
 
 	NewHookedFunction()
 
-	Assert.DeepEquals( "Calling the replaced function should run the hook", {
-		{ ArgCount = 0 }
-	}, Callback.Invocations )
+	Assert.Called( "Calling the replaced function should run the hook", Callback )
 end )
 
 local NestedName = "TestHolder"..os.time()
@@ -149,9 +147,7 @@ UnitTest:Test( "SetupGlobalHook - Handles nested global values", function( Asser
 	-- Ignores the 5th argument as the number of arguments is the max of the original and replacement.
 	NewHookedFunction( 1, 2, 3, 4, 5 )
 
-	Assert.DeepEquals( "Calling the replaced function should run the hook", {
-		{ ArgCount = 4, 1, 2, 3, 4 }
-	}, Callback.Invocations )
+	Assert.Called( "Calling the replaced function should run the hook", Callback, 1, 2, 3, 4 )
 end )
 
 _G[ NestedName ] = nil
@@ -188,9 +184,7 @@ UnitTest:Test( "SetupClassHook - Replaces functions only once", function( Assert
 	local Arg = {}
 	NewHookedFunction( Arg, 1, 2 )
 
-	Assert.DeepEquals( "Calling the replaced function should run the hook", {
-		{ ArgCount = 2, Arg, 1 }
-	}, Callback.Invocations )
+	Assert.Called( "Calling the replaced function should run the hook", Callback, Arg, 1 )
 end )
 
 local HOOK_RETURN_VALUE = "HOOK_RETURN_VALUE"
@@ -282,10 +276,10 @@ for i = 1, #HookModeTests do
 			)
 
 			if TestCase.ShouldCallOriginalOnHookReturn then
-				Assert.Equals( "Should have called the original function", 1, OriginalFunction:GetInvocationCount() )
+				Assert.CalledTimes( "Should have called the original function", OriginalFunction, 1 )
 			else
-				Assert.Equals(
-					"Should not have called the original function", 0, OriginalFunction:GetInvocationCount()
+				Assert.CalledTimes(
+					"Should not have called the original function", OriginalFunction, 0
 				)
 			end
 		end
@@ -304,10 +298,10 @@ for i = 1, #HookModeTests do
 				_G[ GlobalKey ]()
 			)
 			if TestCase.ShouldCallOriginalOnHookNil then
-				Assert.Equals( "Should have called the original function", 1, OriginalFunction:GetInvocationCount() )
+				Assert.CalledTimes( "Should have called the original function", OriginalFunction, 1 )
 			else
-				Assert.Equals(
-					"Should not have called the original function", 0, OriginalFunction:GetInvocationCount()
+				Assert.CalledTimes(
+					"Should not have called the original function", OriginalFunction, 0
 				)
 			end
 		end
@@ -339,10 +333,10 @@ for i = 1, #HookModeTests do
 			)
 
 			if TestCase.ShouldCallOriginalOnHookReturn then
-				Assert.Equals( "Should have called the original function", 1, OriginalFunction:GetInvocationCount() )
+				Assert.CalledTimes( "Should have called the original function", OriginalFunction, 1 )
 			else
-				Assert.Equals(
-					"Should not have called the original function", 0, OriginalFunction:GetInvocationCount()
+				Assert.CalledTimes(
+					"Should not have called the original function", OriginalFunction, 0
 				)
 			end
 		end
@@ -361,10 +355,10 @@ for i = 1, #HookModeTests do
 				_G[ ClassName ][ ClassKey ]()
 			)
 			if TestCase.ShouldCallOriginalOnHookNil then
-				Assert.Equals( "Should have called the original function", 1, OriginalFunction:GetInvocationCount() )
+				Assert.CalledTimes( "Should have called the original function", OriginalFunction, 1 )
 			else
-				Assert.Equals(
-					"Should not have called the original function", 0, OriginalFunction:GetInvocationCount()
+				Assert.CalledTimes(
+					"Should not have called the original function", OriginalFunction, 0
 				)
 			end
 		end

--- a/test/core/shared/hook.lua
+++ b/test/core/shared/hook.lua
@@ -124,6 +124,7 @@ UnitTest:Test( "SetupClassHook replaces functions only once", function( Assert )
 	Assert.Equals( "Function returned from SetupClassHook should be the original method", TestFunction, OldFunc )
 
 	local NewHookedFunction = _G[ ClassName ].TestMethod
+	Assert.NotEquals( "Should have replaced the class method", NewHookedFunction, OldFunc )
 
 	-- Hooking the same function twice with the same hook name and mode should do nothing and return
 	-- the original function from the first setup call.

--- a/test/lib/codegen.lua
+++ b/test/lib/codegen.lua
@@ -1,0 +1,103 @@
+--[[
+	Code generation tests.
+]]
+
+local CodeGen = require "shine/lib/codegen"
+local UnitTest = Shine.UnitTest
+
+local DebugGetInfo = debug.getinfo
+
+local Template = [[local NumArgs = select( "#", ... )
+assert( NumArgs == 2, "Received "..NumArgs.." argument(s)!" )
+
+local InjectedValue1, InjectedValue2 = ...
+return function( {FunctionArguments} )
+	return math.max( InjectedValue1, InjectedValue2{Arguments} )
+end]]
+
+UnitTest:Test( "GenerateFunctionWithArguments - Generates a 0-arguments function as expected", function( Assert )
+	local GeneratedFunction = CodeGen.GenerateFunctionWithArguments( Template, 0, nil, 1, 2 )
+	local Info = DebugGetInfo( GeneratedFunction )
+	Assert.False( "Generated function should not be a vararg", Info.isvararg )
+	Assert.Equals( "Generated function should have 0 parameters", 0, Info.nparams )
+	Assert.Equals( "Should return the max of the injected values", 2, GeneratedFunction( 3 ) )
+end )
+
+UnitTest:Test( "GenerateFunctionWithArguments - Generates a finite-argument function as expected", function( Assert )
+	local GeneratedFunction = CodeGen.GenerateFunctionWithArguments( Template, 2, nil, 1, 2 )
+	local Info = DebugGetInfo( GeneratedFunction )
+	Assert.False( "Generated function should not be a vararg", Info.isvararg )
+	Assert.Equals( "Generated function should have 2 parameters", 2, Info.nparams )
+	Assert.Equals( "Should return the max of the injected values and arguments", 4, GeneratedFunction( 3, 4 ) )
+end )
+
+UnitTest:Test( "GenerateFunctionWithArguments - Generates a vararg if given math.huge", function( Assert )
+	local GeneratedFunction = CodeGen.GenerateFunctionWithArguments( Template, math.huge, nil, 1, 2 )
+	local Info = DebugGetInfo( GeneratedFunction )
+	Assert.True( "Generated function should be a vararg function", Info.isvararg )
+	Assert.Equals( "Should return the max of the injected values and arguments", 4, GeneratedFunction( 3, 4 ) )
+end )
+
+UnitTest:Test( "MakeFunctionGenerator - Generates a table of functions with arguments", function( Assert )
+	local OnFunctionGenerated = UnitTest.MockFunction()
+	local Functions = CodeGen.MakeFunctionGenerator( {
+		Template = Template,
+		ChunkName = "@test/lib/codegen.lua",
+		Args = { 1, 2 },
+		InitialSize = 2,
+		OnFunctionGenerated = OnFunctionGenerated
+	} )
+	for i = 0, 3 do
+		Assert.Equals( "Should return the max of the arguments the function can see", i + 2, Functions[ i ]( 3, 4, 5 ) )
+		Assert.Same( "Should cache functions after the first read", Functions[ i ], Functions[ i ] )
+
+		local Info = DebugGetInfo( Functions[ i ] )
+		Assert.False( "Should not be a vararg", Info.isvararg )
+		Assert.Equals( "Should have the expected number of parameters", i, Info.nparams )
+	end
+
+	Assert.DeepEquals( "Should have invoked the OnFunctionGenerated callback as expected", {
+		{
+			0,
+			Functions[ 0 ],
+			false,
+			ArgCount = 3
+		},
+		{
+			1,
+			Functions[ 1 ],
+			false,
+			ArgCount = 3
+		},
+		{
+			2,
+			Functions[ 2 ],
+			false,
+			ArgCount = 3
+		},
+		{
+			3,
+			Functions[ 3 ],
+			true,
+			ArgCount = 3
+		}
+	}, OnFunctionGenerated.Invocations )
+end )
+
+UnitTest:Test( "MakeFunctionGenerator - Respects the NumArgs parameter", function( Assert )
+	local OnFunctionGenerated = UnitTest.MockFunction()
+	local Functions = CodeGen.MakeFunctionGenerator( {
+		Template = Template,
+		ChunkName = "@test/lib/codegen.lua",
+		Args = { 1, 2, 3, 4 },
+		InitialSize = 3,
+		NumArgs = 2
+	} )
+	for i = 0, 3 do
+		Assert.Equals( "Should return the max of the arguments the function can see", i + 2, Functions[ i ]( 3, 4, 5 ) )
+
+		local Info = DebugGetInfo( Functions[ i ] )
+		Assert.False( "Should not be a vararg", Info.isvararg )
+		Assert.Equals( "Should have the expected number of parameters", i, Info.nparams )
+	end
+end )

--- a/test/lib/colour.lua
+++ b/test/lib/colour.lua
@@ -9,6 +9,18 @@ local SGUI = Shine.GUI
 
 Script.Load( "lua/shine/lib/colour.lua" )
 
+UnitTest:Test( "IsColour - Returns true for a colour object", function( Assert )
+	Assert.True( "Should return true for a colour object", SGUI.IsColour( Colour( 1, 1, 1 ) ) )
+end )
+
+UnitTest:Test( "IsColour - Returns false for a different cdata type", function( Assert )
+	Assert.False( "Should return false for a vector object", SGUI.IsColour( Vector( 1, 1, 1 ) ) )
+end )
+
+UnitTest:Test( "IsColour - Returns false for a non-cdata type", function( Assert )
+	Assert.False( "Should return false for a non-cdata object", SGUI.IsColour( "not a colour" ) )
+end )
+
 local function AssertColoursEqual( Assert, A, B )
 	Assert.Equals( "Red values must match", A.r, B.r )
 	Assert.Equals( "Green values must match", A.g, B.g )

--- a/test/lib/gui/binding/source.lua
+++ b/test/lib/gui/binding/source.lua
@@ -11,15 +11,16 @@ UnitTest:Test( "It should add/remove/call listeners as expected", function( Asse
 	end )
 	local Listener2 = UnitTest.MockFunction()
 
+	local Host = {}
 	local SourceInstance = Source()
 	SourceInstance:AddListener( Listener1 )
 	SourceInstance:AddListener( Listener2 )
 
-	SourceInstance( "test" )
+	SourceInstance( Host, "test" )
 
 	SourceInstance:RemoveListener( Listener2 )
 
-	SourceInstance( "test2" )
+	SourceInstance( Host, "test2" )
 
 	Assert.DeepEquals( "Should have called the first listener twice", {
 		{

--- a/test/lib/gui/richtext/elements/base.lua
+++ b/test/lib/gui/richtext/elements/base.lua
@@ -1,0 +1,56 @@
+--[[
+	Tests for base rich text element.
+]]
+
+local UnitTest = Shine.UnitTest
+local Base = require "shine/lib/gui/richtext/elements/base"
+
+UnitTest:Test( "AddThinkFunction - Adds the given callback", function( Assert )
+	local MetaTable = {
+		__index = {
+			Think = UnitTest.MockFunction()
+		}
+	}
+	local Element = setmetatable( {}, MetaTable )
+
+	local Think = UnitTest.MockFunction()
+	Base.AddThinkFunction( Element, Think )
+
+	Assert.IsType( "Should have set a function value to Think", Element.Think, "function" )
+
+	Element:Think( 0 )
+
+	Assert.DeepEquals( "Should have invoked the added think function", {
+		{
+			ArgCount = 2,
+			Element,
+			0
+		}
+	}, Think.Invocations )
+	Assert.DeepEquals( "Should have invoked the original think function", {
+		{
+			ArgCount = 2,
+			Element,
+			0
+		}
+	}, MetaTable.__index.Think.Invocations )
+end )
+
+UnitTest:Test( "AddThinkFunction - Removes any existing override if passed nil", function( Assert )
+	local MetaTable = {
+		__index = {
+			Think = function() end
+		}
+	}
+	local Element = setmetatable( {
+		Think = function() end,
+		__ExtraThink = UnitTest.MockFunction(),
+		__OldThink = UnitTest.MockFunction()
+	}, MetaTable )
+
+	Base.AddThinkFunction( Element, nil )
+
+	Assert.Nil( "Should have removed the extra think field", Element.__ExtraThink )
+	Assert.Nil( "Should have removed the old think field", Element.__OldThink )
+	Assert.Equals( "Should have restored the original Think function", MetaTable.__index.Think, Element.Think )
+end )

--- a/test/lib/objects/votes.lua
+++ b/test/lib/objects/votes.lua
@@ -43,7 +43,7 @@ UnitTest:Test( "Removing votes", function( Assert )
 	Assert.Equals( "Expected one more vote required to pass", 1, Vote:GetVotesNeeded() )
 	Assert.False( "Vote should not have passed yet", Success )
 
-	Vote:RemoveVote( 1 )
+	Assert.True( "Should have removed client 1's vote", Vote:RemoveVote( 1 ) )
 
 	Assert.False( "Client 1 should not have voted", Vote:GetHasClientVoted( 1 ) )
 	Assert.Equals( "Expected vote count to be reset", 0, Vote:GetVotes() )
@@ -51,7 +51,7 @@ UnitTest:Test( "Removing votes", function( Assert )
 	Assert.False( "Vote should not have passed yet", Success )
 
 	-- Removing the vote again should do nothing.
-	Vote:RemoveVote( 1 )
+	Assert.False( "Should not have removed a non-existent vote", Vote:RemoveVote( 1 ) )
 
 	Assert.Equals( "Expected vote count to be reset", 0, Vote:GetVotes() )
 	Assert.Equals( "Expected two more vote required to pass", 2, Vote:GetVotesNeeded() )

--- a/test/test_init.lua
+++ b/test/test_init.lua
@@ -111,6 +111,10 @@ do
 		return #self.Invocations
 	end
 
+	function MockFunction:SetImplementation( Impl )
+		self.Impl = Impl
+	end
+
 	function MockFunction:__call( ... )
 		self.Invocations[ #self.Invocations + 1 ] = { ArgCount = select( "#", ... ), ... }
 		if self.Impl then


### PR DESCRIPTION
#### Chatbox
* Fixed a rare script error when auto-completing chat commands.
* Fixed chat command completions sometimes being invisible.
* Fixed the settings scrollbar sometimes being invisible.
* Fixed the main scrollbar sometimes having the wrong colour when dragging it.

#### Map Vote
* Fixed the map vote menu incorrectly stating that only one map may be chosen when multiple choice is enabled and the menu is opened automatically before a client has pressed a key.

#### Unstuck
* Improved the algorithm for finding a safe position to reduce the number of times unsticking a player fails.
* Added the `MovementToleranceDistance` option which controls the maximum distance a player's position is allowed to move from the location they request to be unstuck from. This can help in cases where a player is stuck jittering around a location.

#### Vote Draw
The `votedraw` plugin is a new plugin that provides a vote to end the current round as a draw. Players on both teams can vote after a configurable time has passed since the round started. This can be used as an alternative to conceding when the game reaches a stalemate and neither team wishes to lose.

For more information see the [wiki page](https://github.com/Person8880/Shine/wiki/Vote-Draw).

#### Misc
* Improved performance of many hotspots in the code (hook calls, SGUI control events etc.) allowing LuaJIT to better compile code.
* Added a system error notification when a plugin fails to load due to a Lua error.
* Datatable values are now sent at client connection time, rather than waiting for input.

#### API
* Added code generation helpers under `shine/lib/codegen.lua` to create specialised variations of general-purpose code that LuaJIT can compile.
* SGUI easing callbacks now pass the SGUI control as the first argument (this is a breaking change for any code that used the GUIItem argument previously).
* SGUI controls can now more easily track whether the mouse is inside using the `OnMouseEnter` and `OnMouseLeave` events, or the `Control:HasMouseEntered()` method. These changes also mean that `OnMouseMove` is now only called if the mouse is inside the parent control, or has just left it.
* SGUI now automatically queues destruction of controls during events until after the event has fired to avoid destroying GUIItems that are used later in the event. Controls will still be removed from their parent control/layout immediately.
* Hooks added via. the `SetupGlobalHook` and `SetupClassHook` functions now take the exact number of arguments the original function does, unless the original function has a var-arg. To pass through additional arguments, use a custom function for the hook mode and declare any extra arguments on it.
* Timers can now have data attached to them by passing a value after the callback. This data value is available on the timer object's `Data` field.