### PR TITLE
Fix minor bugs and improve AFK kick activity checks

### DIFF
--- a/locale/shine/extensions/improvedchat/enGB.json
+++ b/locale/shine/extensions/improvedchat/enGB.json
@@ -16,5 +16,6 @@
 	"MESSAGE_DISPLAY_TYPE_DOWNWARDS_TOOLTIP": "Old messages do not move until those that are older have faded out.",
 	"CHAT_CONFIG_HINT_VOTEMENU": "To customise the behaviour of the chat, press {VoteMenuButton} > \"{ClientConfigButton}\" and go to the \"{ChatTabButton}\" tab.",
 	"CHAT_CONFIG_HINT_CONSOLE": "To customise the behaviour of the chat, open the vote menu and click \"{ClientConfigButton}\" (or use the sh_clientconfigmenu console command) and go to the \"{ChatTabButton}\" tab.",
+	"CHAT_CONFIG_HINT_CHATBOX": "To customise the behaviour of the chat, open the chatbox, click the settings button and go to the \"{ChatBoxSettingsTab}\" tab.",
 	"CHATBOX_SETTINGS_TAB_LABEL": "Chat HUD"
 }

--- a/lua/shine/core/shared/base_plugin.lua
+++ b/lua/shine/core/shared/base_plugin.lua
@@ -204,7 +204,7 @@ do
 
 	local function UnwrapResults( Success, ... )
 		if not Success then
-			return nil
+			return
 		end
 		return ...
 	end

--- a/lua/shine/extensions/afkkick/server.lua
+++ b/lua/shine/extensions/afkkick/server.lua
@@ -956,6 +956,20 @@ function Plugin:OnFirstThink()
 			:Filter( FilterPlayers )
 			:AsTable()
 	end
+
+	do
+		-- Treat attempting to join a team as activity.
+		local Commands = {
+			"j1", "jointeamone", "j2", "jointeamtwo", "j3", "jointeamthree", "rr", "readyroom", "spectate"
+		}
+		local OnAttemptToJoinTeam = self:WrapCallback( function( Client )
+			self:SubtractAFKTime( Client, 0.1 )
+		end )
+
+		for i = 1, #Commands do
+			Event.Hook( "Console_"..Commands[ i ], OnAttemptToJoinTeam )
+		end
+	end
 end
 
 function Plugin:Cleanup()

--- a/lua/shine/extensions/chatbox/client.lua
+++ b/lua/shine/extensions/chatbox/client.lua
@@ -576,8 +576,9 @@ function Plugin:CreateChatbox()
 	self.ChatBox = Box
 
 	local SettingsButtonSize = LayoutData.Sizes.SettingsButton
+	local TextEntryRowHeight = Scaled( SettingsButtonSize, ScalarScale )
 	local TextEntryLayout = SGUI.Layout:CreateLayout( "Horizontal", {
-		AutoSize = UnitVector( Percentage( 100 ), Scaled( SettingsButtonSize, ScalarScale ) ),
+		AutoSize = UnitVector( Percentage( 100 ), TextEntryRowHeight ),
 		Fill = false
 	} )
 	ChatBoxLayout:AddElement( TextEntryLayout )
@@ -597,8 +598,8 @@ function Plugin:CreateChatbox()
 				Props = {
 					DebugName = "ChatBoxTextEntryIconBackground",
 					AutoSize = UnitVector(
-						Scaled( SettingsButtonSize, ScalarScale ) + PaddingUnit,
-						Scaled( SettingsButtonSize, ScalarScale )
+						TextEntryRowHeight + PaddingUnit,
+						Percentage( 100 )
 					),
 					Padding = Spacing( 0, 0, PaddingUnit, 0 ),
 					StyleName = "TextEntryIconBackground"
@@ -641,12 +642,6 @@ function Plugin:CreateChatbox()
 	}
 	if self.TextScale ~= 1 then
 		TextEntry:SetTextScale( self.TextScale )
-	end
-	if Font == Fonts.kAgencyFB_Tiny then
-		-- For some reason, the tiny font is always 1 behind where it should be...
-		TextEntry.Padding = 3
-		TextEntry.CaretOffset = -1
-		TextEntry:SetupCaret()
 	end
 
 	TextEntryLayout:AddElement( TextEntry )
@@ -713,8 +708,10 @@ function Plugin:CreateChatbox()
 		Text = SGUI.Icons.Ionicons.GearB,
 		Skin = Skin,
 		Font = IconFont,
-		AutoSize = UnitVector( Scaled( SettingsButtonSize, ScalarScale ),
-			Scaled( SettingsButtonSize, ScalarScale ) ),
+		AutoSize = UnitVector(
+			TextEntryRowHeight,
+			Percentage( 100 )
+		),
 		Margin = Spacing( PaddingUnit, 0, 0, 0 ),
 		TextInheritsParentAlpha = false
 	}

--- a/lua/shine/extensions/improvedchat/client.lua
+++ b/lua/shine/extensions/improvedchat/client.lua
@@ -433,6 +433,13 @@ function Plugin:OnFirstThink()
 	SGUI.NotificationManager.RegisterHint( CHAT_CONFIG_HINT_NAME, {
 		MaxTimes = 1,
 		MessageSupplier = function()
+			if Shine:IsExtensionEnabled( "chatbox" ) then
+				local ChatBoxSettingsTab = self:GetPhrase( "CHATBOX_SETTINGS_TAB_LABEL" )
+				return self:GetInterpolatedPhrase( "CHAT_CONFIG_HINT_CHATBOX", {
+					ChatBoxSettingsTab = ChatBoxSettingsTab
+				} )
+			end
+
 			local ChatTabButton = self:GetPhrase( "CLIENT_CONFIG_TAB" )
 
 			local VoteMenuButton = Shine.VoteButton

--- a/lua/shine/extensions/serverswitch/client.lua
+++ b/lua/shine/extensions/serverswitch/client.lua
@@ -25,11 +25,15 @@ function Plugin:Initialise()
 end
 
 VoteMenu:AddPage( "ServerSwitch", function( self )
+	local Servers = Plugin.ServerList
+	if not Plugin.Enabled or not Servers then
+		self:SetPage( "Main" )
+		return
+	end
+
 	self:AddBottomButton( Plugin:GetPhrase( "BACK" ), function()
 		self:SetPage( "Main" )
 	end )
-
-	local Servers = Plugin.ServerList
 
 	local function ClickServer( ID )
 		if self.GetCanSendVote() then

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -512,7 +512,7 @@ function Plugin:OnFirstThink()
 		for i = 1, #Commands do
 			local Entry = Commands[ i ]
 			local Team = Entry.Team
-			Event.Hook( Entry.Event, function( Client )
+			Event.Hook( Entry.Event, self:WrapCallback( function( Client )
 				local Gamerules = GetGamerules()
 				if not Gamerules or Gamerules:GetGameStarted() then return end
 				if self.LastAttemptedTeamJoins[ Client ] == Team then return end
@@ -533,7 +533,7 @@ function Plugin:OnFirstThink()
 				}, true )
 
 				self:UpdateFriendGroupTeamPreference( Client, Silent )
-			end )
+			end ) )
 		end
 	end
 

--- a/lua/shine/lib/gui/objects/tabbedpanel.lua
+++ b/lua/shine/lib/gui/objects/tabbedpanel.lua
@@ -181,12 +181,14 @@ do
 								Menu:Destroy()
 							end )
 							MenuButton:SetIcon( Tab.TabButton:GetIcon() )
-							MaxOfIcons:AddValue( Units.Auto( MenuButton.Icon ) )
+
+							local IconSize = MenuButton.Icon and Units.Auto( MenuButton.Icon ) or Units.Absolute( 0 )
+							MaxOfIcons:AddValue( IconSize )
 
 							MenuButton:SetStyleName( "TabPanelOverflowMenuButton" )
 							MenuButton.Label:SetMargin(
 								Units.Spacing(
-									MaxOfIcons - Units.Auto( MenuButton.Icon ), 0, 0, 0
+									MaxOfIcons - IconSize, 0, 0, 0
 								)
 							)
 						end


### PR DESCRIPTION
#### AFK Kick
* Fixed players that join a team without moving their mouse or pressing movement buttons being treated as AFK.

#### Improved Chat
* The hint indicating where to configure the chat now directs players to the chatbox settings menu if the chatbox is enabled.

#### Server Switch
* Fixed a rare script error when the plugin is disabled after the vote menu page has been opened.

#### Misc
* Fixed some minor UI layout issues.