### PR TITLE
Add team/commander skill support to shuffle, fix build 335 issues

### DIFF
--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -1013,9 +1013,15 @@ Add( "Think", "ReplaceMethods", function()
 		end
 	end
 
-	SetupClassHook( "Commander", "ProcessTechTreeActionForEntity", "OnCommanderTechTreeAction",
-		"PassivePre" )
-	SetupClassHook( "Commander", "TriggerNotification", "OnCommanderNotify", "PassivePre" )
+	SetupClassHook( "MarineCommander", "ProcessTechTreeActionForEntity", "OnCommanderTechTreeAction", "PassivePre" )
+	SetupClassHook( "AlienCommander", "ProcessTechTreeActionForEntity", "OnCommanderTechTreeAction", "PassivePre", {
+		OverrideWithoutWarning = true
+	} )
+
+	if Commander and Commander.TriggerNotification then
+		SetupClassHook( "Commander", "TriggerNotification", "OnCommanderNotify", "PassivePre" )
+	end
+
 	SetupClassHook( "Commander", "Eject", "OnCommanderEjected", "PassivePre" )
 
 	SetupClassHook( "PlayingTeam", "VoteToEjectCommander", "OnVoteToEjectCommander", "PassivePost" )

--- a/lua/shine/extensions/chatbox/client.lua
+++ b/lua/shine/extensions/chatbox/client.lua
@@ -116,6 +116,20 @@ function Plugin:Initialise()
 	return true
 end
 
+function Plugin:PostGUIChatInitialised( GUIChat )
+	self.GUIChat = GUIChat
+
+	if self.Config.MoveVanillaChat then
+		self:MoveVanillaChat()
+	end
+end
+
+function Plugin:OnGUIChatOffsetChanged( GUIChat )
+	if self.GUIChat ~= GUIChat or not self.Config.MoveVanillaChat then return end
+
+	self:MoveVanillaChat()
+end
+
 function Plugin:OnChatMessageDisplayed( PlayerColour, PlayerName, MessageColour, MessageName, TagData )
 	self:AddMessage( PlayerColour, PlayerName, MessageColour, MessageName, TagData )
 end
@@ -2044,6 +2058,10 @@ function Plugin:Cleanup()
 		SGUI:EnableMouse( false )
 		self.Visible = false
 		self.GUIChat:SetIsVisible( true )
+	end
+
+	if self.Config.MoveVanillaChat then
+		self:ResetVanillaChatPos()
 	end
 end
 

--- a/lua/shine/extensions/chatbox/client.lua
+++ b/lua/shine/extensions/chatbox/client.lua
@@ -481,7 +481,8 @@ function Plugin:CreateChatbox()
 	local Pos = self.Config.Pos
 	local ChatBoxPos
 	local PanelSize = VectorMultiply( LayoutData.Sizes.ChatBox, UIScale )
-	local DefaultPos = self.GUIChat.inputItem:GetPosition() - Vector( 0, 100 * UIScale.y, 0 )
+	-- Keep the default position fixed as the GUIChat position can move depending on the team.
+	local DefaultPos = SGUI.LinearScale( Vector2( 100, -430 ) ) - Vector2( 0, 100 * UIScale.y )
 
 	if not Pos.x or not Pos.y then
 		ChatBoxPos = DefaultPos

--- a/lua/shine/extensions/improvedchat/client.lua
+++ b/lua/shine/extensions/improvedchat/client.lua
@@ -117,12 +117,16 @@ Hook.CallAfterFileLoad( "lua/GUIChat.lua", function()
 		OldSetScreenOffset( self, Offset )
 
 		if SGUI.IsValid( self.Panel ) then
-			local CurrentOffset = self:GetOffset()
-			local PanelOffset = self.HasMoved and MOVED_CHAT_OFFSET or DEFAULT_CHAT_OFFSET
-			if Plugin.Config.MessageDisplayType == Plugin.MessageDisplayType.DOWNWARDS then
-				PanelOffset = NO_OFFSET
+			if self.HasMoved or Plugin.Config.MessageDisplayType == Plugin.MessageDisplayType.DOWNWARDS then
+				local CurrentOffset = self:GetOffset()
+				local PanelOffset = MOVED_CHAT_OFFSET
+				if Plugin.Config.MessageDisplayType == Plugin.MessageDisplayType.DOWNWARDS then
+					PanelOffset = NO_OFFSET
+				end
+				self.Panel:SetPos( ComputeChatOffset( CurrentOffset, PanelOffset ) )
+			else
+				Plugin:OnLocalPlayerChanged( Client.GetLocalPlayer() )
 			end
-			self.Panel:SetPos( ComputeChatOffset( CurrentOffset, PanelOffset ) )
 		end
 	end
 

--- a/lua/shine/extensions/improvedchat/client.lua
+++ b/lua/shine/extensions/improvedchat/client.lua
@@ -536,12 +536,16 @@ do
 		return Player.GetTeamNumber and Player:GetTeamNumber() == kSpectatorIndex
 	end
 
+	local BuildNumber = Shared.GetBuildNumber()
 	local function ShouldMoveChatAboveMinimap( Player )
-		return Player and ( IsSpectator( Player ) or Player:isa( "Commander" ) )
+		-- Build 335 moves the commander chat to the right of the minimap, so it no longer needs to move up.
+		return BuildNumber < 335 and Player and ( IsSpectator( Player ) or Player:isa( "Commander" ) )
 	end
 
 	local function ShouldMoveChatAboveAlienHealth( Player )
-		return Player and Player:isa( "Alien" ) and Player.GetTeamNumber and Player:GetTeamNumber() == kTeam2Index
+		-- Build 335 moves the alien chat to the right, so it no longer needs to move up.
+		return BuildNumber < 335 and Player and Player:isa( "Alien" ) and Player.GetTeamNumber
+			and Player:GetTeamNumber() == kTeam2Index
 	end
 
 	function Plugin:UpdateChatOffset( Player )

--- a/lua/shine/extensions/improvedchat/client.lua
+++ b/lua/shine/extensions/improvedchat/client.lua
@@ -515,11 +515,18 @@ function Plugin:SetChatOffset( Offset )
 end
 
 do
+	local BuildNumber = Shared.GetBuildNumber()
 	local ABOVE_ALIEN_HEALTH_OFFSET = Vector2( 0, 75 )
 	-- Commander chat needs to be higher up due to possible control groups.
 	local ABOVE_MINIMAP_COMMANDER_CHAT_OFFSET = Vector2( 0, -5 )
 	-- Spectator chat needs to move to the right to avoid overlapping the marine team player elements.
 	local ABOVE_MINIMAP_CHAT_OFFSET = Vector2( 125, 50 )
+
+	if BuildNumber >= 335 then
+		-- In 335 onwards, chat for specators/commanders is to the right of the minimap.
+		-- This just moves it down a bit more than normal so most messages avoid going too high.
+		ABOVE_MINIMAP_CHAT_OFFSET = Vector2( 0, DEFAULT_CHAT_OFFSET.y + 100 )
+	end
 
 	local function ShouldMoveChat( self )
 		return self.GUIChat and not self.GUIChat.HasMoved
@@ -536,10 +543,8 @@ do
 		return Player.GetTeamNumber and Player:GetTeamNumber() == kSpectatorIndex
 	end
 
-	local BuildNumber = Shared.GetBuildNumber()
 	local function ShouldMoveChatAboveMinimap( Player )
-		-- Build 335 moves the commander chat to the right of the minimap, so it no longer needs to move up.
-		return BuildNumber < 335 and Player and ( IsSpectator( Player ) or Player:isa( "Commander" ) )
+		return Player and ( IsSpectator( Player ) or Player:isa( "Commander" ) )
 	end
 
 	local function ShouldMoveChatAboveAlienHealth( Player )
@@ -551,7 +556,7 @@ do
 	function Plugin:UpdateChatOffset( Player )
 		if ShouldMoveChatAboveMinimap( Player ) then
 			local Offset = ABOVE_MINIMAP_CHAT_OFFSET
-			if Player:isa( "Commander" ) then
+			if BuildNumber < 335 and Player:isa( "Commander" ) then
 				Offset = ABOVE_MINIMAP_COMMANDER_CHAT_OFFSET
 			end
 			return SetChatOffsetIfApplicable( self, Offset )

--- a/lua/shine/extensions/voterandom/team_balance.lua
+++ b/lua/shine/extensions/voterandom/team_balance.lua
@@ -128,93 +128,119 @@ local function GetAverageSkillFunc( Players, Func, TeamNumber )
 	}
 end
 
-local DebugMode = false
-
--- TeamNumber parameter currently unused, but ready for Hive 2.0
-BalanceModule.SkillGetters = {
-	GetHiveSkill = function( Ply, TeamNumber )
-		local Client = GetClientForPlayer( Ply )
-		if Client and Client:GetIsVirtual() then
-			-- Bots are all equal so there's no reason to consider them.
-			return nil
+do
+	local DebugMode = false
+	local function GetPlayerTeamSkill( TeamNumber, Skill, Offset )
+		if TeamNumber == 1 or TeamNumber == 2 then
+			-- Skill offset provides the actual per-team skill.
+			return TeamNumber == 1 and ( Skill + Offset ) or ( Skill - Offset )
 		end
-
-		if Ply.GetPlayerSkill then
-			return Ply:GetPlayerSkill()
-		end
-
-		return nil
-	end,
-
-	-- KA/D Ratio.
-	GetKDR = function( Ply, TeamNumber )
-		do
-			local KDR = Plugin:CallModuleEvent( "GetPlayerKDR", Ply, TeamNumber )
-			if KDR then return KDR end
-		end
-
-		local Kills = Ply.totalKills
-		local Deaths = Ply.totalDeaths
-		local Assists = Ply.totalAssists or 0
-
-		if Kills and Deaths then
-			if Deaths == 0 then Deaths = 1 end
-
-			return ( Kills + Assists * 0.1 ) / Deaths
-		end
-
-		return nil
-	end,
-
-	-- Score per minute played.
-	GetScore = function( Ply, TeamNumber )
-		do
-			local ScorePerMinute = Plugin:CallModuleEvent( "GetPlayerScorePerMinute", Ply, TeamNumber )
-			if ScorePerMinute then return ScorePerMinute end
-		end
-
-		if not Ply.totalScore or not Ply.totalPlayTime then
-			return nil
-		end
-
-		local PlayTime = Ply.totalPlayTime + ( Ply.playTime or 0 )
-		if PlayTime <= 0 then
-			return nil
-		end
-
-		return Ply.totalScore / ( PlayTime / 60 )
-	end
-}
-
-if DebugMode then
-	local OldGetHiveSkill = BalanceModule.SkillGetters.GetHiveSkill
-	BalanceModule.SkillGetters.GetHiveSkill = function( Ply, TeamNumber )
-		local Client = GetClientForPlayer( Ply )
-		if Client and Client:GetIsVirtual() then
-			Client.Skill = Client.Skill or Random( 0, 2500 )
-			return Client.Skill
-		end
-		return OldGetHiveSkill( Ply, TeamNumber )
+		return Skill
 	end
 
-	local OldGetKDR = BalanceModule.SkillGetters.GetKDR
-	BalanceModule.SkillGetters.GetKDR = function( Ply, TeamNumber )
-		local Client = GetClientForPlayer( Ply )
-		if Client and Client:GetIsVirtual() then
-			Client.Skill = Client.Skill or Random() * 3
-			return Client.Skill
-		end
-		return OldGetKDR( Ply, TeamNumber )
-	end
+	BalanceModule.SkillGetters = {
+		GetHiveSkill = function( Ply, TeamNumber, TeamSkillEnabled, CommanderSkillEnabled )
+			local Client = GetClientForPlayer( Ply )
+			if Client and Client:GetIsVirtual() then
+				-- Bots are all equal so there's no reason to consider them.
+				return nil
+			end
 
-	local OldGetScore = BalanceModule.SkillGetters.GetScore
-	BalanceModule.SkillGetters.GetScore = function( Ply, TeamNumber )
-		local Client = GetClientForPlayer( Ply )
-		if Client and Client:GetIsVirtual() then
-			Client.Skill = Client.Skill or Random() * 10
-			return Client.Skill
+			-- First try to use the commander skill value, as long as they are a commander and are being evaluated against
+			-- their current team. If they're being evaluated against the oppposite team, then they would be swapped and
+			-- no longer be the commander.
+			if
+				CommanderSkillEnabled and Ply.GetCommanderSkill and Ply:isa( "Commander" ) and
+				Ply:GetTeamNumber() == TeamNumber
+			then
+				local CommanderSkill = Ply:GetCommanderSkill()
+				local Offset = Ply:GetCommanderSkillOffset()
+
+				return GetPlayerTeamSkill( TeamSkillEnabled and TeamNumber or 0, CommanderSkill, Offset )
+			end
+
+			-- If not a commander or not able to use commander skill, use the player skill and apply the team offset if
+			-- available and enabled.
+			if Ply.GetPlayerSkill then
+				local Skill = Ply:GetPlayerSkill()
+				local Offset = Ply.GetPlayerSkillOffset and Ply:GetPlayerSkillOffset() or 0
+
+				return GetPlayerTeamSkill( TeamSkillEnabled and TeamNumber or 0, Skill, Offset )
+			end
+
+			return nil
+		end,
+
+		-- KA/D Ratio.
+		GetKDR = function( Ply, TeamNumber )
+			do
+				local KDR = Plugin:CallModuleEvent( "GetPlayerKDR", Ply, TeamNumber )
+				if KDR then return KDR end
+			end
+
+			local Kills = Ply.totalKills
+			local Deaths = Ply.totalDeaths
+			local Assists = Ply.totalAssists or 0
+
+			if Kills and Deaths then
+				if Deaths == 0 then Deaths = 1 end
+
+				return ( Kills + Assists * 0.1 ) / Deaths
+			end
+
+			return nil
+		end,
+
+		-- Score per minute played.
+		GetScore = function( Ply, TeamNumber )
+			do
+				local ScorePerMinute = Plugin:CallModuleEvent( "GetPlayerScorePerMinute", Ply, TeamNumber )
+				if ScorePerMinute then return ScorePerMinute end
+			end
+
+			if not Ply.totalScore or not Ply.totalPlayTime then
+				return nil
+			end
+
+			local PlayTime = Ply.totalPlayTime + ( Ply.playTime or 0 )
+			if PlayTime <= 0 then
+				return nil
+			end
+
+			return Ply.totalScore / ( PlayTime / 60 )
 		end
-		return OldGetScore( Ply, TeamNumber )
+	}
+
+	if DebugMode then
+		local OldGetHiveSkill = BalanceModule.SkillGetters.GetHiveSkill
+		BalanceModule.SkillGetters.GetHiveSkill = function( Ply, TeamNumber, TeamSkillEnabled, CommanderSkillEnabled )
+			local Client = GetClientForPlayer( Ply )
+			if Client and Client:GetIsVirtual() then
+				Client.Skill = Client.Skill or Random( 0, 2500 )
+				return Client.Skill
+			end
+			return OldGetHiveSkill( Ply, TeamNumber, TeamSkillEnabled, CommanderSkillEnabled )
+		end
+
+		local OldGetKDR = BalanceModule.SkillGetters.GetKDR
+		BalanceModule.SkillGetters.GetKDR = function( Ply, TeamNumber )
+			local Client = GetClientForPlayer( Ply )
+			if Client and Client:GetIsVirtual() then
+				Client.Skill = Client.Skill or Random() * 3
+				return Client.Skill
+			end
+			return OldGetKDR( Ply, TeamNumber )
+		end
+
+		local OldGetScore = BalanceModule.SkillGetters.GetScore
+		BalanceModule.SkillGetters.GetScore = function( Ply, TeamNumber )
+			local Client = GetClientForPlayer( Ply )
+			if Client and Client:GetIsVirtual() then
+				Client.Skill = Client.Skill or Random() * 10
+				return Client.Skill
+			end
+			return OldGetScore( Ply, TeamNumber )
+		end
 	end
 end
 
@@ -227,6 +253,31 @@ function BalanceModule:Initialise()
 	self.PlayWithFriendsWeighting = self.PlayWithFriendsWeightingValues[ self.Config.TeamPreferences.PlayWithFriendsWeighting ]
 
 	self.dt.IsFriendGroupingEnabled = self.PlayWithFriendsWeighting > 0
+end
+
+function BalanceModule:GetBalanceModeConfig()
+	return self.Config.BalanceModeConfig[ self.Config.BalanceMode ]
+end
+
+function BalanceModule:IsPerTeamSkillEnabled()
+	local Config = self:GetBalanceModeConfig()
+	return Config and Config.UseTeamSkill
+end
+
+function BalanceModule:IsCommanderSkillEnabled()
+	local Config = self:GetBalanceModeConfig()
+	return Config and Config.UseCommanderSkill
+end
+
+--[[
+	Wraps the given ranking function, passing through the configured team/commnader skill flags.
+]]
+function BalanceModule:ApplyConfigToRankingFunction( RankFunc )
+	local TeamSkillEnabled = self:IsPerTeamSkillEnabled()
+	local CommanderSkillEnabled = self:IsCommanderSkillEnabled()
+	return function( Ply, TeamNumber )
+		return RankFunc( Ply, TeamNumber, TeamSkillEnabled, CommanderSkillEnabled )
+	end
 end
 
 function BalanceModule:LoadHappinessHistory()
@@ -405,15 +456,17 @@ end
 
 --[[
 	Can only apply this optimisation if we are using a single skill value.
-	If a player has a different skill depending on which team they are on,
-	swapping will have dire consequences.
+	If a player has a different skill depending on which team they are on/if they are a commander, swapping will have
+	dire consequences.
 
-	Also, commanders must not be swapped if configured to ignore them, so
-	there also must be no commanders present in the teams if ignoring is enabled.
+	Also, commanders must not be swapped if configured to ignore them, so there also must be no commanders present in
+	the teams if ignoring is enabled.
 ]]
 function BalanceModule:ShouldOptimiseHappiness( TeamMembers )
-	return not self.Config.UseTeamSkills
-		and not ( self.Config.IgnoreCommanders and TeamMembersContainCommander( TeamMembers ) )
+	return not self:IsPerTeamSkillEnabled() and not (
+		( self.Config.IgnoreCommanders or self:IsCommanderSkillEnabled() ) and
+		TeamMembersContainCommander( TeamMembers )
+	)
 end
 
 do
@@ -752,8 +805,8 @@ end
 
 function BalanceModule:ComputeTeamSkills( TeamMembers, RankFunc )
 	return {
-		GetAverageSkillFunc( TeamMembers[ 1 ], RankFunc ),
-		GetAverageSkillFunc( TeamMembers[ 2 ], RankFunc )
+		GetAverageSkillFunc( TeamMembers[ 1 ], RankFunc, 1 ),
+		GetAverageSkillFunc( TeamMembers[ 2 ], RankFunc, 2 )
 	}
 end
 
@@ -770,7 +823,7 @@ function BalanceModule:SortPlayersByRank( TeamMembers, SortTable, Count, NumTarg
 
 	-- Update the team skill values in case the team members table was modified by the event.
 	for i = 1, 2 do
-		TeamSkills[ i ] = GetAverageSkillFunc( TeamMembers[ i ], RankFunc )
+		TeamSkills[ i ] = GetAverageSkillFunc( TeamMembers[ i ], RankFunc, i )
 	end
 
 	self:OptimiseTeams( TeamMembers, RankFunc, TeamSkills )
@@ -914,28 +967,27 @@ BalanceModule.ShufflingModes = {
 		local Count = 0
 		local Sorted = {}
 
-		local RankFunc = self.SkillGetters.GetHiveSkill
+		local RankFunc = self:ApplyConfigToRankingFunction( self.SkillGetters.GetHiveSkill )
 		local TargetCount = #Targets
 
 		for i = 1, TargetCount do
 			local Player = Targets[ i ]
-			local Skill = Max( RankFunc( Player, 1 ) or 0, RankFunc( Player, 2 ) or 0 )
-			if Skill > 0 then
+			-- A value of -1 indicates missing data. A skill value of 0 is valid.
+			local Skill = Max( RankFunc( Player, 1 ) or -1, RankFunc( Player, 2 ) or -1 )
+			if Skill >= 0 then
 				Count = Count + 1
 				SortTable[ Count ] = Player
 			end
 		end
 
-		local Sorted = self:SortPlayersByRank( TeamMembers, SortTable, Count,
-			TargetCount, self.SkillGetters.GetHiveSkill )
+		local Sorted = self:SortPlayersByRank( TeamMembers, SortTable, Count, TargetCount, RankFunc )
 
 		self:Print( "Teams were sorted based on Hive skill ranking." )
 
 		-- If some players have rank 0 or no rank data, sort them with the fallback instead.
 		local FallbackTargets = GetFallbackTargets( Targets, Sorted )
 		if #FallbackTargets > 0 then
-			self.ShufflingModes[ self.Config.FallbackMode ]( self, Gamerules,
-				FallbackTargets, TeamMembers, true )
+			self.ShufflingModes[ self.Config.FallbackMode ]( self, Gamerules, FallbackTargets, TeamMembers, true )
 
 			return
 		end
@@ -972,7 +1024,9 @@ do
 	end
 
 	function BalanceModule:GetAverageSkill( Players, TeamNumber, RankFunc )
-		return GetAverageSkillFunc( Players, RankFunc or self.SkillGetters.GetHiveSkill, TeamNumber )
+		return GetAverageSkillFunc(
+			Players, RankFunc or self.SkillGetters.GetHiveSkill, TeamNumber
+		)
 	end
 
 	function BalanceModule:ClearStatsCache()
@@ -996,17 +1050,20 @@ do
 			return self.TeamStatsCache[ RankFunc ]
 		end
 
+		-- Apply configured skill options to the ranking function to apply team/commnader skills if enabled.
+		RankFunc = self:ApplyConfigToRankingFunction( RankFunc )
+
 		local Gamerules = GetGamerules()
 		Shine.Assert( Gamerules, "Gamerules unavailable, unable to compute team stats!" )
 
 		-- Need to do this one team at a time due to Team:GetPlayers() re-using the same table on every call.
 		local Marines = Gamerules.team1:GetPlayers()
-		local MarineSkill = self:GetAverageSkill( Marines, 1 )
+		local MarineSkill = self:GetAverageSkill( Marines, 1, RankFunc )
 		MarineSkill.StandardDeviation = GetStandardDeviation( Marines, MarineSkill.Average,
 			RankFunc, 1 )
 
 		local Aliens = Gamerules.team2:GetPlayers()
-		local AlienSkill = self:GetAverageSkill( Aliens, 2 )
+		local AlienSkill = self:GetAverageSkill( Aliens, 2, RankFunc )
 		AlienSkill.StandardDeviation = GetStandardDeviation( Aliens, AlienSkill.Average,
 			RankFunc, 2 )
 

--- a/lua/shine/extensions/voterandom/team_balance.lua
+++ b/lua/shine/extensions/voterandom/team_balance.lua
@@ -153,16 +153,17 @@ do
 				CommanderSkillEnabled and Ply.GetCommanderSkill and Ply:isa( "Commander" ) and
 				Ply:GetTeamNumber() == TeamNumber
 			then
-				local CommanderSkill = Ply:GetCommanderSkill()
-				local Offset = Ply:GetCommanderSkillOffset()
-
-				return GetPlayerTeamSkill( TeamSkillEnabled and TeamNumber or 0, CommanderSkill, Offset )
+				local CommanderSkill = Ply:GetCommanderSkill() or -1
+				if CommanderSkill >= 0 then
+					local Offset = Ply:GetCommanderSkillOffset() or 0
+					return GetPlayerTeamSkill( TeamSkillEnabled and TeamNumber or 0, CommanderSkill, Offset )
+				end
 			end
 
 			-- If not a commander or not able to use commander skill, use the player skill and apply the team offset if
 			-- available and enabled.
 			if Ply.GetPlayerSkill then
-				local Skill = Ply:GetPlayerSkill()
+				local Skill = Ply:GetPlayerSkill() or 0
 				local Offset = Ply.GetPlayerSkillOffset and Ply:GetPlayerSkillOffset() or 0
 
 				return GetPlayerTeamSkill( TeamSkillEnabled and TeamNumber or 0, Skill, Offset )

--- a/lua/shine/lib/debug.lua
+++ b/lua/shine/lib/debug.lua
@@ -260,13 +260,21 @@ function Shine.GetUpValueAccessor( Function, UpValue, Options )
 	local function GetValue()
 		return Value
 	end
-	Shine.JoinUpValues( Function, GetValue, {
+	local function SetValue( NewValue )
+		Value = NewValue
+	end
+
+	local UpValueParams = {
 		[ UpValue ] = {
 			Name = "Value",
 			Predicate = Options and Options.Predicate
 		}
-	}, Options and Options.Recursive )
-	return GetValue
+	}
+	local IsRecursive = Options and Options.Recursive
+	Shine.JoinUpValues( Function, GetValue, UpValueParams, IsRecursive )
+	Shine.JoinUpValues( Function, SetValue, UpValueParams, IsRecursive )
+
+	return GetValue, SetValue
 end
 
 --[[

--- a/lua/shine/lib/gui/objects/textentry.lua
+++ b/lua/shine/lib/gui/objects/textentry.lua
@@ -129,10 +129,13 @@ end
 function TextEntry:SetSize( SizeVec )
 	self.BaseClass.SetSize( self, SizeVec )
 
-	local InnerBoxSize = SizeVec - self.BorderSize * 2
+	local InnerBoxSize = Vector2(
+		Max( SizeVec.x - self.BorderSize.x * 2, 0 ),
+		Max( SizeVec.y - self.BorderSize.y * 2, 0 )
+	)
 	self.InnerBox:SetSize( InnerBoxSize )
 
-	self.Width = InnerBoxSize.x - ( self.Padding * 2 )
+	self.Width = Max( InnerBoxSize.x - ( self.Padding * 2 ), 0 )
 	self.Height = InnerBoxSize.y
 
 	self:InvalidateLayout()

--- a/lua/shine/lib/gui/richtext/elements/spacer.lua
+++ b/lua/shine/lib/gui/richtext/elements/spacer.lua
@@ -15,14 +15,14 @@ end
 
 function Spacer:Split( Index, TextSizeProvider, Segments, MaxWidth )
 	self.OriginalElement = Index
-	self.Width = self.AutoWidth:GetValue( MaxWidth, 1 )
+	self.Width = self.AutoWidth:GetValue( MaxWidth, nil, 1 )
 	self.WidthWithoutSpace = self.IgnoreOnNewLine and 0 or self.Width
 
 	Segments[ #Segments + 1 ] = self
 end
 
 function Spacer:GetWidth( TextSizeProvider, MaxWidth )
-	local Width = self.AutoWidth:GetValue( MaxWidth, 1 )
+	local Width = self.AutoWidth:GetValue( MaxWidth, nil, 1 )
 	return Width, self.IgnoreOnNewLine and 0 or Width
 end
 

--- a/test/extensions/mapvote.lua
+++ b/test/extensions/mapvote.lua
@@ -1146,9 +1146,12 @@ MapVote.Config.ForcedMaps = {
 }
 MapVote.ForcedMapCount = 2
 MapVote.Vote.Nominated = { "ns2_tram", "ns2_summit", "ns2_veil", "ns2_biodome" }
+
+local ForcedMapsList = table.GetKeys( MapVote.Config.ForcedMaps )
+
 UnitTest:Test( "BuildMapChoices - ADD_MAP should allow max options to be exceeded", function( Assert )
 	-- Nominated 4 maps, with 5 max nominations and 5 max options, with exceed action ADD_MAP, so should just add the nominations.
-	Assert:ArrayEquals( {
+	Assert:ArrayContainsExactly( {
 		"ns2_derelict", "ns2_kodiak", "ns2_tram", "ns2_summit", "ns2_veil", "ns2_biodome"
 	}, MapVote:BuildMapChoices() )
 end )
@@ -1156,13 +1159,13 @@ end )
 MapVote.Config.Nominations.MaxOptionsExceededAction = MapVote.MaxOptionsExceededAction.REPLACE_MAP
 UnitTest:Test( "BuildMapChoices - REPLACE_MAP should ensure max options is not exceeded", function( Assert )
 	Assert:ArrayEquals( {
-		"ns2_biodome", "ns2_kodiak", "ns2_tram", "ns2_summit", "ns2_veil"
+		"ns2_biodome", ForcedMapsList[ 2 ], "ns2_tram", "ns2_summit", "ns2_veil"
 	}, MapVote:BuildMapChoices() )
 end )
 
 MapVote.Config.Nominations.MaxOptionsExceededAction = MapVote.MaxOptionsExceededAction.SKIP
 UnitTest:Test( "BuildMapChoices - SKIP should ensure max options is not exceeded", function( Assert )
-	Assert:ArrayEquals( {
+	Assert:ArrayContainsExactly( {
 		"ns2_derelict", "ns2_kodiak", "ns2_tram", "ns2_summit", "ns2_veil"
 	}, MapVote:BuildMapChoices() )
 end )

--- a/test/lib/debug.lua
+++ b/test/lib/debug.lua
@@ -124,11 +124,15 @@ UnitTest:Test( "GetUpValueAccessor", function( Assert )
 		return TargetUpValue
 	end
 
-	local Accessor = Shine.GetUpValueAccessor( FuncReferencingTarget, "TargetUpValue" )
-	Assert.Equals( "Accessor didn't return upvalue", Accessor(), TargetUpValue )
+	local Getter, Setter = Shine.GetUpValueAccessor( FuncReferencingTarget, "TargetUpValue" )
+	Assert.Equals( "Getter didn't return upvalue", Getter(), TargetUpValue )
 
 	TargetUpValue = {}
-	Assert.Equals( "Accessor didn't return upvalue after re-assignment", Accessor(), TargetUpValue )
+	Assert.Equals( "Getter didn't return upvalue after re-assignment", Getter(), TargetUpValue )
+
+	Setter( 123 )
+	Assert.Equals( "Setter didn't update the upvalue", 123, TargetUpValue )
+	Assert.Equals( "Getter doesn't reflect state after calling setter", 123, Getter() )
 end )
 
 UnitTest:Test( "GetLocals - omits var-args when none provided", function( Assert )


### PR DESCRIPTION
#### AFK Kick
* Improved detection of certain commander actions such as dropping medpacks.

#### Improved Chat
* Fixed the chat position not being reset correctly when disabling the "move outer messages" option in the chatbox.

#### Vote Shuffle
* Added support for team and commander skill values which are enabled by default. Use the `BalanceModeConfig.HIVE` section of the plugin config to enable/disable them. Note that these will only work with the upcoming build 335 game update. See the [plugin's wiki page](https://github.com/Person8880/Shine/wiki/Vote-Random#teamrole-based-skills) for details on how these new values are used.

#### Misc
* Applied various compatibility fixes for changes to the chat in the upcoming build 335 game update.
