### PR TITLE
Improve default shuffle and pregame behaviour

### DIFF
--- a/locale/shine/extensions/voterandom/enGB.json
+++ b/locale/shine/extensions/voterandom/enGB.json
@@ -135,6 +135,9 @@
 	"AUTO_SHUFFLE_ENABLED_RANDOM_BASED": "Automatic random teams have been enabled.",
 	"AUTO_SHUFFLE_ENABLED_SCORE_BASED": "Automatic score based teams have been enabled.",
 
+	"AUTO_SHUFFLE_DISABLE_TOOLTIP": "Vote to disable automatic shuffling for the next round.",
+	"AUTO_SHUFFLE_ENABLE_TOOLTIP": "Vote to enable automatic shuffling for the next round.",
+
 	"ERROR_CONSTRAINTS": "Teams are already sufficiently balanced.",
 
 	"ERROR_MUST_WAIT_HIVE_BASED": "You must wait for {SecondsToWait:Duration} before voting for Hive skill based teams.",

--- a/lua/shine/extensions/chatbox/client.lua
+++ b/lua/shine/extensions/chatbox/client.lua
@@ -278,7 +278,10 @@ local Skin = {
 			TextInheritsParentAlpha = false,
 			States = {
 				Selected = {
-					TextColour = Colours.ModeText,
+					TextColour = Colours.ModeText
+				},
+				Highlighted = {
+					TextColour = Colours.ModeText
 				}
 			}
 		},
@@ -289,7 +292,10 @@ local Skin = {
 			TextInheritsParentAlpha = false,
 			States = {
 				Selected = {
-					TextColour = Colours.ModeText,
+					TextColour = Colours.ModeText
+				},
+				Highlighted = {
+					TextColour = Colours.ModeText
 				}
 			}
 		}

--- a/lua/shine/extensions/mapvote/client.lua
+++ b/lua/shine/extensions/mapvote/client.lua
@@ -123,6 +123,8 @@ function Plugin:Initialise()
 end
 
 function Plugin:OnFirstThink()
+	self:BroadcastModuleEvent( "OnFirstThink" )
+
 	SGUI.NotificationManager.RegisterHint( MAP_GRID_SWITCH_BACK_HINT, {
 		MaxTimes = 1,
 		MessageSource = self:GetName(),

--- a/lua/shine/extensions/pregame/server.lua
+++ b/lua/shine/extensions/pregame/server.lua
@@ -139,6 +139,11 @@ function Plugin:AddCommanderBots( Gamerules )
 		return
 	end
 
+	if not OnConsoleAddBots then
+		self.Logger:Warn( "Unable to add commander bots, OnConsoleAddBots does not exist." )
+		return
+	end
+
 	self:AddCommanderBotIfNeeded( Gamerules, BotController, kTeam1Index )
 	self:AddCommanderBotIfNeeded( Gamerules, BotController, kTeam2Index )
 end

--- a/lua/shine/extensions/voterandom/client.lua
+++ b/lua/shine/extensions/voterandom/client.lua
@@ -225,6 +225,7 @@ function Plugin:NetworkUpdate( Key, Old, New )
 
 		Button.DefaultText = self:GetVoteButtonText()
 		Button:SetText( Button.DefaultText )
+		Button:SetTooltip( self:GetVoteButtonTooltip() )
 	end
 end
 
@@ -236,6 +237,12 @@ function Plugin:GetVoteButtonText()
 	end
 
 	return self:GetPhrase( "ENABLE_AUTO_SHUFFLE" )
+end
+
+function Plugin:GetVoteButtonTooltip()
+	if not self.dt.IsVoteForAutoShuffle then return nil end
+
+	return self:GetPhrase( self.dt.IsAutoShuffling and "AUTO_SHUFFLE_DISABLE_TOOLTIP" or "AUTO_SHUFFLE_ENABLE_TOOLTIP" )
 end
 
 function Plugin:GetTeamPreference()
@@ -349,6 +356,10 @@ function Plugin:OnVoteButtonCreated( Button, VoteMenu )
 			SGUI.NotificationManager.DisplayHint( FRIEND_GROUP_HINT_NAME )
 			return OldClick( self )
 		end
+	end
+
+	if self.dt.IsVoteForAutoShuffle then
+		Button:SetTooltip( self:GetVoteButtonTooltip() )
 	end
 end
 

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -1797,6 +1797,11 @@ function Plugin:CreateCommands()
 				Stats.Average, Stats.StandardDeviation )
 		end
 
+		Message[ #Message + 1 ] = StringFormat(
+			"Team skills are %s. Commander skills are %s.",
+			self:IsPerTeamSkillEnabled() and "enabled" or "disabled",
+			self:IsCommanderSkillEnabled() and "enabled" or "disabled"
+		)
 		Message[ #Message + 1 ] = StringFormat( "Team preference cost weighting: %s. History rounds: %d.",
 			self.Config.TeamPreferences.CostWeighting, self.Config.TeamPreferences.MaxHistoryRounds )
 		Message[ #Message + 1 ] = StringFormat( "Play with friends cost weighting: %s. Max group size: %d.",

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -1857,6 +1857,10 @@ do
 
 		self.TooltipText = Text
 		self:ListenForHoverEvents( self.ShowTooltip, self.HideTooltip )
+
+		if SGUI.IsValid( self.Tooltip ) then
+			self.Tooltip:UpdateText( Text )
+		end
 	end
 
 	local DEFAULT_HOVER_TIME = 0.5

--- a/lua/shine/lib/gui/objects/tabbedpanel.lua
+++ b/lua/shine/lib/gui/objects/tabbedpanel.lua
@@ -39,7 +39,7 @@ end
 function TabPanelButton:SetActiveCol( Col )
 	self.ActiveCol = Col
 
-	if self.Highlighted or self.Selected then
+	if self.Selected then
 		self.Background:SetColor( Col )
 	end
 end
@@ -47,7 +47,7 @@ end
 function TabPanelButton:SetInactiveCol( Col )
 	self.InactiveCol = Col
 
-	if not self.Highlighted and not self.Selected then
+	if not self.Selected then
 		self.Background:SetColor( Col )
 	end
 end
@@ -69,8 +69,10 @@ function TabPanelButton:OnMouseMove( Down )
 
 	if self:MouseIn( self.Background, 0.9 ) then
 		self.Highlighted = true
+		self:AddStylingState( "Highlighted" )
 	else
 		self.Highlighted = false
+		self:RemoveStylingState( "Highlighted" )
 	end
 end
 

--- a/lua/shine/lib/gui/objects/tooltip.lua
+++ b/lua/shine/lib/gui/objects/tooltip.lua
@@ -71,6 +71,14 @@ function Tooltip:SetText( Text, Font, Scale )
 	self:ComputeAndSetSize( Text )
 end
 
+function Tooltip:UpdateText( Text )
+	local TextObj = self.Text
+	if not TextObj then return end
+
+	TextObj:SetText( Text )
+	self:ComputeAndSetSize( Text )
+end
+
 function Tooltip:ComputeAndSetSize( Text )
 	local Scale = self.TextScale
 	local WidthScale = Scale and Scale.x or 1

--- a/lua/shine/lib/gui/skins/default.lua
+++ b/lua/shine/lib/gui/skins/default.lua
@@ -287,13 +287,23 @@ local Skin = {
 			Font = Fonts.kAgencyFB_Small,
 			ActiveCol = WindowBackground,
 			InactiveCol = DarkButton,
-			TextColour = BrightText
+			TextColour = BrightText,
+			States = {
+				Highlighted = {
+					InactiveCol = CategoryButton
+				}
+			}
 		},
 		Horizontal = {
 			Font = Fonts.kAgencyFB_Small,
 			ActiveCol = HorizontalTabBackground,
 			InactiveCol = DarkButton,
-			TextColour = BrightText
+			TextColour = BrightText,
+			States = {
+				Highlighted = {
+					InactiveCol = CategoryButton
+				}
+			}
 		}
 	},
 	TextEntry = {

--- a/lua/shine/lib/gui/skins/default_light.lua
+++ b/lua/shine/lib/gui/skins/default_light.lua
@@ -315,13 +315,23 @@ local Skin = {
 			Font = Fonts.kAgencyFB_Small,
 			ActiveCol = WindowBackground,
 			InactiveCol = DarkButton,
-			TextColour = BrightText
+			TextColour = BrightText,
+			States = {
+				Highlighted = {
+					InactiveCol = Colour( 0.95, 0.95, 0.95, 1 )
+				}
+			}
 		},
 		Horizontal = {
 			Font = Fonts.kAgencyFB_Small,
 			ActiveCol = HorizontalTabBackground,
 			InactiveCol = DarkButton,
-			TextColour = BrightText
+			TextColour = BrightText,
+			States = {
+				Highlighted = {
+					InactiveCol = Colour( 0.875, 0.875, 0.875, 1 )
+				}
+			}
 		}
 	},
 	TextEntry = {


### PR DESCRIPTION
#### Map Vote
* Fixed the vote menu button not displaying the number of votes cast to start a map vote.

#### Pregame
* Added a new `AutoAddCommanderBots` option (default `true`) that will add commander bots when starting a game for any team without a commander.

#### Vote Shuffle
* Commander bots are no longer removed by a shuffle when `ApplyToBots` is `false`.
* The `sh_teamstats` command will now indicate whether team/commander skills are being used or not.