### PR TITLE
Restore friend groups on map change, minor bug fixes

### DIFF
--- a/lua/shine/extensions/ban/server.lua
+++ b/lua/shine/extensions/ban/server.lua
@@ -792,7 +792,7 @@ end
 	the client's connected.
 ]]
 function Plugin:ClientConnect( Client )
-	if not self.Config.CheckFamilySharing then return end
+	if not self.Config.CheckFamilySharing or Client:GetIsVirtual() then return end
 
 	local IsSharingFromBannedAccount, Sharer = self:CheckFamilySharing( Client:GetUserId(), true )
 	if IsSharingFromBannedAccount then

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -25,7 +25,7 @@ local TableConcat = table.concat
 local tostring = tostring
 
 local Plugin, PluginName = ...
-Plugin.Version = "2.9"
+Plugin.Version = "2.10"
 Plugin.PrintName = "Shuffle"
 
 Plugin.HasConfig = true
@@ -300,6 +300,11 @@ Plugin.ConfigMigrationSteps = {
 		VersionTo = "2.9",
 		Apply = Shine.Migrator()
 			:AddField( "BalanceModeConfig", Plugin.DefaultConfig.BalanceModeConfig )
+	},
+	{
+		VersionTo = "2.10",
+		Apply = Shine.Migrator()
+			:AddField( { "TeamPreferences", "FriendGroupRestoreTimeoutSeconds" }, 300 )
 	}
 }
 
@@ -648,6 +653,7 @@ function Plugin:Initialise()
 	self.FriendGroupConfigBySteamID = {}
 	self.FriendGroupInvitesBySteamID = {}
 	self.FriendGroupInviteDelaysBySteamID = {}
+	self:LoadFriendGroups()
 
 	self:BroadcastModuleEvent( "Initialise" )
 	self.Enabled = true
@@ -1327,6 +1333,7 @@ end
 
 function Plugin:ClientConnect( Client )
 	self:UpdateVoteCounters( self.Vote )
+	self:HandleFriendGroupClientConnect( Client )
 
 	if not self.ReconnectingClients or not self.ReconnectLogTimeout then return end
 
@@ -1340,6 +1347,10 @@ function Plugin:ClientConnect( Client )
 
 	self:Print( "Client %s reconnected after a shuffle vote.", true,
 		Shine.GetClientInfo( Client ) )
+end
+
+function Plugin:MapChange()
+	self:SaveFriendGroups()
 end
 
 function Plugin:GetCurrentVoteConstraints()

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -839,7 +839,11 @@ do
 			-- Bot and we don't want to deal with them, so kick them out.
 			if Client:GetIsVirtual() and not IsCommander and not self.Config.ApplyToBots then
 				if Pass == 1 then
-					Server.DisconnectClient( Client )
+					if Client.bot and Client.bot.Disconnect then
+						Client.bot:Disconnect()
+					else
+						Server.DisconnectClient( Client )
+					end
 				end
 				return
 			end

--- a/lua/shine/extensions/voterandom/team_balance.lua
+++ b/lua/shine/extensions/voterandom/team_balance.lua
@@ -604,9 +604,6 @@ function BalanceModule.IsPlayerCommander( Player, Client )
 end
 
 function BalanceModule:OptimiseTeams( TeamMembers, RankFunc, TeamSkills )
-	-- Sanity check, make sure both team tables have even counts.
-	Shine.EqualiseTeamCounts( TeamMembers )
-
 	local TeamPreferences = TeamMembers.TeamPreferences
 	local function GetNumPasses( self )
 		return next( TeamPreferences ) and 2 or 1
@@ -850,6 +847,9 @@ function BalanceModule:SortPlayersByRank( TeamMembers, SortTable, Count, NumTarg
 
 	-- If you want/need to control number of players on teams, this is the best point to do it.
 	Shine.Hook.Call( "PreShuffleOptimiseTeams", TeamMembers )
+
+	-- Sanity check, make sure both team tables have even counts.
+	Shine.EqualiseTeamCounts( TeamMembers )
 
 	if NoSecondPass then
 		return Sorted

--- a/lua/shine/extensions/voterandom/team_balance.lua
+++ b/lua/shine/extensions/voterandom/team_balance.lua
@@ -46,7 +46,9 @@ BalanceModule.DefaultConfig = {
 		-- How long to wait for a response to a friend group invitation before revoking it.
 		FriendGroupInviteDurationInSeconds = 15,
 		-- How long after a friend group invite fails before a player can send another invite.
-		FriendGroupInviteCooldownInSeconds = 15
+		FriendGroupInviteCooldownInSeconds = 15,
+		-- How long after map change to restore friend groups for (a value of 0 disables restoring groups).
+		FriendGroupRestoreTimeoutSeconds = 300
 	}
 }
 
@@ -72,6 +74,7 @@ do
 
 	Validator:AddFieldRule( "TeamPreferences.FriendGroupInviteDurationInSeconds", Validator.Min( 5 ) )
 	Validator:AddFieldRule( "TeamPreferences.FriendGroupInviteCooldownInSeconds", Validator.Min( 0 ) )
+	Validator:AddFieldRule( "TeamPreferences.FriendGroupRestoreTimeoutSeconds", Validator.Min( 0 ) )
 
 	BalanceModule.ConfigValidator = Validator
 end

--- a/lua/shine/lib/player.lua
+++ b/lua/shine/lib/player.lua
@@ -387,7 +387,7 @@ end, Hook.MAX_PRIORITY )
 Hook.Add( "ClientConnect", Indexes, function( Client )
 	Indexes.BySteamID[ Client:GetUserId() ] = Client
 	Indexes.ByGameID[ Client.ShineGameID ] = Client
-end, Hook.MAX_PRIORITY + 1 )
+end, Hook.MAX_PRIORITY + 0.1 )
 
 Hook.Add( "ClientDisconnect", Indexes, function( Client )
 	Indexes.BySteamID[ Client:GetUserId() ] = nil

--- a/test/lib/timer.lua
+++ b/test/lib/timer.lua
@@ -1,0 +1,123 @@
+--[[
+	Timer tests.
+]]
+
+local Time = 0
+local Env = setmetatable( {
+	Shine = setmetatable( {
+		Hook = {
+			Add = function() end
+		}
+	}, { __index = Shine } ),
+	Shared = {
+		GetTime = function() return Time end
+	}
+}, { __index = _G } )
+
+-- Load a copy of the timer system to avoid interacting with real timers.
+local Func = assert( loadfile( "lua/shine/lib/timer.lua" ) )
+setfenv( Func, Env )
+
+Func()
+
+local Timer = Env.Shine.Timer
+local UnitTest = Shine.UnitTest
+
+local function AdvanceTime( Amount )
+	Time = Time + Amount
+	Timer.__ProcessTimers( Time )
+end
+
+UnitTest:Test( "SimpleTimer fires after given delay once", function( Assert )
+	local Callback = UnitTest.MockFunction()
+	local SimpleTimer = Timer.Simple( 5, Callback )
+	Assert.True( "Should have added the timer", Timer.Exists( SimpleTimer.Name ) )
+
+	AdvanceTime( 1 )
+	Assert.CalledTimes( "Should not have called the timer yet", Callback, 0 )
+
+	AdvanceTime( 4 )
+	Assert.Called( "Should have called the timer after its delay", Callback, SimpleTimer )
+	Assert.False( "Should have removed the timer after calling it", Timer.Exists( SimpleTimer.Name ) )
+
+	AdvanceTime( 1 )
+	Assert.CalledTimes( "Should not have called the timer again", Callback, 1 )
+end )
+
+UnitTest:Test( "Timer removal mid-iteration should be handled", function( Assert )
+	local Timer1Callback = UnitTest.MockFunction( function() Timer.Destroy( "Test2" ) end )
+	local Timer2Callback = UnitTest.MockFunction()
+	local Timer3Callback = UnitTest.MockFunction()
+
+	local Timer1 = Timer.Create( "Test1", 5, 2, Timer1Callback )
+	Timer.Create( "Test2", 5, 2, Timer2Callback )
+	local Timer3 = Timer.Create( "Test3", 5, 2, Timer3Callback )
+
+	AdvanceTime( 5 )
+
+	Assert.Called( "Should have called the first timer", Timer1Callback, Timer1 )
+	Assert.CalledTimes( "Should not have called the second timer", Timer2Callback, 0 )
+	Assert.False( "Second timer should have been destroyed", Timer.Exists( "Test2" ) )
+	Assert.Called( "Should have called the third timer", Timer3Callback, Timer3 )
+
+	AdvanceTime( 5 )
+
+	Assert.CalledTimes( "Should have called the first timer again", Timer1Callback, 2 )
+	Assert.CalledTimes( "Should still not have called the second timer", Timer2Callback, 0 )
+	Assert.CalledTimes( "Should have called the third timer again", Timer3Callback, 2 )
+	Assert.False( "First timer should have run out of repetitions", Timer.Exists( "Test1" ) )
+	Assert.False( "Third timer should have run out of repetitions", Timer.Exists( "Test3" ) )
+end )
+
+UnitTest:Test( "Timer pause mid-iteration should be handled", function( Assert )
+	local Timer1Callback = UnitTest.MockFunction( function() Timer.Pause( "Test2" ) end )
+	local Timer2Callback = UnitTest.MockFunction()
+
+	local Timer1 = Timer.Create( "Test1", 5, 2, Timer1Callback )
+	Timer.Create( "Test2", 5, 2, Timer2Callback )
+
+	AdvanceTime( 5 )
+
+	Assert.Called( "Should have called the first timer", Timer1Callback, Timer1 )
+	Assert.CalledTimes( "Should not have called the second timer", Timer2Callback, 0 )
+	Assert.True( "Second timer should still exist", Timer.Exists( "Test2" ) )
+
+	local Timer2 = Timer.Get( "Test2" )
+	Assert.NotNil( "Second timer should be retrievable", Timer2 )
+	Assert.True( "Second timer should be paused", Timer2.Paused )
+
+	AdvanceTime( 5 )
+
+	Assert.CalledTimes( "Should have called the first timer again", Timer1Callback, 2 )
+	Assert.CalledTimes( "Should still not have called the second timer", Timer2Callback, 0 )
+	Assert.False( "First timer should have run out of repetitions", Timer.Exists( "Test1" ) )
+
+	AdvanceTime( 5 )
+
+	Assert.CalledTimes( "Should not have called the first timer again", Timer1Callback, 2 )
+	Assert.CalledTimes( "Should still not have called the second timer", Timer2Callback, 0 )
+
+	Timer.Resume( "Test2" )
+	Assert.Falsy( "Second timer should no longer be paused", Timer2.Paused )
+	Assert.True( "Second timer should still exist", Timer.Exists( "Test2" ) )
+
+	Timer1Callback = UnitTest.MockFunction()
+	Timer1 = Timer.Create( "Test1", 5, 2, Timer1Callback )
+
+	AdvanceTime( 5 )
+
+	Assert.Called( "Should have called the first timer again", Timer1Callback, Timer1 )
+	Assert.Called( "Should have called the second timer", Timer2Callback, Timer2 )
+
+	AdvanceTime( 5 )
+
+	Assert.CalledTimes( "Should have called the first timer again", Timer1Callback, 2 )
+	Assert.CalledTimes( "Should have called the second timer again", Timer2Callback, 2 )
+
+	AdvanceTime( 5 )
+
+	Assert.CalledTimes( "Should not have called the first timer again", Timer1Callback, 2 )
+	Assert.False( "First timer should have run out of repetitions", Timer.Exists( "Test1" ) )
+	Assert.CalledTimes( "Should not have called the second timer again", Timer2Callback, 2 )
+	Assert.False( "Second timer should have run out of repetitions", Timer.Exists( "Test2" ) )
+end )


### PR DESCRIPTION
#### Bans
* Fixed family sharing queries being fired for bots.

#### Vote Shuffle
* Friend groups are now saved across map changes and will be restored for up to 5 minutes after a map change by default (controlled by the `TeamPreferences.FriendGroupRestoreTimeoutSeconds` option).
* Fixed team optimisation using incorrect skill values if external plugins altered the teams to have more than a 1 player size difference before a shuffle.