### PR TITLE
Add option to limit specator votes in active round, bug fixes

### DIFF
--- a/lua/shine/extensions/mapvote/server.lua
+++ b/lua/shine/extensions/mapvote/server.lua
@@ -18,7 +18,7 @@ local TableCount = table.Count
 local tonumber = tonumber
 
 local Plugin, PluginName = ...
-Plugin.Version = "1.12"
+Plugin.Version = "1.13"
 
 Plugin.HasConfig = true
 Plugin.ConfigName = "MapVote.json"
@@ -277,6 +277,11 @@ Plugin.ConfigMigrationSteps = {
 				end
 				return Plugin.DefaultConfig.MaxVoteChoicesPerPlayer
 			end )
+	},
+	{
+		VersionTo = "1.13",
+		Apply = Shine.Migrator()
+			:AddField( { "VoteSettings", "ConsiderSpectatorsDuringActiveRound" }, true )
 	}
 }
 

--- a/lua/shine/extensions/votealltalk/server.lua
+++ b/lua/shine/extensions/votealltalk/server.lua
@@ -8,7 +8,7 @@ Plugin.DependsOnPlugins = {
 	"basecommands"
 }
 
-Plugin.Version = "1.1"
+Plugin.Version = "1.2"
 
 Plugin.HasConfig = true
 Plugin.ConfigName = "VoteAllTalk.json"
@@ -19,6 +19,14 @@ Plugin.VoteCommand = {
 	ConCommand = "sh_votealltalk",
 	ChatCommand = "votealltalk",
 	Help = "Votes to enable or disable all talk."
+}
+
+Plugin.ConfigMigrationSteps = {
+	{
+		VersionTo = "1.2",
+		Apply = Shine.Migrator()
+			:AddField( { "VoteSettings", "ConsiderSpectatorsDuringActiveRound" }, true )
+	}
 }
 
 local ALLTALK_TYPE = "AllTalk"

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -590,6 +590,8 @@ function Plugin:OnFirstThink()
 end
 
 function Plugin:Initialise()
+	self:BroadcastModuleEvent( "Initialise" )
+
 	local BalanceMode = self.Config.BalanceMode
 	local FallbackMode = self.Config.FallbackMode
 
@@ -654,7 +656,6 @@ function Plugin:Initialise()
 	self.FriendGroupInvitesBySteamID = {}
 	self.FriendGroupInviteDelaysBySteamID = {}
 
-	self:BroadcastModuleEvent( "Initialise" )
 	self:LoadFriendGroups()
 
 	self.Enabled = true

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -25,7 +25,7 @@ local TableConcat = table.concat
 local tostring = tostring
 
 local Plugin, PluginName = ...
-Plugin.Version = "2.10"
+Plugin.Version = "2.11"
 Plugin.PrintName = "Shuffle"
 
 Plugin.HasConfig = true
@@ -305,6 +305,11 @@ Plugin.ConfigMigrationSteps = {
 		VersionTo = "2.10",
 		Apply = Shine.Migrator()
 			:AddField( { "TeamPreferences", "FriendGroupRestoreTimeoutSeconds" }, 300 )
+	},
+	{
+		VersionTo = "2.11",
+		Apply = Shine.Migrator()
+			:AddField( { "VoteSettings", "ConsiderSpectatorsDuringActiveRound" }, true )
 	}
 }
 

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -653,9 +653,10 @@ function Plugin:Initialise()
 	self.FriendGroupConfigBySteamID = {}
 	self.FriendGroupInvitesBySteamID = {}
 	self.FriendGroupInviteDelaysBySteamID = {}
-	self:LoadFriendGroups()
 
 	self:BroadcastModuleEvent( "Initialise" )
+	self:LoadFriendGroups()
+
 	self.Enabled = true
 
 	return true

--- a/lua/shine/extensions/votesurrender/server.lua
+++ b/lua/shine/extensions/votesurrender/server.lua
@@ -15,7 +15,7 @@ local Max = math.max
 local Random = math.random
 
 local Plugin = ...
-Plugin.Version = "1.4"
+Plugin.Version = "1.5"
 
 Plugin.HasConfig = true
 Plugin.ConfigName = "VoteSurrender.json"
@@ -41,8 +41,17 @@ Plugin.DefaultConfig = {
 
 Plugin.CheckConfig = true
 Plugin.CheckConfigTypes = true
+Plugin.VoteApplicableToSpectators = false
 
 Shine.LoadPluginModule( "vote.lua", Plugin )
+
+Plugin.ConfigMigrationSteps = {
+	{
+		VersionTo = "1.5",
+		Apply = Shine.Migrator()
+			:RemoveField( { "VoteSettings", "ConsiderSpectatorsInVotes" } )
+	}
+}
 
 function Plugin:Initialise()
 	local function ClampConfigOption( Option, Min, Max )

--- a/test/test_init.lua
+++ b/test/test_init.lua
@@ -95,7 +95,8 @@ function UnitTest.MakeMockClient( SteamID )
 			return {
 				GetName = function() return "Test" end
 			}
-		end
+		end,
+		GetIsVirtual = function() return SteamID == 0 end
 	}
 end
 


### PR DESCRIPTION
#### Map Vote
* Added the `VoteSettings.ConsiderSpectatorsDuringActiveRound` option. When `false`, spectators cannot vote during an active round. Note that the existing `VoteSettings.ConsiderSpectatorsInVotes` option must still be `true` for spectators to be able to vote.

#### Vote All Talk
* Added the `VoteSettings.ConsiderSpectatorsDuringActiveRound` option.

#### Vote Shuffle
* Added the `VoteSettings.ConsiderSpectatorsDuringActiveRound` option.
* Fixed errors related to logging when loading the plugin.
