### PR TITLE
Add blending option for alien commander skill

### DIFF
--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -25,7 +25,7 @@ local TableConcat = table.concat
 local tostring = tostring
 
 local Plugin, PluginName = ...
-Plugin.Version = "2.11"
+Plugin.Version = "2.12"
 Plugin.PrintName = "Shuffle"
 
 Plugin.HasConfig = true
@@ -93,7 +93,10 @@ Plugin.DefaultConfig = {
 	BalanceModeConfig = {
 		[ Plugin.ShuffleMode.HIVE ] = {
 			UseTeamSkill = true,
-			UseCommanderSkill = true
+			UseCommanderSkill = true,
+			-- Whether to blend the commander and field skill values for an alien commander to account for them being
+			-- out of the hive for a significant amount of time during a round.
+			BlendAlienCommanderAndFieldSkills = false
 		}
 	},
 
@@ -310,6 +313,11 @@ Plugin.ConfigMigrationSteps = {
 		VersionTo = "2.11",
 		Apply = Shine.Migrator()
 			:AddField( { "VoteSettings", "ConsiderSpectatorsDuringActiveRound" }, true )
+	},
+	{
+		VersionTo = "2.12",
+		Apply = Shine.Migrator()
+			:AddField( { "BalanceModeConfig", Plugin.ShuffleMode.HIVE, "BlendAlienCommanderAndFieldSkills" }, false )
 	}
 }
 

--- a/lua/shine/extensions/voterandom/server.lua
+++ b/lua/shine/extensions/voterandom/server.lua
@@ -1827,10 +1827,13 @@ function Plugin:CreateCommands()
 				Stats.Average, Stats.StandardDeviation )
 		end
 
+		local BalanceModeConfig = self:GetBalanceModeConfig()
+
 		Message[ #Message + 1 ] = StringFormat(
-			"Team skills are %s. Commander skills are %s.",
+			"Team skills are %s. Commander skills are %s. Alien commander skill blending is %s.",
 			self:IsPerTeamSkillEnabled() and "enabled" or "disabled",
-			self:IsCommanderSkillEnabled() and "enabled" or "disabled"
+			self:IsCommanderSkillEnabled() and "enabled" or "disabled",
+			BalanceModeConfig and BalanceModeConfig.BlendAlienCommanderAndFieldSkills and "enabled" or "disabled"
 		)
 		Message[ #Message + 1 ] = StringFormat( "Team preference cost weighting: %s. History rounds: %d.",
 			self.Config.TeamPreferences.CostWeighting, self.Config.TeamPreferences.MaxHistoryRounds )

--- a/lua/shine/extensions/voterandom/team_balance.lua
+++ b/lua/shine/extensions/voterandom/team_balance.lua
@@ -294,7 +294,7 @@ function BalanceModule:IsCommanderSkillEnabled()
 end
 
 --[[
-	Wraps the given ranking function, passing through the configured team/commnader skill flags.
+	Wraps the given ranking function, passing through the configured team/commander skill flags.
 ]]
 function BalanceModule:ApplyConfigToRankingFunction( RankFunc )
 	local TeamSkillEnabled = self:IsPerTeamSkillEnabled()
@@ -1107,7 +1107,7 @@ do
 			return self.TeamStatsCache[ RankFunc ]
 		end
 
-		-- Apply configured skill options to the ranking function to apply team/commnader skills if enabled.
+		-- Apply configured skill options to the ranking function to apply team/commander skills if enabled.
 		RankFunc = self:ApplyConfigToRankingFunction( RankFunc )
 
 		local Gamerules = GetGamerules()

--- a/test/extensions/voterandom/team_balance.lua
+++ b/test/extensions/voterandom/team_balance.lua
@@ -1,0 +1,64 @@
+--[[
+	Team balance function tests.
+]]
+
+local UnitTest = Shine.UnitTest
+
+local VoteShuffle = UnitTest:LoadExtension( "voterandom" )
+if not VoteShuffle or not VoteShuffle.Config then return end
+
+local MockShuffle = UnitTest.MockOf( VoteShuffle )
+
+local MockClient = UnitTest.MakeMockClient( 123 )
+local MockPlayer
+
+UnitTest:Before( function()
+	MockPlayer = {
+		GetPlayerSkill = function() return 1000 end,
+		GetPlayerSkillOffset = function() return 500 end,
+		GetCommanderSkill = function() return 500 end,
+		GetCommanderSkillOffset = function() return 100 end,
+		GetClient = function() return MockClient end,
+		GetTeamNumber = function() return 2 end,
+		isa = function( self, Name ) return Name == "Commander" end
+	}
+end )
+
+UnitTest:Test( "SkillGetters.GetHiveSkill - Returns commander skill for a commander on the evaluated team with no blending", function( Assert )
+	local Skill = MockShuffle.SkillGetters.GetHiveSkill( MockPlayer, 2, true, true )
+	Assert.Equals( "Should use commander skill", 400, Skill )
+end )
+
+UnitTest:Test( "SkillGetters.GetHiveSkill - Returns field skill if commanders skills are not enabled", function( Assert )
+	local Skill = MockShuffle.SkillGetters.GetHiveSkill( MockPlayer, 1, true, false )
+	Assert.Equals( "Should use field skill", 1500, Skill )
+end )
+
+UnitTest:Test( "SkillGetters.GetHiveSkill - Returns field skill for a commander not on the evaluated team", function( Assert )
+	local Skill = MockShuffle.SkillGetters.GetHiveSkill( MockPlayer, 1, true, true )
+	Assert.Equals( "Should use field skill", 1500, Skill )
+end )
+
+UnitTest:Test( "SkillGetters.GetHiveSkill - Returns field skill for a field player", function( Assert )
+	MockPlayer.isa = function() return false end
+
+	local Skill = MockShuffle.SkillGetters.GetHiveSkill( MockPlayer, 2, true, true )
+	Assert.Equals( "Should use field skill", 500, Skill )
+end )
+
+UnitTest:Test( "SkillGetters.GetHiveSkill - Returns blended field and commander skill if blending is applicable and enabled", function( Assert )
+	local Skill = MockShuffle.SkillGetters.GetHiveSkill( MockPlayer, 2, true, true, {
+		BlendAlienCommanderAndFieldSkills = true
+	} )
+	Assert.Equals( "Should use blended skill", 450, Skill )
+end )
+
+UnitTest:Test( "SkillGetters.GetHiveSkill - Returns average commander skill when team skills are disabled", function( Assert )
+	local Skill = MockShuffle.SkillGetters.GetHiveSkill( MockPlayer, 2, false, true )
+	Assert.Equals( "Should use average commander skill", 500, Skill )
+end )
+
+UnitTest:Test( "SkillGetters.GetHiveSkill - Returns average field skill when team skills are disabled", function( Assert )
+	local Skill = MockShuffle.SkillGetters.GetHiveSkill( MockPlayer, 1, false, false )
+	Assert.Equals( "Should use average field skill", 1000, Skill )
+end )


### PR DESCRIPTION
#### Vote Shuffle
* Added the `BalanceModeConfig.HIVE.BlendAlienCommanderAndFieldSkills` option. When enabled, shuffle will use the average of an alien commander's field and commander skill, instead of just their commander skill. This may improve results for commanders that frequently leave the hive to fight.