### PR TITLE
Add family sharing check immunity and fix minor bug

### DIFF
--- a/lua/shine/extensions/voterandom/team_balance.lua
+++ b/lua/shine/extensions/voterandom/team_balance.lua
@@ -983,7 +983,7 @@ function BalanceModule:SortByScore( Gamerules, Targets, TeamMembers, Silent, Ran
 	self.Logger:Debug( "After SortByScore:" )
 	self.Logger:IfDebugEnabled( DebugLogTeamMembers, self, TeamMembers )
 
-	EvenlySpreadTeams( Gamerules, TeamMembers )
+	EvenlySpreadTeams( Gamerules, TeamMembers, self.Config.BalanceMode )
 end
 
 BalanceModule.ShufflingModes = {
@@ -994,7 +994,7 @@ BalanceModule.ShufflingModes = {
 		self.Logger:Debug( "After AddPlayersRandomly:" )
 		self.Logger:IfDebugEnabled( DebugLogTeamMembers, self, TeamMembers )
 
-		EvenlySpreadTeams( Gamerules, TeamMembers )
+		EvenlySpreadTeams( Gamerules, TeamMembers, self.Config.BalanceMode )
 
 		if not Silent then
 			self:Print( "Teams were sorted randomly." )
@@ -1049,7 +1049,7 @@ BalanceModule.ShufflingModes = {
 			return
 		end
 
-		EvenlySpreadTeams( Gamerules, TeamMembers )
+		EvenlySpreadTeams( Gamerules, TeamMembers, self.Config.BalanceMode )
 	end
 }
 

--- a/lua/shine/lib/player.lua
+++ b/lua/shine/lib/player.lua
@@ -238,7 +238,7 @@ do
 	--[[
 		Ensures no team has more than 1 extra player compared to the other.
 	]]
-	function Shine.EvenlySpreadTeams( Gamerules, TeamMembers )
+	function Shine.EvenlySpreadTeams( Gamerules, TeamMembers, BalanceMode )
 		Hook.Call( "PreEvenlySpreadTeams", Gamerules, TeamMembers )
 
 		-- Yes, we repeat this, but the reporting needs it...
@@ -261,18 +261,14 @@ do
 
 		Hook.Remove( "JoinTeam", "StopPeopleBreakingShuffle" )
 
-		local NewMarineCount = MarineTeam:GetNumPlayers()
-		local NewAlienCount = AlienTeam:GetNumPlayers()
-		local NewDiff = Abs( NewMarineCount - NewAlienCount )
-		-- If the number of players has changed, something else is interfering with teams and it's not our fault.
-		local IsSameAmountOfPlayers = NumMarine + NumAlien == NewMarineCount + NewAlienCount
+		if BalanceMode then
+			local NewMarineCount = MarineTeam:GetNumPlayers()
+			local NewAlienCount = AlienTeam:GetNumPlayers()
+			local NewDiff = Abs( NewMarineCount - NewAlienCount )
+			-- If the number of players has changed, something else is interfering with teams and it's not our fault.
+			local IsSameAmountOfPlayers = NumMarine + NumAlien == NewMarineCount + NewAlienCount
 
-		if NewDiff > 1 and IsSameAmountOfPlayers then
-			local VoteRandom = Shine.Plugins.voterandom
-
-			if VoteRandom then
-				local BalanceMode = VoteRandom.Config.BalanceMode
-
+			if NewDiff > 1 and IsSameAmountOfPlayers then
 				local Marines = PlayersToString( Marine )
 				local Aliens = PlayersToString( Alien )
 				local NewMarines = PlayersToString( MarineTeam:GetPlayers() )


### PR DESCRIPTION
#### Bans
* Added the `sh_ban_family_share_immune` permission, which can be used to make certain users immune to family sharing checks.

#### Misc
* Fixed a rare script error with the `sh_forcerandom` command.