### PR TITLE
Improve badge config and remote user loading

### DIFF
--- a/lua/shine/extensions/badges.lua
+++ b/lua/shine/extensions/badges.lua
@@ -436,12 +436,17 @@ function Plugin:AssignForcedBadges( Client )
 	end
 end
 
-function Plugin:OnUserReload()
-	self:Setup()
+function Plugin:OnUserReload( TriggerType )
+	if TriggerType == Shine.UserDataReloadTriggerType.INITIAL_WEB_LOAD then
+		-- Treat the first load from web data the same as startup as it's likely to occur before most players load in.
+		self:SetupAndLoadUserBadges()
+	else
+		-- Otherwise, only reload the currently connected player's badges, leave the rest to be loaded later.
+		self:Setup()
 
-	-- Re-assign connected player's badges.
-	for Client in Shine.GameIDs:Iterate() do
-		self:AssignBadgesToClient( Client )
+		for Client in Shine.IterateClients() do
+			self:AssignBadgesToClient( Client )
+		end
 	end
 end
 

--- a/lua/shine/lib/table.lua
+++ b/lua/shine/lib/table.lua
@@ -5,6 +5,7 @@
 local IsType = Shine.IsType
 local pairs = pairs
 local Random = math.random
+local rawget = rawget
 local TableSort = table.sort
 
 --[[
@@ -21,6 +22,57 @@ function table.ArraysEqual( Left, Right )
 	end
 
 	return true
+end
+
+do
+	local rawequal = rawequal
+	local type = type
+
+	local function DeepEquals( Table1, Table2, Comparing )
+		if rawequal( Table1, Table2 ) then return true end
+		if type( Table1 ) ~= type( Table2 ) then return false end
+		if type( Table1 ) ~= "table" then return Table1 == Table2 end
+
+		local CurrentComparison = Comparing[ Table1 ]
+		if CurrentComparison then
+			-- Cycle, only equal if the other table cycles in the same way (i.e. to its equivalent table). If so, no
+			-- need to go further as the equality is already being checked.
+			return rawequal( CurrentComparison, Table2 )
+		end
+
+		-- Remember the comparison to detect cycles further down.
+		Comparing[ Table1 ] = Table2
+
+		-- Table2 must have all keys that Table1 does, holding deep-equal values.
+		for Key, Value in pairs( Table1 ) do
+			if not DeepEquals( Value, rawget( Table2, Key ), Comparing ) then return false end
+		end
+
+		-- Table2 must not contain any keys that Table1 does not (no need to check equality again here, a table can't
+		-- hold nil).
+		for Key, Value in pairs( Table2 ) do
+			if rawget( Table1, Key ) == nil then return false end
+		end
+
+		Comparing[ Table1 ] = nil
+
+		return true
+	end
+
+	--[[
+		Returns true if the given values are deep-equal, ignoring any metatable __index metamethods.
+
+		Two values are deep-equal if:
+		* They are both the same value by reference (e.g. the same userdata/cdata/table instance), or
+		* They are both the same scalar value (e.g. two equal numbers), or
+		* They are both tables with the exact same keys, each holding deep-equal values.
+
+		In the case of cycles, equality is determined by the cycles in both tables pointing to the same table instance
+		that the cycle's root is being compared against.
+	]]
+	function table.DeepEquals( Table1, Table2 )
+		return DeepEquals( Table1, Table2, {} )
+	end
 end
 
 do
@@ -225,7 +277,6 @@ function table.Mixin( Source, Destination, Keys )
 end
 
 do
-	local rawget = rawget
 	local function Get( Table, Key )
 		return Table[ Key ]
 	end

--- a/lua/shine/lib/table.lua
+++ b/lua/shine/lib/table.lua
@@ -760,7 +760,11 @@ do
 	local function WriteValue( Value, Buffer, FormattingOptions, State )
 		local ValueType = type( Value )
 
-		local Writer = assert( Writers[ ValueType ], StringFormat( "Unsupported value type: %s", ValueType ) )
+		local Writer = Writers[ ValueType ]
+		if not Writer then
+			error( StringFormat( "Unsupported value type: %s", ValueType ) )
+		end
+
 		local Output = Writer( Value, FormattingOptions, State )
 		if Output then
 			State.BufferCount = State.BufferCount + 1

--- a/test/extensions/badges.lua
+++ b/test/extensions/badges.lua
@@ -46,15 +46,24 @@ UnitTest:Test( "GetMasterBadgeLookup", function( Assert )
 		},
 		[ "8" ] = {
 			"test8", "test1"
-		}
+		},
+		TestList1 = { "test1", "test2" },
+		IgnoreNonTableFields = true
 	}
 
-	local Lookup = Badges:GetMasterBadgeLookup( MasterBadgeTable )
+	local Lookup, NamedBadgeLists = Badges:GetMasterBadgeLookup( MasterBadgeTable )
 	Assert:NotNil( Lookup )
 	Assert:ArrayEquals( { 1, 8 }, Lookup:Get( "test1" ) )
 	Assert:ArrayEquals( { 2 }, Lookup:Get( "test2" ) )
 	Assert:ArrayEquals( { 2 }, Lookup:Get( "test2b" ) )
 	Assert:ArrayEquals( { 8 }, Lookup:Get( "test8" ) )
+
+	MasterBadgeTable.IgnoreNonTableFields = nil
+	Assert.DeepEquals(
+		"Named lookup should include all table fields from the master table",
+		MasterBadgeTable,
+		NamedBadgeLists
+	)
 end )
 
 UnitTest:Test( "MapBadgesToRows", function( Assert )
@@ -102,6 +111,21 @@ local MockGroups = {
 			"TestGroupWithCycle1"
 		}
 	},
+	TestGroupWithNamedList = {
+		Badges = {
+			[ "1" ] = {
+				{ BadgeList = "TestList1" }
+			},
+			[ "2" ] = {
+				{ BadgeList = "TestList2" }
+			}
+		}
+	},
+	TestGroupWithNamedListDefaultRow = {
+		Badges = {
+			{ BadgeList = "TestList1" }
+		}
+	},
 	[ -1 ] = {
 		Badges = {
 			[ "3" ] = { "test3", "test4" },
@@ -120,6 +144,12 @@ local function GroupBadgesForComparison( GroupBadges )
 		Forced = GroupBadges.Forced and GroupBadges.Forced:AsTable()
 	}
 end
+
+Badges.NamedBadgeLists = {
+	-- Badge lists should support recursive references, this will expand to include test3 and test4.
+	TestList1 = { "test1", "test2", { BadgeList = "TestList2" } },
+	TestList2 = { "test3", "test4" }
+}
 
 UnitTest:Test( "BuildGroupBadges - Builds with master badge lookup as expected", function( Assert )
 	Badges.MasterBadgeTable = Shine.Multimap{
@@ -164,6 +194,24 @@ UnitTest:Test( "BuildGroupBadges - Builds with master badge lookup as expected",
 		}
 	}, GroupBadgesForComparison( GroupBadges ) )
 
+	GroupBadges = Badges:BuildGroupBadges( "TestGroupWithNamedList" )
+	Assert.DeepEquals( "Should have built badges for TestGroupWithNamedList as expected", {
+		Assigned = {
+			[ 1 ] = { "test1", "test2", "test3", "test4" },
+			[ 2 ] = { "test3", "test4" }
+		}
+	}, GroupBadgesForComparison( GroupBadges ) )
+
+	GroupBadges = Badges:BuildGroupBadges( "TestGroupWithNamedListDefaultRow" )
+	Assert.DeepEquals( "Should have built badges for TestGroupWithNamedListDefaultRow as expected", {
+		Assigned = {
+			[ 5 ] = { "test1", "test2", "test3", "test4" },
+			-- test1 is mapped to these by the master table.
+			[ 6 ] = { "test1" },
+			[ 7 ] = { "test1" }
+		}
+	}, GroupBadgesForComparison( GroupBadges ) )
+
 	GroupBadges = Badges:BuildGroupBadges( -1 )
 	Assert.DeepEquals( "Should have built badges for the default group as expected", {
 		Assigned = {
@@ -174,7 +222,7 @@ UnitTest:Test( "BuildGroupBadges - Builds with master badge lookup as expected",
 end )
 
 UnitTest:Test( "BuildGroupBadges - Builds without master badge lookup as expected", function( Assert )
-	Badges.MasterBadgeTable = Shine.Multimap()
+	Badges.MasterBadgeTable = nil
 
 	local GroupBadges = Badges:BuildGroupBadges( "TestGroupThatInheritsBadges" )
 	Assert.DeepEquals( "Should have built badges for TestGroupThatInheritsBadges as expected", {
@@ -205,6 +253,21 @@ UnitTest:Test( "BuildGroupBadges - Builds without master badge lookup as expecte
 		},
 		Forced = {
 			[ 10 ] = "test11"
+		}
+	}, GroupBadgesForComparison( GroupBadges ) )
+
+	GroupBadges = Badges:BuildGroupBadges( "TestGroupWithNamedList" )
+	Assert.DeepEquals( "Should have built badges for TestGroupWithNamedList as expected", {
+		Assigned = {
+			[ 1 ] = { "test1", "test2", "test3", "test4" },
+			[ 2 ] = { "test3", "test4" }
+		}
+	}, GroupBadgesForComparison( GroupBadges ) )
+
+	GroupBadges = Badges:BuildGroupBadges( "TestGroupWithNamedListDefaultRow" )
+	Assert.DeepEquals( "Should have built badges for TestGroupWithNamedListDefaultRow as expected", {
+		Assigned = {
+			[ 5 ] = { "test1", "test2", "test3", "test4" }
 		}
 	}, GroupBadgesForComparison( GroupBadges ) )
 

--- a/test/extensions/badges.lua
+++ b/test/extensions/badges.lua
@@ -148,7 +148,8 @@ end
 Badges.NamedBadgeLists = {
 	-- Badge lists should support recursive references, this will expand to include test3 and test4.
 	TestList1 = { "test1", "test2", { BadgeList = "TestList2" } },
-	TestList2 = { "test3", "test4" }
+	-- Cycles in lists should be handled.
+	TestList2 = { "test3", "test4", { BadgeList = "TestList1" } }
 }
 
 UnitTest:Test( "BuildGroupBadges - Builds with master badge lookup as expected", function( Assert )
@@ -198,7 +199,7 @@ UnitTest:Test( "BuildGroupBadges - Builds with master badge lookup as expected",
 	Assert.DeepEquals( "Should have built badges for TestGroupWithNamedList as expected", {
 		Assigned = {
 			[ 1 ] = { "test1", "test2", "test3", "test4" },
-			[ 2 ] = { "test3", "test4" }
+			[ 2 ] = { "test3", "test4", "test1", "test2" }
 		}
 	}, GroupBadgesForComparison( GroupBadges ) )
 
@@ -260,7 +261,7 @@ UnitTest:Test( "BuildGroupBadges - Builds without master badge lookup as expecte
 	Assert.DeepEquals( "Should have built badges for TestGroupWithNamedList as expected", {
 		Assigned = {
 			[ 1 ] = { "test1", "test2", "test3", "test4" },
-			[ 2 ] = { "test3", "test4" }
+			[ 2 ] = { "test3", "test4", "test1", "test2" }
 		}
 	}, GroupBadgesForComparison( GroupBadges ) )
 

--- a/test/lib/gui/richtext/elements/text.lua
+++ b/test/lib/gui/richtext/elements/text.lua
@@ -27,15 +27,18 @@ UnitTest:Test( "GetLines - Should copy all properties when multiple lines are pr
 	Assert.DeepEquals( "Should return each line, preserving properties", {
 		Text( {
 			Value = "Multiple lines",
-			DoClick = Element.DoClick
+			DoClick = Element.DoClick,
+			Setup = Element.Setup
 		} ),
 		Text( {
 			Value = "of",
-			DoClick = Element.DoClick
+			DoClick = Element.DoClick,
+			Setup = Element.Setup
 		} ),
 		Text( {
 			Value = "text.",
-			DoClick = Element.DoClick
+			DoClick = Element.DoClick,
+			Setup = Element.Setup
 		} )
 	}, Element:GetLines() )
 end )

--- a/test/lib/table.lua
+++ b/test/lib/table.lua
@@ -314,6 +314,140 @@ UnitTest:Test( "ArraysEqual", function( Assert )
 	Assert:False( table.ArraysEqual( Left, Right ) )
 end )
 
+UnitTest:Test( "DeepEquals - Returns true if tables are deep-equal accounting for cycles", function( Assert )
+	local Left = {
+		TestTable = {
+			Child = {
+				1, 2, 3, Test = true
+			},
+			Value = "123"
+		}
+	}
+	Left.TestTable.Cycle = Left
+
+	local Right = {
+		TestTable = {
+			Child = {
+				1, 2, 3, Test = true
+			},
+			Value = "123"
+		}
+	}
+	Right.TestTable.Cycle = Right
+
+	Assert:True( table.DeepEquals( Left, Right ) )
+end )
+
+UnitTest:Test( "DeepEquals - Returns false if tables are not deep-equal due to a different cycle", function( Assert )
+	local Left = {
+		TestTable = {
+			Child = {
+				1, 2, 3, Test = true
+			},
+			Value = "123"
+		}
+	}
+	Left.TestTable.Cycle = Left
+
+	local Right = {
+		TestTable = {
+			Child = {
+				1, 2, 3, Test = true
+			},
+			Value = "123"
+		}
+	}
+	Right.TestTable.Cycle = table.Copy( Right )
+
+	Assert:False( table.DeepEquals( Left, Right ) )
+end )
+
+UnitTest:Test( "DeepEquals - Returns false if tables are not deep-equal due to the left table having more keys", function( Assert )
+	local Left = {
+		TestTable = {
+			Child = {
+				1, 2, 3, Test = true
+			},
+			Value = "123"
+		}
+	}
+
+	local Right = {
+		TestTable = {
+			Child = {
+				1, 2, Test = true
+			},
+			Value = "123"
+		}
+	}
+
+	Assert:False( table.DeepEquals( Left, Right ) )
+end )
+
+UnitTest:Test( "DeepEquals - Returns false if tables are not deep-equal due to the right table having more keys", function( Assert )
+	local Left = {
+		TestTable = {
+			Child = {
+				1, 2, 3
+			},
+			Value = "123"
+		}
+	}
+
+	local Right = {
+		TestTable = {
+			Child = {
+				1, 2, 3, Test = true
+			},
+			Value = "123"
+		}
+	}
+
+	Assert:False( table.DeepEquals( Left, Right ) )
+end )
+
+UnitTest:Test( "DeepEquals - Returns false if tables are not deep-equal despite inherited keys", function( Assert )
+	local Left = {
+		TestTable = {
+			Child = {
+				1, 2, 3, Test = true
+			},
+			Value = "123"
+		}
+	}
+
+	local Right = {
+		TestTable = {
+			Child = setmetatable( {
+				1, 2, 3
+			}, { __index = { Test = true } } ),
+			Value = "123"
+		}
+	}
+
+	Assert:False( table.DeepEquals( Left, Right ) )
+
+	Left = {
+		TestTable = {
+			Child = setmetatable( {
+				1, 2, 3
+			}, { __index = { Test = true } } ),
+			Value = "123"
+		}
+	}
+
+	Right = {
+		TestTable = {
+			Child = {
+				1, 2, 3, Test = true
+			},
+			Value = "123"
+		}
+	}
+
+	Assert:False( table.DeepEquals( Left, Right ) )
+end )
+
 UnitTest:Test( "AsEnum", function( Assert )
 	local Values = {
 		"This", "Is", "An", "Enum"

--- a/test/lib/table.lua
+++ b/test/lib/table.lua
@@ -314,6 +314,24 @@ UnitTest:Test( "ArraysEqual", function( Assert )
 	Assert:False( table.ArraysEqual( Left, Right ) )
 end )
 
+UnitTest:Test( "DeepEquals - Returns true for tables that are reference-equal", function( Assert )
+	local Table = {
+		TestTable = {
+			Child = {
+				1, 2, 3, Test = true
+			},
+			Value = "123"
+		}
+	}
+	Assert:True( table.DeepEquals( Table, Table ) )
+end )
+
+UnitTest:Test( "DeepEquals - Returns true for non-table values that are equal", function( Assert )
+	Assert:True( table.DeepEquals( true, true ) )
+	Assert:True( table.DeepEquals( 1, 1 ) )
+	Assert:True( table.DeepEquals( "test", "test" ) )
+end )
+
 UnitTest:Test( "DeepEquals - Returns true if tables are deep-equal accounting for cycles", function( Assert )
 	local Left = {
 		TestTable = {
@@ -446,6 +464,46 @@ UnitTest:Test( "DeepEquals - Returns false if tables are not deep-equal despite 
 	}
 
 	Assert:False( table.DeepEquals( Left, Right ) )
+end )
+
+UnitTest:Test( "DeepEquals - Returns false if tables are not deep-equal due differing values at the same keys", function( Assert )
+	local Left = {
+		TestTable = {
+			Child = {
+				1, 2, 3
+			},
+			Value = "123"
+		}
+	}
+
+	local Right = {
+		TestTable = {
+			Child = {
+				1, 2, 4
+			},
+			Value = "123"
+		}
+	}
+
+	Assert:False( table.DeepEquals( Left, Right ) )
+end )
+
+UnitTest:Test( "DeepEquals - Returns false for values of differing types", function( Assert )
+	Assert:False( table.DeepEquals( {}, true ) )
+	Assert:False( table.DeepEquals( {}, 1 ) )
+	Assert:False( table.DeepEquals( {}, "test" ) )
+	Assert:False( table.DeepEquals( true, {} ) )
+	Assert:False( table.DeepEquals( 1, {} ) )
+	Assert:False( table.DeepEquals( "test", {} ) )
+end )
+
+UnitTest:Test( "DeepEquals - Returns false for non-table values that are not equal", function( Assert )
+	Assert:False( table.DeepEquals( false, true ) )
+	Assert:False( table.DeepEquals( 2, 1 ) )
+	Assert:False( table.DeepEquals( "test", "test2" ) )
+	Assert:False( table.DeepEquals( true, false ) )
+	Assert:False( table.DeepEquals( 1, 2 ) )
+	Assert:False( table.DeepEquals( "test2", "test" ) )
 end )
 
 UnitTest:Test( "AsEnum", function( Assert )

--- a/test/test_init.lua
+++ b/test/test_init.lua
@@ -6,10 +6,14 @@ Print( "Beginning Shine unit testing..." )
 
 local Args = { ... }
 local OnlyOutputFailingTests = false
+local Files = {}
 
 for i = 1, #Args do
-	if Args[ i ]:gsub( "%s", "" ) == "--failures-only" then
+	local Arg = Args[ i ]:gsub( "%s", "" )
+	if Arg == "--failures-only" then
 		OnlyOutputFailingTests = true
+	elseif Arg == "--test-file" then
+		Files[ #Files + 1 ] = Args[ i + 1 ]
 	end
 end
 
@@ -25,13 +29,16 @@ local getmetatable = getmetatable
 local pairs = pairs
 local pcall = pcall
 local rawequal = rawequal
+local rawget = rawget
 local select = select
 local setmetatable = setmetatable
 local StringExplode = string.Explode
 local StringFormat = string.format
+local TableArraysEqual = table.ArraysEqual
 local TableClear = require "table.clear"
 local TableConcat = table.concat
 local TableCopy = table.Copy
+local TableDeepEquals = table.DeepEquals
 local type = type
 local xpcall = xpcall
 
@@ -233,22 +240,6 @@ do
 	end
 end
 
-local function DeepEquals( Table1, Table2 )
-	if rawequal( Table1, Table2 ) then return true end
-	if type( Table1 ) ~= type( Table2 ) then return false end
-	if type( Table1 ) ~= "table" then return Table1 == Table2 end
-
-	for Key, Value in pairs( Table1 ) do
-		if not DeepEquals( Value, Table2[ Key ] ) then return false end
-	end
-
-	for Key, Value in pairs( Table2 ) do
-		if not DeepEquals( Value, Table1[ Key ] ) then return false end
-	end
-
-	return true
-end
-
 local function ArrayToString( Array )
 	return StringFormat( "{ %s }", Shine.Stream( Array ):Concat( ", " ) )
 end
@@ -286,7 +277,7 @@ UnitTest.Assert = {
 	end,
 
 	DeepEquals = function( A, B )
-		return DeepEquals( A, B ), StringFormat( "Expected %s to deep equal %s", B, A )
+		return TableDeepEquals( A, B ), StringFormat( "Expected %s to deep equal %s", B, A )
 	end,
 
 	ArrayContainsExactly = function( ExpectedValues, Actual )
@@ -299,7 +290,7 @@ UnitTest.Assert = {
 			local Expected = ExpectedValues[ i ]
 			local FoundMatch = false
 			for j = 1, #Actual do
-				if DeepEquals( Actual[ j ], Expected ) then
+				if TableDeepEquals( Actual[ j ], Expected ) then
 					FoundMatch = true
 					break
 				end
@@ -346,7 +337,7 @@ UnitTest.Assert = {
 	end,
 
 	ArrayEquals = function( A, B )
-		return table.ArraysEqual( A, B ), StringFormat( "Expected %s to match array %s",
+		return TableArraysEqual( A, B ), StringFormat( "Expected %s to match array %s",
 			ArrayToString( B ), ArrayToString( A ) )
 	end,
 
@@ -363,7 +354,7 @@ UnitTest.Assert = {
 		}
 
 		for i = 1, #Invocations do
-			if DeepEquals( Invocations[ i ], ExpectedInvocation ) then
+			if TableDeepEquals( Invocations[ i ], ExpectedInvocation ) then
 				return true
 			end
 		end
@@ -474,8 +465,9 @@ function UnitTest:Output( File )
 	return Passed, #self.Results, Duration
 end
 
-local Files = {}
-Shared.GetMatchingFileNames( "test/*.lua", true, Files )
+if #Files == 0 then
+	Shared.GetMatchingFileNames( "test/*.lua", true, Files )
+end
 
 local FinalResults = {
 	Passed = 0, Total = 0, Duration = 0

--- a/test/test_init.lua
+++ b/test/test_init.lua
@@ -29,7 +29,6 @@ local getmetatable = getmetatable
 local pairs = pairs
 local pcall = pcall
 local rawequal = rawequal
-local rawget = rawget
 local select = select
 local setmetatable = setmetatable
 local StringExplode = string.Explode


### PR DESCRIPTION
#### Badges
* Named badge lists can now be defined once in the `Badges` section of the user config and then re-used elsewhere in the file. This avoids needing to repeat the same badge list multiple times. See [the wiki for details](https://github.com/Person8880/Shine/wiki/Badges#named-badge-lists).
* Reduced performance impact when handling a large number of badges across multiple columns for users where user data is not reloaded after startup.

#### Misc
* User data is no longer reloaded and saved when user data loaded remotely does not differ from the locally cached data.