### PR TITLE
Fix friend group errors, improve welcome message tracking

### DIFF
--- a/lua/shine/extensions/voterandom/friend_groups.lua
+++ b/lua/shine/extensions/voterandom/friend_groups.lua
@@ -635,7 +635,7 @@ function Plugin:RestoreClientToFriendGroup( Client, PersistedFriendGroups )
 	local ConnectedMembers = {}
 	for i = 1, #Group.Members do
 		local MemberSteamID = Group.Members[ i ]
-		if MemberSteamID ~= SteamID then
+		if MemberSteamID ~= SteamID and MemberSteamID ~= 0 then
 			local Member = Shine.GetClientByNS2ID( MemberSteamID )
 			if Member then
 				ConnectedMembers[ #ConnectedMembers + 1 ] = Member

--- a/lua/shine/extensions/voterandom/friend_groups.lua
+++ b/lua/shine/extensions/voterandom/friend_groups.lua
@@ -629,7 +629,7 @@ end
 function Plugin:RestoreClientToFriendGroup( Client, PersistedFriendGroups )
 	local SteamID = Client:GetUserId()
 	local Group = PersistedFriendGroups[ SteamID ]
-	if not Group then return false end
+	if not Group or #Group.Members <= 1 then return false end
 
 	-- Search for the connected members of the original group and join them together.
 	local ConnectedMembers = {}
@@ -658,7 +658,7 @@ function Plugin:RestoreClientToFriendGroup( Client, PersistedFriendGroups )
 end
 
 function Plugin:HandleFriendGroupClientConnect( Client )
-	if not self.PersistedFriendGroups then return end
+	if not self.PersistedFriendGroups or Client:GetIsVirtual() then return end
 	if SharedTime() > self.Config.TeamPreferences.FriendGroupRestoreTimeoutSeconds then return end
 
 	self:RestoreClientToFriendGroup( Client, self.PersistedFriendGroups )
@@ -721,15 +721,33 @@ function Plugin:UpdateAllFriendGroupTeamPreferences()
 end
 
 do
+	local function NotVirtualClient( Client )
+		return not Client:GetIsVirtual()
+	end
+
 	local function GetUserID( Client )
 		return Client:GetUserId()
 	end
 
 	local function SerialiseGroup( Group )
+		-- Make sure if there's groups with bots in them somehow, they're not saved with the bots.
+		local HumanMembers = Shine.Stream.Of( Group.Clients ):Filter( NotVirtualClient ):Map( GetUserID ):AsTable()
+		local LeaderID = Group.Leader:GetUserId()
 		return {
-			Leader = Group.Leader:GetUserId(),
-			Members = Shine.Stream.Of( Group.Clients ):Map( GetUserID ):AsTable()
+			Leader = LeaderID == 0 and HumanMembers[ 1 ] or LeaderID,
+			Members = HumanMembers
 		}
+	end
+
+	local function IsValidGroup( Group )
+		return #Group.Members > 1
+	end
+
+	function Plugin:SerialiseFriendGroups()
+		return Shine.Stream.Of( self.FriendGroups )
+			:Map( SerialiseGroup )
+			:Filter( IsValidGroup )
+			:AsTable()
 	end
 
 	local FRIEND_GROUP_FILE = "config://shine/temp/shuffle_friend_groups.json"
@@ -739,7 +757,7 @@ do
 	local OSTime = os.time
 
 	function Plugin:SaveFriendGroups()
-		local PersistedGroups = Shine.Stream.Of( self.FriendGroups ):Map( SerialiseGroup ):AsTable()
+		local PersistedGroups = self:SerialiseFriendGroups()
 
 		Shine.SaveJSONFile( {
 			Groups = PersistedGroups,
@@ -775,7 +793,10 @@ do
 		for i = 1, #Groups do
 			local Group = Groups[ i ]
 			for j = 1, #Group.Members do
-				GroupsByMemberID[ Group.Members[ j ] ] = Group
+				local Member = Group.Members[ j ]
+				if Member ~= 0 then
+					GroupsByMemberID[ Member ] = Group
+				end
 			end
 		end
 

--- a/lua/shine/extensions/welcomemessages/server.lua
+++ b/lua/shine/extensions/welcomemessages/server.lua
@@ -201,8 +201,11 @@ function Plugin:ClientConnect( Client )
 		local Player = Client:GetControllingPlayer()
 		if not Player then return end
 
-		if not self:IsPlayerIDRemembered( ID ) then
-			self:RememberPlayerID( ID )
+		local IsBot = Client:GetIsVirtual()
+		if IsBot or not self:IsPlayerIDRemembered( ID ) then
+			if not IsBot then
+				self:RememberPlayerID( ID )
+			end
 			self:SendTranslatedNotifyColour( nil, "PLAYER_JOINED_GENERIC", {
 				R = 255, G = 255, B = 255,
 				TargetName = Player:GetName()

--- a/lua/shine/extensions/welcomemessages/server.lua
+++ b/lua/shine/extensions/welcomemessages/server.lua
@@ -19,7 +19,7 @@ Plugin.Version = "1.4"
 
 Plugin.HasConfig = true
 Plugin.ConfigName = "WelcomeMessages.json"
-Plugin.MessageDisplayHistoryFile = "config://shine/temp/welcomemessages_history.json"
+Plugin.PlayerMemoryFilePath = "config://shine/temp/welcomemessages_history.json"
 
 Plugin.DefaultConfig = {
 	MessageDelay = 5,
@@ -122,28 +122,19 @@ do
 	Plugin.ConfigValidator = Validator
 end
 
+Shine.LoadPluginModule( "player_memory.lua", Plugin )
+
 function Plugin:Initialise()
+	self:BroadcastModuleEvent( "Initialise" )
+
 	self.Welcomed = {}
-	self.AlreadyDisplayedMessages = Shine.LoadJSONFile( self.MessageDisplayHistoryFile ) or {}
 	self.Enabled = true
 
 	return true
 end
 
-function Plugin:SaveMessageDisplayHistory()
-	Shine.SaveJSONFile( self.AlreadyDisplayedMessages, self.MessageDisplayHistoryFile )
-end
-
-function Plugin:RememberMessageDisplay( ID )
-	self.AlreadyDisplayedMessages[ ID ] = true
-	self:SaveMessageDisplayHistory()
-end
-
-function Plugin:ForgetMessageDisplay( ID )
-	if not self.AlreadyDisplayedMessages[ ID ] then return end
-
-	self.AlreadyDisplayedMessages[ ID ] = nil
-	self:SaveMessageDisplayHistory()
+function Plugin:MapChange()
+	self:BroadcastModuleEvent( "MapChange" )
 end
 
 function Plugin:ShouldShowMessage( Client )
@@ -193,8 +184,8 @@ function Plugin:ClientConnect( Client )
 		local MessageTable = self.Config.Users[ ID ]
 
 		if MessageTable and MessageTable.Welcome then
-			if not self.AlreadyDisplayedMessages[ ID ] then
-				self:RememberMessageDisplay( ID )
+			if not self:IsPlayerIDRemembered( ID ) then
+				self:RememberPlayerID( ID )
 				self:DisplayMessage( MessageTable.Welcome )
 			end
 
@@ -210,17 +201,20 @@ function Plugin:ClientConnect( Client )
 		local Player = Client:GetControllingPlayer()
 		if not Player then return end
 
-		self:SendTranslatedNotifyColour( nil, "PLAYER_JOINED_GENERIC", {
-			R = 255, G = 255, B = 255,
-			TargetName = Player:GetName()
-		} )
+		if not self:IsPlayerIDRemembered( ID ) then
+			self:RememberPlayerID( ID )
+			self:SendTranslatedNotifyColour( nil, "PLAYER_JOINED_GENERIC", {
+				R = 255, G = 255, B = 255,
+				TargetName = Player:GetName()
+			} )
+		end
 	end )
 end
 
 function Plugin:ClientDisconnect( Client )
 	local ID = tostring( Client:GetUserId() )
 
-	self:ForgetMessageDisplay( ID )
+	self:ForgetPlayerID( ID )
 
 	if not self.Welcomed[ Client ] then return end
 

--- a/lua/shine/lib/player.lua
+++ b/lua/shine/lib/player.lua
@@ -657,6 +657,9 @@ local ConsoleInfo = "Console[N/A]"
 
 function Shine.GetClientInfo( Client )
 	if not Client then return ConsoleInfo end
+	if not Shine:IsValidClient( Client ) then
+		return "<Invalid>[?]"
+	end
 
 	local Player = Client:GetControllingPlayer()
 

--- a/lua/shine/modules/player_memory.lua
+++ b/lua/shine/modules/player_memory.lua
@@ -1,0 +1,65 @@
+--[[
+	Provides a basic means of tracking whether a given player ID has been processed across map changes.
+]]
+
+local Plugin = ... or _G.Plugin
+
+local Module = {}
+
+function Module:Initialise()
+	self.RememberedPlayers = Shine.LoadJSONFile( self.PlayerMemoryFilePath ) or {}
+	self.RememberedPlayersNeedSaving = false
+end
+
+function Module:GetRememberedPlayerIDs()
+	return self.RememberedPlayers
+end
+
+function Module:IsPlayerIDRemembered( ID )
+	return self:GetRememberedPlayerIDs()[ ID ]
+end
+
+function Module:RememberPlayerID( ID )
+	local RememberedPlayers = self:GetRememberedPlayerIDs()
+	if not RememberedPlayers[ ID ] then
+		-- Remember the player but defer saving until later. It's less important if an action is repeated.
+		RememberedPlayers[ ID ] = true
+		self.RememberedPlayersNeedSaving = true
+	end
+end
+
+function Module:ForgetPlayerID( ID )
+	local RememberedPlayers = self:GetRememberedPlayerIDs()
+	if RememberedPlayers[ ID ] then
+		RememberedPlayers[ ID ] = nil
+		-- Save the state on remove to ensure the associated action is performed again on next connect.
+		self:SaveRememberedPlayers()
+	end
+end
+
+function Module:SaveRememberedPlayers()
+	Shine.SaveJSONFile( self.RememberedPlayers, self.PlayerMemoryFilePath )
+	self.RememberedPlayersNeedSaving = false
+end
+
+function Module:MapChange()
+	-- Clear out any players that never connected during this map.
+	local ConnectedIDs = {}
+	for Client in Shine.IterateClients() do
+		ConnectedIDs[ tostring( Client:GetUserId() ) ] = true
+	end
+
+	local RememberedPlayers = self:GetRememberedPlayerIDs()
+	for ID in pairs( RememberedPlayers ) do
+		if not ConnectedIDs[ ID ] then
+			self.RememberedPlayersNeedSaving = true
+			RememberedPlayers[ ID ] = nil
+		end
+	end
+
+	if self.RememberedPlayersNeedSaving then
+		self:SaveRememberedPlayers()
+	end
+end
+
+Plugin:AddModule( Module )

--- a/test/extensions/voterandom/voterandom.lua
+++ b/test/extensions/voterandom/voterandom.lua
@@ -1242,6 +1242,20 @@ do
 		Assert:Equals( 1, #MockPlugin.FriendGroups )
 	end )
 
+	UnitTest:Test( "RestoreClientToFriendGroup - Does nothing if the other member is a bot", function( Assert )
+		local Client = MockClient( 123 )
+		local Bot = MockClient( 0 )
+
+		local Restored = VoteShuffle.RestoreClientToFriendGroup( MockPlugin, Client, {
+			[ 123 ] = {
+				Leader = 123,
+				Members = { 123, 0 }
+			}
+		} )
+		Assert.False( "Should not have restored the client", Restored )
+		Assert:Equals( 1, #MockPlugin.FriendGroups )
+	end )
+
 	UnitTest:Test( "RestoreClientToFriendGroup - Does nothing if all other members are in a full group", function( Assert )
 		local Client = MockClient( 123 )
 

--- a/test/extensions/voterandom/voterandom.lua
+++ b/test/extensions/voterandom/voterandom.lua
@@ -1133,6 +1133,75 @@ do
 
 	Shine.IsValidClient = OldIsValidClient
 
+	UnitTest:Test( "SerialiseFriendGroups - Saves friend groups with human members", function( Assert )
+		local SerialisedGroups = VoteShuffle.SerialiseFriendGroups( MockPlugin )
+		Assert:DeepEquals( {
+			{
+				Members = {
+					12345,
+					54321,
+					67890
+				},
+				Leader = 12345
+			}
+		}, SerialisedGroups )
+	end )
+
+	UnitTest:Test( "SerialiseFriendGroups - Omits bots from the serialised groups", function( Assert )
+		MockPlugin.FriendGroups = {
+			{
+				Leader = MockClient( 0 ),
+				Clients = {
+					MockClient( 0 ),
+					MockClient( 12345 ),
+					MockClient( 54321 )
+				}
+			}
+		}
+
+		local SerialisedGroups = VoteShuffle.SerialiseFriendGroups( MockPlugin )
+		Assert:DeepEquals( {
+			{
+				Members = {
+					12345,
+					54321
+				},
+				-- Should make the leader the first human player.
+				Leader = 12345
+			}
+		}, SerialisedGroups )
+	end )
+
+	UnitTest:Test( "SerialiseFriendGroups - Omits groups containing only a single human and a bot", function( Assert )
+		MockPlugin.FriendGroups = {
+			{
+				Leader = MockClient( 12345 ),
+				Clients = {
+					MockClient( 0 ),
+					MockClient( 12345 )
+				}
+			}
+		}
+
+		local SerialisedGroups = VoteShuffle.SerialiseFriendGroups( MockPlugin )
+		Assert:DeepEquals( {}, SerialisedGroups )
+	end )
+
+	UnitTest:Test( "SerialiseFriendGroups - Omits groups containing only bots", function( Assert )
+		MockPlugin.FriendGroups = {
+			{
+				Leader = MockClient( 0 ),
+				Clients = {
+					MockClient( 0 ),
+					MockClient( 0 )
+				}
+			}
+		}
+
+		local SerialisedGroups = VoteShuffle.SerialiseFriendGroups( MockPlugin )
+		Assert:DeepEquals( {}, SerialisedGroups )
+	end )
+
 	local OldGetClientByNS2ID = Shine.GetClientByNS2ID
 
 	function Shine.GetClientByNS2ID( ID )
@@ -1143,6 +1212,19 @@ do
 		local Client = MockClient( 123 )
 
 		local Restored = VoteShuffle.RestoreClientToFriendGroup( MockPlugin, Client, {} )
+		Assert.False( "Should not have restored the client", Restored )
+		Assert:Equals( 1, #MockPlugin.FriendGroups )
+	end )
+
+	UnitTest:Test( "RestoreClientToFriendGroup - Does nothing if the group contains only a single member", function( Assert )
+		local Client = MockClient( 123 )
+
+		local Restored = VoteShuffle.RestoreClientToFriendGroup( MockPlugin, Client, {
+			[ 123 ] = {
+				Leader = 123,
+				Members = { 123 }
+			}
+		} )
 		Assert.False( "Should not have restored the client", Restored )
 		Assert:Equals( 1, #MockPlugin.FriendGroups )
 	end )


### PR DESCRIPTION
#### Vote Shuffle
* Fixed script errors if friend groups contained bots on the previous map and those groups attempt to restore themselves.

#### Welcome Messages
* Generic welcome messages are no longer repeated every map change, only players that have not previously connected will be displayed.