### PR TITLE
Improve shuffle bot handling and pregame max player count

### DIFF
--- a/lua/shine/core/server/permissions.lua
+++ b/lua/shine/core/server/permissions.lua
@@ -408,10 +408,14 @@ do
 
 	local GameID = 0
 	local HumanPlayerCount = 0
-	local function GetHumanPlayerCount()
+	function Shine.GetHumanPlayerCount()
 		return HumanPlayerCount
 	end
-	Shine.GetHumanPlayerCount = GetHumanPlayerCount
+
+	local BotPlayerCount = 0
+	function Shine.GetBotPlayerCount()
+		return BotPlayerCount
+	end
 
 	Shine.Hook.Add( "ClientConnect", "AssignGameID", function( Client )
 		-- Make sure the same client isn't seen twice.
@@ -421,13 +425,19 @@ do
 		GameIDs:Add( Client, GameID )
 		Client.ShineGameID = GameID
 
-		HumanPlayerCount = HumanPlayerCount + ( Client:GetIsVirtual() and 0 or 1 )
+		local IsVirtual = Client:GetIsVirtual()
+
+		BotPlayerCount = BotPlayerCount + ( IsVirtual and 1 or 0 )
+		HumanPlayerCount = HumanPlayerCount + ( IsVirtual and 0 or 1 )
 	end, Shine.Hook.MAX_PRIORITY )
 
 	Shine.Hook.Add( "ClientDisconnect", "AssignGameID", function( Client )
 		if not GameIDs:Remove( Client ) then return true end
 
-		HumanPlayerCount = HumanPlayerCount - ( Client:GetIsVirtual() and 0 or 1 )
+		local IsVirtual = Client:GetIsVirtual()
+
+		BotPlayerCount = BotPlayerCount - ( IsVirtual and 1 or 0 )
+		HumanPlayerCount = HumanPlayerCount - ( IsVirtual and 0 or 1 )
 	end, Shine.Hook.MAX_PRIORITY )
 end
 

--- a/lua/shine/extensions/namefilter.lua
+++ b/lua/shine/extensions/namefilter.lua
@@ -120,12 +120,15 @@ end
 
 Plugin.FilterActions = {
 	[ Plugin.FilterActionType.RENAME ] = function( self, Player, OldName )
-		local UserName = "NSPlayer"..Random( 1e3, 1e5 )
 		local Client = Player:GetClient()
-		if not Client then return UserName end
+		if not Client then return "NSPlayer"..Random( 1e3, 1e5 ) end
+
+		-- Use the client's Steam ID as it's guaranteed to be unique.
+		local SteamID = Client:GetUserId()
+		local UserName = "NSPlayer"..SteamID
 
 		self:Print( "Client %s[%s] was renamed from filtered name: %s", true,
-			UserName, Client:GetUserId(), OldName )
+			UserName, SteamID, OldName )
 
 		return UserName
 	end,
@@ -191,8 +194,10 @@ function Plugin:ProcessFilter( Player, Name, Filter )
 
 		if not Success then
 			self.InvalidFilters[ Filter ] = true
-			self:Print( "Pattern '%s' is invalid: %s. Set \"PlainText\": true if you do not want to use a Lua pattern match.",
-				true, Pattern, StringGSub( Start, "^.+:%d+:(.+)$", "%1" ) )
+			self:Print(
+				"Pattern '%s' is invalid: %s. Set \"PlainText\": true if you do not want to use a Lua pattern match.",
+				true, Pattern, StringGSub( Start, "^.+:%d+:(.+)$", "%1" )
+			)
 			return
 		end
 	end

--- a/lua/shine/extensions/namefilter.lua
+++ b/lua/shine/extensions/namefilter.lua
@@ -213,16 +213,20 @@ end
 	Check for a forced name, and if the player has one, apply it.
 ]]
 function Plugin:EnforceName( Client )
-	local ID = Client and Client:GetUserId()
+	if not Client then return nil end
+
+	local ID = Client:GetUserId()
 	return self.Config.ForcedNames[ tostring( ID ) ]
 end
 
-
 --[[
-	When a player's name changes, we check all set filters on their new name.
+	When a player's name changes, check all set filters on their new name.
 ]]
 function Plugin:CheckPlayerName( Player, Name, OldName )
-	local ForcedName = self:EnforceName( Player:GetClient() )
+	local Client = Player:GetClient()
+	if Client and Client:GetIsVirtual() then return end
+
+	local ForcedName = self:EnforceName( Client )
 	if ForcedName then return ForcedName end
 
 	local Filters = self.Config.Filters

--- a/lua/shine/extensions/pregame/server.lua
+++ b/lua/shine/extensions/pregame/server.lua
@@ -8,6 +8,7 @@ local IsType = Shine.IsType
 local Ceil = math.ceil
 local Clamp = math.Clamp
 local Floor = math.floor
+local GetNumPlayers = Shine.GetHumanPlayerCount
 local Max = math.max
 local SharedTime = Shared.GetTime
 local StringFormat = string.format
@@ -734,7 +735,7 @@ function Plugin:IsBelowMaxPlayerLimit( Gamerules )
 
 	local MaxPlayers = self.Config.MaxPlayers
 	if MaxPlayers > 0 then
-		local NumPlayers = self:GetNumPlayersFromGamerules( Gamerules )
+		local NumPlayers = GetNumPlayers()
 		if NumPlayers > MaxPlayers then
 			if self.DisabledFromMaxPlayers or self:DisableCurrentMode( Gamerules ) then
 				return false

--- a/lua/shine/extensions/pregame/server.lua
+++ b/lua/shine/extensions/pregame/server.lua
@@ -8,7 +8,6 @@ local IsType = Shine.IsType
 local Ceil = math.ceil
 local Clamp = math.Clamp
 local Floor = math.floor
-local GetNumPlayers = Shine.GetHumanPlayerCount
 local Max = math.max
 local SharedTime = Shared.GetTime
 local StringFormat = string.format
@@ -728,6 +727,17 @@ function Plugin:DisableCurrentMode( Gamerules )
 	return true
 end
 
+do
+	-- GetNumPlayingPlayers returns the number of players in a player slot, including bots.
+	local GetNumPlayingPlayers = Server.GetNumPlayingPlayers
+	local GetBotPlayerCount = Shine.GetBotPlayerCount
+
+	function Plugin:GetTotalHumanPlayerCount()
+		-- Assume that bots are always considered "playing", doesn't make sense for a bot to spectate.
+		return GetNumPlayingPlayers() - GetBotPlayerCount()
+	end
+end
+
 function Plugin:IsBelowMaxPlayerLimit( Gamerules )
 	-- Doesn't make sense to apply a max player count if using the MIN_PLAYER_COUNT mode as it already requires two
 	-- commanders.
@@ -735,7 +745,7 @@ function Plugin:IsBelowMaxPlayerLimit( Gamerules )
 
 	local MaxPlayers = self.Config.MaxPlayers
 	if MaxPlayers > 0 then
-		local NumPlayers = GetNumPlayers()
+		local NumPlayers = self:GetTotalHumanPlayerCount()
 		if NumPlayers > MaxPlayers then
 			if self.DisabledFromMaxPlayers or self:DisableCurrentMode( Gamerules ) then
 				return false

--- a/test/extensions/namefilter.lua
+++ b/test/extensions/namefilter.lua
@@ -38,7 +38,7 @@ Plugin.Config.Filters = {
 
 UnitTest:Test( "CheckPlayerName returns new name when pattern filter matches", function( Assert )
 	local Name = Plugin:CheckPlayerName( MockPlayer, "BannedNaaaame", "NSPlayer" )
-	Assert.NotEquals( "Name should be rejected", "BannedNaaaame", Name )
+	Assert.Equals( "Name should be rejected", "NSPlayer654321", Name )
 end )
 
 UnitTest:Test( "CheckPlayerName returns nothing when pattern filter does not match", function( Assert )
@@ -47,11 +47,20 @@ UnitTest:Test( "CheckPlayerName returns nothing when pattern filter does not mat
 end )
 
 Plugin.Config.Filters = {
+	{ Pattern = "BannedN[a]+me", Excluded = USER_ID }
+}
+
+UnitTest:Test( "CheckPlayerName returns nothing when player matches the filter exclusion", function( Assert )
+	local Name = Plugin:CheckPlayerName( MockPlayer, "BannedNaaaame", "NSPlayer" )
+	Assert.Nil( "Name should be accepted", Name )
+end )
+
+Plugin.Config.Filters = {
 	{ Pattern = "BannedN[a]+me", PlainText = true }
 }
 UnitTest:Test( "CheckPlayerName returns new name when plain filter matches", function( Assert )
 	local Name = Plugin:CheckPlayerName( MockPlayer, "BannedN[a]+me", "NSPlayer" )
-	Assert.NotEquals( "Name should be rejected", "BannedN[a]+me", Name )
+	Assert.Equals( "Name should be rejected", "NSPlayer654321", Name )
 end )
 
 UnitTest:Test( "CheckPlayerName returns nothing when plain filter does not match", function( Assert )

--- a/test/extensions/namefilter.lua
+++ b/test/extensions/namefilter.lua
@@ -9,16 +9,23 @@ if not Plugin then return end
 
 Plugin = UnitTest.MockOf( Plugin )
 Plugin.Config.ForcedNames = {
-	[ "123456" ] = "Test"
+	[ "123456" ] = "Test",
+	[ "nil" ] = "Shouldn't be used"
 }
 
 local USER_ID = 123456
 local MockClient = {
-	GetUserId = function() return USER_ID end
+	GetUserId = function() return USER_ID end,
+	GetIsVirtual = function() return USER_ID == 0 end
 }
 local MockPlayer = {
 	GetClient = function() return MockClient end
 }
+
+UnitTest:Test( "EnforceName returns nil if client is nil", function( Assert )
+	local Name = Plugin:EnforceName( nil )
+	Assert.Nil( "Name should not be enforced", Name )
+end )
 
 UnitTest:Test( "EnforceName returns enforced name", function( Assert )
 	local Name = Plugin:EnforceName( MockClient )
@@ -36,6 +43,13 @@ Plugin.Config.Filters = {
 	{ Pattern = "BannedN[a]+me" }
 }
 
+USER_ID = 0
+UnitTest:Test( "CheckPlayerName returns nothing for a bot", function( Assert )
+	local Name = Plugin:CheckPlayerName( MockPlayer, "BannedNaaaame", "NSPlayer" )
+	Assert.Nil( "Name should be accepted", Name )
+end )
+
+USER_ID = 654321
 UnitTest:Test( "CheckPlayerName returns new name when pattern filter matches", function( Assert )
 	local Name = Plugin:CheckPlayerName( MockPlayer, "BannedNaaaame", "NSPlayer" )
 	Assert.Equals( "Name should be rejected", "NSPlayer654321", Name )

--- a/test/test_init.lua
+++ b/test/test_init.lua
@@ -102,7 +102,10 @@ function UnitTest.MakeMockClient( SteamID )
 				GetName = function() return "Test" end
 			}
 		end,
-		GetIsVirtual = function() return SteamID == 0 end
+		GetIsVirtual = function() return SteamID == 0 end,
+		bot = SteamID == 0 and {
+			Disconnect = UnitTest.MockFunction()
+		} or nil
 	}
 end
 


### PR DESCRIPTION
#### Badges
* Improved resiliency to changes in loading order when assigning names to badges.

#### Name Filter
* Improved the `RENAME` filter action to avoid duplicate names.

#### Pregame
* The `MaxPlayers` option now applies to the number of players on the server that are not in spectate, rather than the number of players on playing teams.

#### Vote Shuffle
* Fixed bots sometimes preventing human players from being assigned to teams when `ApplyToBots` is `true`.