### PR TITLE
tweak: Fix debug lib usage for build 343

### DIFF
--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -8,7 +8,7 @@ local Shine = Shine
 
 local Clamp = math.Clamp
 local DebugGetInfo = debug.getinfo
-local DebugGetMetaTable = debug.getmetatable
+local DebugGetMetaField = debug.getmetafield
 local DebugSetUpValue = debug.setupvalue
 local Huge = math.huge
 local IsCallable = Shine.IsCallable
@@ -280,9 +280,9 @@ local function GetNumArguments( Func )
 	local Offset = 0
 	if IsType( Func, "table" ) then
 		-- Handle callable tables here too.
-		local Meta = DebugGetMetaTable( Func )
-		if Meta and IsType( Meta.__call, "function" ) then
-			Func = Meta.__call
+		local MetaFunc = DebugGetMetaField(Func, "__call")
+		if MetaFunc and IsType( MetaFunc, "function" ) then
+			Func = MetaFunc
 			-- __call has a self argument which isn't seen by the caller.
 			Offset = 1
 		else

--- a/lua/shine/lib/debug.lua
+++ b/lua/shine/lib/debug.lua
@@ -5,10 +5,11 @@
 local assert = assert
 local DebugGetInfo = debug.getinfo
 local DebugGetLocal = debug.getlocal
-local DebugGetMetaTable = debug.getmetatable
+local DebugGetMetaField = debug.getmetafield
 local DebugGetUpValue = debug.getupvalue
 local DebugSetUpValue = debug.setupvalue
 local DebugUpValueJoin = debug.upvaluejoin
+local DebugIsCFunction = debug.iscfunction
 local pairs = pairs
 local StringFormat = string.format
 local StringStartsWith = string.StartsWith
@@ -30,7 +31,7 @@ local function ForEachUpValue( Func, Filter, Recursive, Done )
 			return Val, i, Func
 		end
 
-		if Recursive and not Done[ Val ] and type( Val ) == "function" then
+		if Recursive and not Done[ Val ] and type( Val ) == "function" and not DebugIsCFunction( Val ) then
 			local LowerVal, j, Function = ForEachUpValue( Val, Filter, true, Done )
 			if LowerVal ~= nil then
 				return LowerVal, j, Function
@@ -297,8 +298,8 @@ end
 function Shine.IsCallable( Object )
 	if type( Object ) == "function" then return true end
 
-	local Meta = DebugGetMetaTable( Object )
-	return not not ( Meta and type( Meta.__call ) == "function" )
+	local MetaCallField = DebugGetMetaField( Object, "__call")
+	return not not ( MetaCallField and type(MetaCallField) == "function" )
 end
 
 --[[

--- a/lua/shine/lib/table.lua
+++ b/lua/shine/lib/table.lua
@@ -627,7 +627,7 @@ do
 		return KeyValueIterator( Keys, Table )
 	end
 
-	local DebugGetMetatable = debug.getmetatable
+	local DebugGetMetaField = debug.getmetafield
 	local tostring = tostring
 	local type = type
 
@@ -643,12 +643,12 @@ do
 		-- Identical types on either side, and comparable (e.g. number vs number).
 		if LeftType == RightType and ComparableTypes[ LeftType ] then return true end
 
-		local LeftMeta = DebugGetMetatable( A )
-		local RightMeta = DebugGetMetatable( B )
+		local LeftMeta = DebugGetMetaField ( A, "__lt" )
+		local RightMeta = DebugGetMetaField ( B, "__lt" )
 
 		-- Two Lua objects are comparable if the appropriate meta-methods are the same on
 		-- the objects on either side. In this case we only need __lt.
-		if LeftMeta and LeftMeta.__lt and RightMeta and RightMeta.__lt == LeftMeta.__lt then
+		if LeftMeta and RightMeta and RightMeta == LeftMeta then
 			return true
 		end
 


### PR DESCRIPTION
New lua sandbox of the upcoming ns2 build 343 does not allow access to debug.getmetatable and C-functions anymore.

The new ns2 build is available for testing at the steam beta branch.