### PR TITLE
Fix shuffle team preference history and fix ban data conversion

### DIFF
--- a/lua/shine/extensions/ban/server.lua
+++ b/lua/shine/extensions/ban/server.lua
@@ -158,7 +158,7 @@ function Plugin:LoadBansFromWeb()
 		if BansData.Banned then
 			Edited = true
 			self.Config.Banned = BansData.Banned
-		elseif BansData[ 1 ] and BanData[ 1 ].id then
+		elseif BansData[ 1 ] and BansData[ 1 ].id then
 			Edited = true
 			self.Config.Banned = self:NS2ToShine( BansData )
 		end

--- a/lua/shine/extensions/voterandom/team_balance.lua
+++ b/lua/shine/extensions/voterandom/team_balance.lua
@@ -800,13 +800,9 @@ function BalanceModule:OptimiseTeams( TeamMembers, RankFunc, TeamSkills )
 	self.Logger:Debug( "After optimisation:" )
 	self.Logger:IfDebugEnabled( DebugLogTeamMembers, self, TeamMembers )
 
-	if self:ShouldOptimiseHappiness( TeamMembers ) then
-		self:OptimiseHappiness( TeamMembers )
-
+	if self:OptimiseHappiness( TeamMembers ) then
 		self.Logger:Debug( "After happiness optimisation:" )
 		self.Logger:IfDebugEnabled( DebugLogTeamMembers, self, TeamMembers )
-	else
-		self.LastShufflePreferences = nil
 	end
 end
 
@@ -849,12 +845,13 @@ function BalanceModule:OptimiseHappiness( TeamMembers )
 
 	-- If there are more weighted unhappy players than happy, swap the teams around entirely.
 	-- This will put all the people who are not happy with their team onto the team they want, and vice-versa.
-	if TotalHappiness < 0 then
+	if TotalHappiness < 0 and self:ShouldOptimiseHappiness( TeamMembers ) then
 		self.Logger:Debug( "Swapping teams due to happiness..." )
 		TeamMembers[ 1 ], TeamMembers[ 2 ] = TeamMembers[ 2 ], TeamMembers[ 1 ]
+		return true, TotalHappiness
 	end
 
-	return TotalHappiness
+	return false, TotalHappiness
 end
 
 function BalanceModule:ComputeTeamSkills( TeamMembers, RankFunc )

--- a/test/extensions/voterandom/voterandom.lua
+++ b/test/extensions/voterandom/voterandom.lua
@@ -300,7 +300,9 @@ UnitTest:Test( "OptimiseHappiness - More unhappiness swaps teams", function( Ass
 		-- Player 4 is neutral
 	}
 
-	Assert:Equals( -1, VoteShuffle:OptimiseHappiness( TeamMembers ) )
+	local Swapped, TotalHappiness = VoteShuffle:OptimiseHappiness( TeamMembers )
+	Assert:True( Swapped )
+	Assert:Equals( -1, TotalHappiness )
 	Assert:Equals( Team2, TeamMembers[ 1 ] )
 	Assert:Equals( Team1, TeamMembers[ 2 ] )
 	Assert:TableEquals( {
@@ -309,6 +311,39 @@ UnitTest:Test( "OptimiseHappiness - More unhappiness swaps teams", function( Ass
 		[ 3 ] = 1
 	}, VoteShuffle.LastShufflePreferences )
 end )
+
+VoteShuffle.Config.BalanceModeConfig[ VoteShuffle.ShuffleMode.HIVE ].UseTeamSkill = true
+
+UnitTest:Test( "OptimiseHappiness - More unhappiness with per-team skills does not swap teams but does record preferences", function( Assert )
+	local TeamMembers = {
+		{ FakePlayer( 1 ), FakePlayer( 2 ) },
+		{ FakePlayer( 3 ), FakePlayer( 4 ) },
+	}
+	local Team1 = TeamMembers[ 1 ]
+	local Team2 = TeamMembers[ 2 ]
+	TeamMembers.TeamPreferences = {
+		-- Player 1 is unhappy
+		[ Team1[ 1 ] ] = 2,
+		-- Player 2 is happy
+		[ Team1[ 2 ] ] = 1,
+		-- Player 3 is unhappy
+		[ Team2[ 1 ] ] = 1
+		-- Player 4 is neutral
+	}
+
+	local Swapped, TotalHappiness = VoteShuffle:OptimiseHappiness( TeamMembers )
+	Assert:False( Swapped )
+	Assert:Equals( -1, TotalHappiness )
+	Assert:Equals( Team1, TeamMembers[ 1 ] )
+	Assert:Equals( Team2, TeamMembers[ 2 ] )
+	Assert:TableEquals( {
+		[ 1 ] = 2,
+		[ 2 ] = 1,
+		[ 3 ] = 1
+	}, VoteShuffle.LastShufflePreferences )
+end )
+
+VoteShuffle.Config.BalanceModeConfig[ VoteShuffle.ShuffleMode.HIVE ].UseTeamSkill = false
 
 UnitTest:Test( "OptimiseHappiness - Less unhappiness does nothing", function( Assert )
 	local TeamMembers = {
@@ -327,7 +362,9 @@ UnitTest:Test( "OptimiseHappiness - Less unhappiness does nothing", function( As
 		-- Player 4 is neutral
 	}
 
-	Assert:Equals( 1, VoteShuffle:OptimiseHappiness( TeamMembers ) )
+	local Swapped, TotalHappiness = VoteShuffle:OptimiseHappiness( TeamMembers )
+	Assert:False( Swapped )
+	Assert:Equals( 1, TotalHappiness )
 	Assert:Equals( Team1, TeamMembers[ 1 ] )
 	Assert:Equals( Team2, TeamMembers[ 2 ] )
 	Assert:TableEquals( {


### PR DESCRIPTION
#### Bans
* Fixed error when converting NS2 ban format from remote ban data.

#### Vote Shuffle
* Fixed historic team preferences not being recorded as expected, resulting in team preferences not being weighted properly.