### PR TITLE
Add tweaks plugin that adds minimap location highlighting

### DIFF
--- a/locale/shine/core/enGB.json
+++ b/locale/shine/core/enGB.json
@@ -95,5 +95,10 @@
 	"WARNING_UNREGISTERED_PLUGINS": "Some plugins failed to load as they have not been registered: {Context}",
 	"INFO_PLUGIN_VERSION_UPDATE": "Plugin version updated to {Context}.",
 
-	"ADMIN_MENU_STATUS_TAB": "Status"
+	"ADMIN_MENU_STATUS_TAB": "Status",
+
+	"CLIENT_CONFIG_RESET_TO_DEFAULT_BUTTON_TOOLTIP": "Reset to Default",
+	"RED_SLIDER_LABEL": "Red",
+	"GREEN_SLIDER_LABEL": "Green",
+	"BLUE_SLIDER_LABEL": "Blue"
 }

--- a/locale/shine/extensions/tweaks/enGB.json
+++ b/locale/shine/extensions/tweaks/enGB.json
@@ -1,4 +1,8 @@
 {
+	"CLIENT_CONFIG_TAB": "Tweaks",
+	"ALIEN_HIGHLIGHT_COLOUR_DESCRIPTION": "Alien Highlight Colour:",
+	"MARINE_HIGHLIGHT_COLOUR_DESCRIPTION": "Marine Highlight Colour:",
+	"HOSTILE_HIGHLIGHT_COLOUR_DESCRIPTION": "Hostile Highlight Colour:",
 	"CLIENT_PLUGIN_NAME": "Tweaks",
 	"CLIENT_PLUGIN_DESCRIPTION": "Provides the following minor tweaks:\n* Highlights the current location when looking at the minimap as a marine or alien."
 }

--- a/locale/shine/extensions/tweaks/enGB.json
+++ b/locale/shine/extensions/tweaks/enGB.json
@@ -1,8 +1,8 @@
 {
 	"CLIENT_CONFIG_TAB": "Tweaks",
-	"ALIEN_HIGHLIGHT_COLOUR_DESCRIPTION": "Alien Highlight Colour:",
-	"MARINE_HIGHLIGHT_COLOUR_DESCRIPTION": "Marine Highlight Colour:",
-	"HOSTILE_HIGHLIGHT_COLOUR_DESCRIPTION": "Hostile Highlight Colour:",
+	"ALIEN_HIGHLIGHT_COLOUR_DESCRIPTION": "Alien minimap highlight colour:",
+	"MARINE_HIGHLIGHT_COLOUR_DESCRIPTION": "Marine minimap highlight colour:",
+	"HOSTILE_HIGHLIGHT_COLOUR_DESCRIPTION": "Hostile minimap highlight colour:",
 	"CLIENT_PLUGIN_NAME": "Tweaks",
 	"CLIENT_PLUGIN_DESCRIPTION": "Provides the following minor tweaks:\n* Highlights the current location when looking at the minimap as a marine or alien."
 }

--- a/locale/shine/extensions/tweaks/enGB.json
+++ b/locale/shine/extensions/tweaks/enGB.json
@@ -1,0 +1,4 @@
+{
+	"CLIENT_PLUGIN_NAME": "Tweaks",
+	"CLIENT_PLUGIN_DESCRIPTION": "Provides the following minor tweaks:\n* Highlights the current location when looking at the minimap as a marine or alien."
+}

--- a/lua/shine/core/client/config_gui.lua
+++ b/lua/shine/core/client/config_gui.lua
@@ -541,6 +541,7 @@ ConfigMenu:AddTab( Locale:GetPhrase( "Core", "SETTINGS_TAB" ), {
 				local ElementsByKey = {}
 				local SettingsWithBindings = {}
 				local Dropdowns = {}
+				local ColourPickers = {}
 
 				for i = 1, #Settings do
 					local Setting = Settings[ i ]
@@ -550,6 +551,8 @@ ConfigMenu:AddTab( Locale:GetPhrase( "Core", "SETTINGS_TAB" ), {
 
 					if Setting.Type == "Dropdown" then
 						Dropdowns[ #Dropdowns + 1 ] = ValueHolder
+					elseif Setting.Type == "Colour" then
+						ColourPickers[ #ColourPickers + 1 ] = ValueHolder
 					end
 
 					local TranslationSource = Setting.TranslationSource or "Core"
@@ -672,6 +675,14 @@ ConfigMenu:AddTab( Locale:GetPhrase( "Core", "SETTINGS_TAB" ), {
 						local Dropdown = Dropdowns[ i ]
 						if SGUI.IsValid( Dropdown ) then
 							Dropdown:DestroyMenu()
+						end
+					end
+
+					-- Do the same for colour picker popups, even though they should have been closed already.
+					for i = 1, #ColourPickers do
+						local ColourPicker = ColourPickers[ i ]
+						if SGUI.IsValid( ColourPicker ) then
+							ColourPicker:DestroyPopup()
 						end
 					end
 				end )

--- a/lua/shine/core/client/config_gui.lua
+++ b/lua/shine/core/client/config_gui.lua
@@ -441,8 +441,21 @@ local SettingsTypes = {
 				UpdateWithCommand( DefaultValue[ 1 ], DefaultValue[ 2 ], DefaultValue[ 3 ] )
 			end
 
+			local function ToIntColour( Value )
+				return Round( Value.r * 255 ), Round( Value.g * 255 ), Round( Value.b * 255 )
+			end
+
+			-- Disable the reset button if already using the default value.
+			Binder():FromElement( Tree.ColourPicker, "Value" )
+				:ToElement( Tree.ResetButton, "Enabled", {
+					Transformer = function( Value )
+						local R, G, B = ToIntColour( Value )
+						return R ~= DefaultValue[ 1 ] or G ~= DefaultValue[ 2 ] or B ~= DefaultValue[ 3 ]
+					end
+				} ):BindProperty()
+
 			function Tree.ColourPicker:OnValueChanged( Value )
-				local R, G, B = Round( Value.r * 255 ), Round( Value.g * 255 ), Round( Value.b * 255 )
+				local R, G, B = ToIntColour( Value )
 				UpdateWithCommand( R, G, B )
 			end
 

--- a/lua/shine/core/shared/base_plugin/config.lua
+++ b/lua/shine/core/shared/base_plugin/config.lua
@@ -347,6 +347,14 @@ if Client then
 				Default = function() return not self.Config[ ConfigKey ] end
 			}
 		end,
+		Colour = function( self, ConfigKey, Command, Options )
+			Command:AddParam{
+				Type = "colour",
+				TakeRestOfLine = true,
+				Optional = true,
+				Default = self.DefaultConfig[ ConfigKey ]
+			}
+		end,
 		Radio = function( self, ConfigKey, Command, Options )
 			Command:AddParam{
 				Type = "enum",
@@ -501,7 +509,8 @@ if Client then
 				Icon = Group.Icon
 			},
 			Tooltip = Tooltip,
-			OptionTooltips = OptionTooltips
+			OptionTooltips = OptionTooltips,
+			DefaultValue = self.DefaultConfig[ ConfigKey ]
 		} )
 
 		local PostProcessor = PostProcessors[ Options.Type ]

--- a/lua/shine/core/shared/commands.lua
+++ b/lua/shine/core/shared/commands.lua
@@ -231,7 +231,7 @@ Shine.CommandUtil.ParamTypes = {
 			local Components = StringExplode( String, "[%s,]" )
 			local Colour = { 255, 255, 255 }
 			for i = 1, 3 do
-				Colour[ i ] = MathsClamp( MathsFloor( tonumber( Components[ i ] ) ) or 255, 0, 255 )
+				Colour[ i ] = MathsClamp( MathsFloor( tonumber( Components[ i ] ) or 255 ), 0, 255 )
 			end
 			return Colour
 		end,

--- a/lua/shine/core/shared/commands.lua
+++ b/lua/shine/core/shared/commands.lua
@@ -14,7 +14,10 @@ Shared.RegisterNetworkMessage( "Shine_TranslatedCommandError", {
 } )
 
 local IsType = Shine.IsType
-local MathClamp = math.ClampEx
+local MathsClamp = math.Clamp
+local MathsClampEx = math.ClampEx
+local MathsFloor = math.floor
+local StringExplode = string.Explode
 local StringFormat = string.format
 local StringToTime = string.ToTime
 local StringUpper = string.upper
@@ -147,7 +150,7 @@ Shine.CommandUtil.ParamTypes = {
 	-- the given min and max if set. Also rounds if asked.
 	number = {
 		Parse = function( Client, String, Table )
-			local Num = MathClamp( tonumber( String ), Table.Min, Table.Max )
+			local Num = MathsClampEx( tonumber( String ), Table.Min, Table.Max )
 
 			if not Num then
 				return GetDefault( Table )
@@ -173,7 +176,7 @@ Shine.CommandUtil.ParamTypes = {
 				end
 			end
 
-			Time = MathClamp( Time, Table.Min, Table.Max )
+			Time = MathsClampEx( Time, Table.Min, Table.Max )
 
 			return Table.Round and Round( Time ) or Time
 		end,
@@ -217,6 +220,22 @@ Shine.CommandUtil.ParamTypes = {
 		GetAutoCompletions = function( Arg )
 			return Arg.Values
 		end
+	},
+	colour = {
+		Parse = function( Client, String, Table )
+			if not String or String == "" then
+				return GetDefault( Table )
+			end
+
+			-- Accept comma and/or spaces as separators (spaces can be used if TakeRestOfLine is enabled on the arg).
+			local Components = StringExplode( String, "[%s,]" )
+			local Colour = { 255, 255, 255 }
+			for i = 1, 3 do
+				Colour[ i ] = MathsClamp( MathsFloor( tonumber( Components[ i ] ) ) or 255, 0, 255 )
+			end
+			return Colour
+		end,
+		Help = "colour"
 	}
 }
 
@@ -251,7 +270,7 @@ do
 			end
 
 			local TeamNumber = tonumber( String )
-			if TeamNumber then return MathClamp( Round( TeamNumber ), 0, 3 ) end
+			if TeamNumber then return MathsClampEx( Round( TeamNumber ), 0, 3 ) end
 
 			String = StringLower( String )
 

--- a/lua/shine/core/shared/extensions.lua
+++ b/lua/shine/core/shared/extensions.lua
@@ -1025,4 +1025,4 @@ Hook.Add( "OnMapLoad", "AutoLoadExtensions", function()
 			end
 		end
 	end
-end, Shine.Hook.MAX_PRIORITY )
+end, Shine.Hook.MAX_PRIORITY + 1 )

--- a/lua/shine/extensions/tweaks/client.lua
+++ b/lua/shine/extensions/tweaks/client.lua
@@ -2,9 +2,12 @@
 	Misc tweaks.
 ]]
 
+local RenderPipeline = require "shine/lib/gui/util/pipeline"
+
 local Max = math.max
 local Min = math.min
 local StringFormat = string.format
+local TableEmpty = table.Empty
 
 local Plugin = Shine.Plugin( ... )
 
@@ -45,8 +48,27 @@ Shine.Hook.CallAfterFileLoad( "lua/GUIMinimap.lua", function()
 	Shine.Hook.SetupClassHook( "GUIMinimap", "UpdatePlayerIcon", "OnGUIMinimapUpdatePlayerIcon", "PassivePost" )
 end )
 
+local MINIMAP_WIDTH, MINIMAP_HEIGHT = 1024, 1024
+
 function Plugin:Initialise()
 	self.Minimaps = Shine.Set()
+
+	local BlurPipeline = RenderPipeline.ApplyBlurToNode( {
+		Width = MINIMAP_WIDTH,
+		Height = MINIMAP_HEIGHT,
+		BlurRadius = 8,
+		NodeToBlur = RenderPipeline.GUIViewNode {
+			View = Shine.GetPluginFile( self:GetName(), "minimap_view.lua" ),
+			Input = {}
+		}
+	} )
+	self.HighlightPipeline = BlurPipeline:CopyWithAdditionalNodes( {
+		RenderPipeline.GUIViewNode {
+			View = Shine.GetPluginFile( self:GetName(), "minimap_blend_view.lua" ),
+			Input = {}
+		}
+	} )
+
 	return true
 end
 
@@ -88,42 +110,115 @@ function Plugin:GetLocationsForName( Name )
 	return self.LocationIndex:Get( Name )
 end
 
-local TARGET_TEXTURE_NAME = "*shine_tweaks_minimap_highlights"
-local TextureCount = 0
-local function GetMinimapTexture()
-	TextureCount = TextureCount + 1
-	return TARGET_TEXTURE_NAME..TextureCount
-end
-
 function Plugin:SetupMinimap( Minimap )
 	if self.Minimaps:Contains( Minimap ) then return end
 
 	local MinimapItem = Minimap.minimap
-	if not Minimap.HighlightView then
-		local Width, Height = 1024, 1024
-
-		local TextureName = GetMinimapTexture()
-		Minimap.HighlightViewTexture = TextureName
-
-		Minimap.HighlightView = Client.CreateGUIView( Width, Height )
-		Minimap.HighlightView:Load( Shine.GetPluginFile( self:GetName(), "minimap_view.lua" ) )
-		Minimap.HighlightView:SetGlobal( "MinimapTexture", MinimapItem:GetTexture() )
-		Minimap.HighlightView:SetGlobal( "Width", Width )
-		Minimap.HighlightView:SetGlobal( "Height", Height )
-		Minimap.HighlightView:SetGlobal( "NeedsRefresh", 1 )
-		Minimap.HighlightView:SetTargetTexture( TextureName )
-		Minimap.HighlightView:SetRenderCondition( GUIView.RenderOnce )
+	if not Minimap.HighlightPipeline then
+		Minimap.HighlightPipeline = self.HighlightPipeline:Copy()
+		Minimap.HighlightPipeline.Minimap = Minimap
 	end
 
 	if not Minimap.HighlightItem then
 		Minimap.HighlightItem = GUIManager:CreateGraphicItem()
+		Minimap.HighlightItem:SetInheritsParentAlpha( true )
 		Minimap.HighlightItem:SetSize( MinimapItem:GetSize() )
-		Minimap.HighlightItem:SetTexture( Minimap.HighlightViewTexture )
+		Minimap.HighlightItem:SetInheritsParentStencilSettings( false )
+		Minimap.HighlightItem:SetStencilFunc( GUIItem.Always )
 		Minimap.HighlightItem:SetIsVisible( false )
 		MinimapItem:AddChild( Minimap.HighlightItem )
 	end
 
+	Minimap.HighlightStencilBoxes = Minimap.HighlightStencilBoxes or {}
+
 	self.Minimaps:Add( Minimap )
+end
+
+local function GetStencilBox( Minimap, Index )
+	local Box = Minimap.HighlightStencilBoxes[ Index ]
+	if not Box then
+		Box = GUIManager:CreateGraphicItem()
+		Box:SetInheritsParentAlpha( false )
+		Box:SetInheritsParentStencilSettings( false )
+		Box:SetIsStencil( true )
+		Box:SetClearsStencilBuffer( Index == 1 )
+		Box:SetAnchor( GUIItem.Middle, GUIItem.Center )
+		Box:SetLayer( -100 )
+		Minimap.background:AddChild( Box )
+		Minimap.HighlightStencilBoxes[ Index ] = Box
+	end
+	return Box
+end
+
+local function GetLocationForHighlightOnMinimap( Minimap )
+	if Minimap.comMode ~= GUIMinimapFrame.kModeBig or PlayerUI_IsOverhead() then
+		return nil
+	end
+
+	local LocationName = PlayerUI_GetLocationName()
+	if not LocationName or LocationName == "" then
+		return nil
+	end
+
+	return LocationName
+end
+
+local function OnRefreshComplete( HighlightViewTexture, Pipeline )
+	local Minimap = Pipeline.Minimap
+	if not Minimap.HighlightItem or not Minimap.StencilBoxParams then return end
+
+	for i = 1, #Minimap.StencilBoxParams do
+		local Params = Minimap.StencilBoxParams[ i ]
+		local Box = GetStencilBox( Minimap, i )
+		Box:SetPosition( Vector2( math.floor( Params.X ), math.floor( Params.Y ) ) )
+		Box:SetSize( Vector2( math.ceil( Params.W ), math.ceil( Params.H ) ) )
+		Box:SetIsVisible( true )
+		Box:SetIsStencil( true )
+	end
+
+	for i = #Minimap.StencilBoxParams + 1, #Minimap.HighlightStencilBoxes do
+		Minimap.HighlightStencilBoxes[ i ]:SetIsVisible( false )
+		Minimap.HighlightStencilBoxes[ i ]:SetIsStencil( false )
+	end
+
+	Minimap.StencilBoxParams = nil
+end
+
+local function OnMinimapHighlightRenderCompleted( OutputTexture, Pipeline )
+	local Minimap = Pipeline.Minimap
+	Minimap.HighlightPipelineContext = nil
+
+	if not Minimap.HighlightItem then
+		OutputTexture:Free()
+		return
+	end
+
+	local TextureName = OutputTexture:GetName()
+	Minimap.HighlightViewTexture = OutputTexture
+	Minimap.HighlightItem:SetTexture( TextureName )
+	Minimap.HighlightItem:SetIsVisible( not not GetLocationForHighlightOnMinimap( Minimap ) )
+
+	OnRefreshComplete( OutputTexture, Pipeline )
+end
+
+function Plugin:RefreshMinimapHighlightTexture( Minimap, StencilBoxParams )
+	Minimap.StencilBoxParams = StencilBoxParams
+
+	if Minimap.HighlightPipelineContext then
+		-- Not finished rendering for the first time, start again.
+		Minimap.HighlightPipelineContext:Restart()
+	elseif Minimap.HighlightViewTexture then
+		-- Previously rendered, trigger a refresh of the texture.
+		Minimap.HighlightViewTexture:Refresh( OnRefreshComplete )
+	else
+		-- Not rendered yet, trigger the first render.
+		Minimap.HighlightPipelineContext = RenderPipeline.Execute(
+			Minimap.HighlightPipeline,
+			MINIMAP_WIDTH,
+			MINIMAP_HEIGHT,
+			OnMinimapHighlightRenderCompleted
+		)
+	end
 end
 
 local function HideLocationBoxes( Minimap )
@@ -133,15 +228,13 @@ local function HideLocationBoxes( Minimap )
 end
 
 local HostileColour = Colour( 1, 0, 0 )
+local function Input( Key, Value )
+	return { Key = Key, Value = Value }
+end
 
 function Plugin:OnGUIMinimapUpdatePlayerIcon( Minimap )
-	if Minimap.comMode ~= GUIMinimapFrame.kModeBig or PlayerUI_IsOverhead() then
-		HideLocationBoxes( Minimap )
-		return
-	end
-
-	local LocationName = PlayerUI_GetLocationName()
-	if not LocationName or LocationName == "" then
+	local LocationName = GetLocationForHighlightOnMinimap( Minimap )
+	if not LocationName then
 		HideLocationBoxes( Minimap )
 		return
 	end
@@ -150,7 +243,7 @@ function Plugin:OnGUIMinimapUpdatePlayerIcon( Minimap )
 	self:SetupMinimap( Minimap )
 
 	Minimap.HighlightItem:SetSize( Minimap.minimap:GetSize() )
-	Minimap.HighlightItem:SetIsVisible( true )
+	Minimap.HighlightItem:SetIsVisible( not not Minimap.HighlightViewTexture )
 
 	local TeamNumber = PlayerUI_GetTeamNumber()
 	local IsMarine = TeamNumber == kMarineTeamType
@@ -197,16 +290,25 @@ function Plugin:OnGUIMinimapUpdatePlayerIcon( Minimap )
 		BackgroundColour = Colour( 1, 1, 1, 1 )
 	end
 
-	BackgroundColour.a = 0.3
-
 	-- Locations are composed of multiple trigger entities, so draw a box for each one.
 	local Locations = self:GetLocationsForName( LocationName )
 	local NumLocations = #Locations
-	local HighlightView = Minimap.HighlightView
 	local Size = Minimap.HighlightItem:GetSize()
 
-	HighlightView:SetGlobal( "NumBoxes", NumLocations )
-	HighlightView:SetGlobal( "HighlightColour", BackgroundColour )
+	local MinimapNodeInput = Minimap.HighlightPipeline.Nodes[ 1 ].Input
+	local BlendNodeInput = Minimap.HighlightPipeline.Nodes[ 4 ].Input
+	TableEmpty( MinimapNodeInput )
+	TableEmpty( BlendNodeInput )
+
+	MinimapNodeInput[ 1 ] = Input( "MinimapTexture", Minimap.minimap:GetTexture() )
+	BlendNodeInput[ 1 ] = MinimapNodeInput[ 1 ]
+	MinimapNodeInput[ 2 ] = Input( "NumBoxes", NumLocations )
+	BlendNodeInput[ 2 ] = MinimapNodeInput[ 2 ]
+	MinimapNodeInput[ 3 ] = Input( "HighlightColour", BackgroundColour )
+	BlendNodeInput[ 3 ] = Input( "BackgroundTexture", RenderPipeline.TextureInput )
+
+	local Count = 3
+	local StencilBoxParams = {}
 
 	for i = 1, NumLocations do
 		local Location = Locations[ i ]
@@ -222,14 +324,37 @@ function Plugin:OnGUIMinimapUpdatePlayerIcon( Minimap )
 		local Width = BottomRightX - TopLeftX
 		local Height = BottomRightY - TopLeftY
 
-		HighlightView:SetGlobal( "X"..i, TopLeftX / Size.x * 1024 )
-		HighlightView:SetGlobal( "Y"..i, TopLeftY / Size.y * 1024 )
-		HighlightView:SetGlobal( "W"..i, Width / Size.x * 1024 )
-		HighlightView:SetGlobal( "H"..i, Height / Size.y * 1024 )
+		-- TODO: Make GUIView texture size and box co-ordinates reflect the minimap item's size to avoid precision
+		-- differences causing gaps in the rendering.
+		local X = math.floor( TopLeftX ) / Size.x * MINIMAP_WIDTH
+		local Y = math.floor( TopLeftY ) / Size.y * MINIMAP_HEIGHT
+		local W = math.ceil( Width ) / Size.x * MINIMAP_WIDTH
+		local H = math.ceil( Height ) / Size.y * MINIMAP_HEIGHT
+
+		Count = Count + 1
+		MinimapNodeInput[ Count ] = Input( "X"..i, X )
+		BlendNodeInput[ Count ] = MinimapNodeInput[ Count ]
+		Count = Count + 1
+		MinimapNodeInput[ Count ] = Input( "Y"..i, Y )
+		BlendNodeInput[ Count ] = MinimapNodeInput[ Count ]
+		Count = Count + 1
+		MinimapNodeInput[ Count ] = Input( "W"..i, W )
+		BlendNodeInput[ Count ] = MinimapNodeInput[ Count ]
+		Count = Count + 1
+		MinimapNodeInput[ Count ] = Input( "H"..i, H )
+		BlendNodeInput[ Count ] = MinimapNodeInput[ Count ]
+
+		StencilBoxParams[ i ] = {
+			X = TopLeftX,
+			Y = TopLeftY,
+			W = Width,
+			H = Height
+		}
 	end
 
-	HighlightView:SetGlobal( "NeedsRefresh", 1 )
-	HighlightView:SetRenderCondition( GUIView.RenderOnce )
+	Minimap.minimap:SetStencilFunc( GUIItem.Equal )
+
+	self:RefreshMinimapHighlightTexture( Minimap, StencilBoxParams )
 end
 
 function Plugin:Cleanup()
@@ -239,17 +364,34 @@ function Plugin:Cleanup()
 			Minimap.HighlightItem = nil
 		end
 
-		if Minimap.HighlightView then
-			Client.DestroyGUIView( Minimap.HighlightView )
-			Minimap.HighlightView = nil
+		if Minimap.HighlightStencilBoxes then
+			for i = 1, #Minimap.HighlightStencilBoxes do
+				GUI.DestroyItem( Minimap.HighlightStencilBoxes[ i ] )
+				Minimap.HighlightStencilBoxes[ i ] = nil
+			end
+			Minimap.HighlightStencilBoxes = nil
 		end
 
+		if Minimap.HighlightViewTexture then
+			Minimap.HighlightViewTexture:Free()
+			Minimap.HighlightViewTexture = nil
+		end
+
+		if Minimap.HighlightPipelineContext then
+			Minimap.HighlightPipelineContext:Terminate()
+			Minimap.HighlightPipelineContext:RemoveHooks()
+			Minimap.HighlightPipelineContext = nil
+		end
+
+		Minimap.minimap:SetStencilFunc( Minimap.stencilFunc or GUIItem.Always )
+
+		Minimap.HighlightPipeline = nil
 		Minimap.LastLocationName = nil
 		Minimap.LastPowered = nil
-		Minimap.HighlightViewTexture = nil
 	end
 
 	self.Minimaps = nil
+	self.HighlightPipeline = nil
 
 	return self.BaseClass.Cleanup( self )
 end

--- a/lua/shine/extensions/tweaks/client.lua
+++ b/lua/shine/extensions/tweaks/client.lua
@@ -1,0 +1,194 @@
+--[[
+	Misc tweaks.
+]]
+
+local Max = math.max
+local Min = math.min
+
+local Plugin = Shine.Plugin( ... )
+
+Plugin.HasConfig = false
+Plugin.Version = "1.0"
+
+Shine.Hook.CallAfterFileLoad( "lua/GUIMinimap.lua", function()
+	Shine.Hook.SetupClassHook( "GUIMinimap", "Initialize", "OnGUIMinimapInit", "PassivePost" )
+	Shine.Hook.SetupClassHook( "GUIMinimap", "Uninitialize", "OnGUIMinimapDestroy", "PassivePost" )
+	Shine.Hook.SetupClassHook( "GUIMinimap", "UpdatePlayerIcon", "OnGUIMinimapUpdatePlayerIcon", "PassivePost" )
+end )
+
+function Plugin:Initialise()
+	self.Minimaps = Shine.Set()
+
+	local Minimap = ClientUI.GetScript( "GUIMinimapFrame" )
+	if Minimap then
+		self:SetupMinimap( Minimap )
+	end
+
+	return true
+end
+
+function Plugin:OnGUIMinimapInit( Minimap )
+	self:SetupMinimap( Minimap )
+end
+
+function Plugin:OnGUIMinimapDestroy( Minimap )
+	self.Minimaps:Remove( Minimap )
+end
+
+function Plugin:InvalidateLocationCache()
+	for Minimap in self.Minimaps:Iterate() do
+		-- Force an update of the location box.
+		Minimap.LastLocationEntity = nil
+	end
+end
+Plugin.OnResolutionChanged = Plugin.InvalidateLocationCache
+
+function Plugin:GetLocationsForName( Name )
+	if not self.LocationIndex then
+		local Locations = GetLocations()
+		local LocationsByName = Shine.Multimap()
+		for i = 1, #Locations do
+			local Location = Locations[ i ]
+			LocationsByName:Add( Location:GetName(), Location )
+		end
+
+		self.LocationIndex = LocationsByName
+	end
+
+	return self.LocationIndex:Get( Name )
+end
+
+function Plugin:SetupMinimap( Minimap )
+	if not Minimap.MapStencil then
+		Minimap.MapStencil = GUIManager:CreateGraphicItem()
+		Minimap.MapStencil:SetAnchor( GUIItem.Left, GUIItem.Top )
+		Minimap.MapStencil:SetPosition( Vector2( 0, 0 ) )
+		Minimap.MapStencil:SetSize( Minimap.minimap:GetSize() )
+		Minimap.MapStencil:SetTexture( Minimap.minimap:GetTexture() )
+		Minimap.MapStencil:SetIsStencil( true )
+		Minimap.MapStencil:SetClearsStencilBuffer( true )
+
+		Minimap.minimap:AddChild( Minimap.MapStencil )
+	end
+
+	if not Minimap.CurrentLocationBoxes then
+		Minimap.CurrentLocationBoxes = {}
+	end
+
+	self.Minimaps:Add( Minimap )
+end
+
+local function GetLocationBox( Minimap, Index )
+	local Box = Minimap.CurrentLocationBoxes[ Index ]
+	if not Box then
+		Box = GUIManager:CreateGraphicItem()
+		Box:SetAnchor( GUIItem.Middle, GUIItem.Center )
+		Box:SetIsVisible( false )
+		Box:SetInheritsParentStencilSettings( false )
+		Box:SetStencilFunc( GUIItem.NotEqual )
+		Minimap.minimap:AddChild( Box )
+
+		Minimap.CurrentLocationBoxes[ Index ] = Box
+	end
+
+	return Box
+end
+
+local function HideLocationBoxes( Minimap )
+	Minimap.LastLocationEntity = nil
+	for i = 1, #Minimap.CurrentLocationBoxes do
+		Minimap.CurrentLocationBoxes[ i ]:SetIsVisible( false )
+	end
+end
+
+local UnpoweredColour = Colour( 1, 0, 0 )
+
+function Plugin:OnGUIMinimapUpdatePlayerIcon( Minimap )
+	if not Minimap.CurrentLocationBoxes then return end
+
+	if Minimap.comMode ~= GUIMinimapFrame.kModeBig or PlayerUI_IsOverhead() then
+		HideLocationBoxes( Minimap )
+		return
+	end
+
+	local Origin = PlayerUI_GetPositionOnMinimap()
+	local LocationEntity = GetLocationForPoint( Origin )
+	if not LocationEntity then
+		HideLocationBoxes( Minimap )
+		return
+	end
+
+	Minimap.MapStencil:SetSize( Minimap.minimap:GetSize() )
+
+	local IsMarine = PlayerUI_IsOnMarineTeam()
+
+	-- Avoid doing the same thing over and over when the location hasn't changed...
+	if not IsMarine and Minimap.LastLocationEntity == LocationEntity then return end
+
+	Minimap.LastLocationEntity = LocationEntity
+
+	local BackgroundColour
+	if IsMarine then
+		local PowerNode = GetPowerPointForLocation( LocationEntity:GetName() )
+		if not PowerNode or not PowerNode:GetIsPowering() then
+			BackgroundColour = UnpoweredColour
+		else
+			BackgroundColour = Colour( kMarineTeamColorFloat )
+		end
+	elseif PlayerUI_IsOnAlienTeam() then
+		BackgroundColour = Colour( kAlienTeamColorFloat )
+	else
+		BackgroundColour = Colour( 1, 1, 1, 1 )
+	end
+
+	BackgroundColour.a = 0.3
+
+	-- Locations are composed of multiple trigger entities, so draw a box for each one.
+	local Locations = self:GetLocationsForName( LocationEntity:GetName() )
+	for i = 1, #Locations do
+		local Location = Locations[ i ]
+		local Box = GetLocationBox( Minimap, i )
+
+		local Extents = Location.scale * 0.2395
+		local Coords = Location:GetCoords()
+		local Mins = Coords:TransformPoint( -Extents )
+		local Maxs = Coords:TransformPoint( Extents )
+
+		local TopLeftX, TopLeftY = Minimap:PlotToMap( Max( Maxs.x, Mins.x ), Min( Maxs.z, Mins.z ) )
+		local BottomRightX, BottomRightY = Minimap:PlotToMap( Min( Maxs.x, Mins.x ), Max( Maxs.z, Mins.z ) )
+
+		local Width = BottomRightX - TopLeftX
+		local Height = BottomRightY - TopLeftY
+
+		Box:SetIsVisible( true )
+		Box:SetPosition( Vector2( TopLeftX, TopLeftY ) )
+		Box:SetSize( Vector2( Width, Height ) )
+		Box:SetColor( BackgroundColour )
+	end
+
+	for i = #Locations + 1, #Minimap.CurrentLocationBoxes do
+		Minimap.CurrentLocationBoxes[ i ]:SetIsVisible( false )
+	end
+end
+
+function Plugin:Cleanup()
+	for Minimap in self.Minimaps:Iterate() do
+		if Minimap.MapStencil then
+			GUI.DestroyItem( Minimap.MapStencil )
+			Minimap.MapStencil = nil
+		end
+
+		if Minimap.CurrentLocationBoxes then
+			for i = 1, #Minimap.CurrentLocationBoxes do
+				GUI.DestroyItem( Minimap.CurrentLocationBoxes[ i ] )
+			end
+			Minimap.CurrentLocationBoxes = nil
+		end
+	end
+
+	self.Minimaps = nil
+
+	return self.BaseClass.Cleanup( self )
+end
+
+return Plugin

--- a/lua/shine/extensions/tweaks/client.lua
+++ b/lua/shine/extensions/tweaks/client.lua
@@ -4,6 +4,7 @@
 
 local Max = math.max
 local Min = math.min
+local StringFormat = string.format
 
 local Plugin = Shine.Plugin( ... )
 
@@ -252,5 +253,44 @@ function Plugin:Cleanup()
 
 	return self.BaseClass.Cleanup( self )
 end
+
+Plugin.ConfigGroup = {
+	Icon = Shine.GUI.Icons.Ionicons.Wrench
+}
+Plugin.ClientConfigSettings = {
+	{
+		ConfigKey = "AlienHighlightColour",
+		Command = "sh_tweaks_alien_highlight_colour",
+		Type = "Colour",
+		CommandMessage = function( Value )
+			return StringFormat(
+				"Alien minimap highlight colour set to [ %d, %d, %d ].",
+				Value[ 1 ], Value[ 2 ], Value[ 3 ]
+			)
+		end
+	},
+	{
+		ConfigKey = "MarineHighlightColour",
+		Command = "sh_tweaks_marine_highlight_colour",
+		Type = "Colour",
+		CommandMessage = function( Value )
+			return StringFormat(
+				"Marine minimap highlight colour set to [ %d, %d, %d ].",
+				Value[ 1 ], Value[ 2 ], Value[ 3 ]
+			)
+		end
+	},
+	{
+		ConfigKey = "HostileHighlightColour",
+		Command = "sh_tweaks_hostile_highlight_colour",
+		Type = "Colour",
+		CommandMessage = function( Value )
+			return StringFormat(
+				"Hostile minimap highlight colour set to [ %d, %d, %d ].",
+				Value[ 1 ], Value[ 2 ], Value[ 3 ]
+			)
+		end
+	}
+}
 
 return Plugin

--- a/lua/shine/extensions/tweaks/minimap_blend_view.lua
+++ b/lua/shine/extensions/tweaks/minimap_blend_view.lua
@@ -1,0 +1,105 @@
+--[[
+	A GUIView that renders the minimap over the top of a previously rendered blurred highlight background.
+
+	This results in a glow around the current location, plus extra colour added on top of the minimap itself.
+
+	This is done in a texture to make alpha blending apply to an opaque version of the texture rendered by this view,
+	rather than applying to each layer rendered directly to the screen which then messes with how it looks.
+]]
+
+Width = 1024
+Height = 1024
+
+local Background
+local Overlay
+local Minimap
+local Boxes = {}
+
+local function MakeBox()
+	local Box = GUI.CreateItem()
+	Box:SetInheritsParentAlpha( false )
+	Box:SetInheritsParentStencilSettings( false )
+	Box:SetIsStencil( true )
+	Box:SetClearsStencilBuffer( false )
+	Box:SetAnchor( GUIItem.Middle, GUIItem.Center )
+
+	Background:AddChild( Box )
+
+	return Box
+end
+
+local function UpdateWithValues()
+	local Size = Vector( _G.Width, _G.Height, 0 )
+	Background:SetSize( Size )
+	Minimap:SetSize( Size )
+	Overlay:SetSize( Size )
+
+	if _G.MinimapTexture then
+		Minimap:SetTexture( _G.MinimapTexture )
+	end
+
+	if _G.BackgroundTexture then
+		Background:SetTexture( _G.BackgroundTexture )
+		Overlay:SetTexture( _G.BackgroundTexture )
+	end
+
+	local NumBoxes = _G.NumBoxes or 0
+
+	-- Update the boxes to constrain the minimap texture rendering to just the current location.
+	-- This will blend over the top of the background highlight to produce a glowing texture.
+	for i = 1, math.max( NumBoxes, #Boxes ) do
+		local X = _G[ "X"..i ]
+		local Y = _G[ "Y"..i ]
+		local W = _G[ "W"..i ]
+		local H = _G[ "H"..i ]
+
+		local Box = Boxes[ i ]
+		if not X or not Y or not W or not H or i > NumBoxes then
+			if Box then Box:SetIsVisible( false ) end
+		else
+			if not Box then
+				Box = MakeBox()
+				Boxes[ i ] = Box
+			end
+
+			Box:SetIsVisible( true )
+			Box:SetPosition( Vector( X, Y, 0 ) )
+			Box:SetSize( Vector( W, H, 0 ) )
+		end
+	end
+
+	_G.NeedsUpdate = false
+end
+
+function Initialise()
+	-- Background draws the blurred highlight box behind the minimap, making it glow.
+	Background = GUI.CreateItem()
+	Background:SetBlendTechnique( GUIItem.Set )
+	Background:SetColor( Color( 1, 1, 1, 1 ) )
+	Background:SetIsVisible( true )
+
+	-- Minimap is drawn over the top of the highlighting, but constrained to be within the current location only.
+	Minimap = GUI.CreateItem()
+	Minimap:SetLayer( 100 )
+	Minimap:SetStencilFunc( GUIItem.NotEqual )
+	Minimap:SetColor( Color( 1, 1, 1, 1 ) )
+	Background:AddChild( Minimap )
+
+	-- Overlay adds colour on top of the opaque minimap.
+	Overlay = GUI.CreateItem()
+	Overlay:SetIsVisible( true )
+	Overlay:SetLayer( 150 )
+	Overlay:SetColor( Color( 1, 1, 1, 0.4 ) )
+	Overlay:SetBlendTechnique( GUIItem.Add )
+	Background:AddChild( Overlay )
+
+	UpdateWithValues()
+end
+
+function Update( DeltaTime )
+	if _G.NeedsUpdate then
+		UpdateWithValues()
+	end
+end
+
+Initialise()

--- a/lua/shine/extensions/tweaks/minimap_view.lua
+++ b/lua/shine/extensions/tweaks/minimap_view.lua
@@ -5,12 +5,17 @@
 	making the highlight stronger.
 ]]
 
-Width = 1024
-Height = 1024
+MinimapWidth = 1024
+MinimapHeight = 1024
+
+MinimapX = 0
+MinimapY = 0
+
+NumBoxes = 0
+HighlightColour = Color( 1, 1, 1, 0 )
 
 local Stencil
 local Boxes = {}
-local DefaultColour = Color( 1, 1, 1, 0 )
 
 local function MakeBox()
 	local Box = GUI.CreateItem()
@@ -27,14 +32,15 @@ local function MakeBox()
 end
 
 local function UpdateWithValues()
-	Stencil:SetSize( Vector( _G.Width, _G.Height, 0 ) )
+	Stencil:SetSize( Vector( _G.MinimapWidth, _G.MinimapHeight, 0 ) )
+	Stencil:SetPosition( Vector( _G.MinimapX, _G.MinimapY, 0 ) )
 
 	if _G.MinimapTexture then
 		Stencil:SetTexture( _G.MinimapTexture )
 	end
 
-	local RectColour = _G.HighlightColour or DefaultColour
-	local NumBoxes = _G.NumBoxes or 0
+	local RectColour = _G.HighlightColour
+	local NumBoxes = _G.NumBoxes
 
 	for i = 1, math.max( NumBoxes, #Boxes ) do
 		local X = _G[ "X"..i ]

--- a/lua/shine/extensions/tweaks/minimap_view.lua
+++ b/lua/shine/extensions/tweaks/minimap_view.lua
@@ -1,0 +1,80 @@
+--[[
+	A GUIView that renders the minimap with boxes over the current location.
+
+	This is done inside a GUIView as it allows the use of the "Set" blend technique which avoids overlapping boxes from
+	making the highlight stronger.
+]]
+
+Width = 1024
+Height = 1024
+
+local Stencil
+local Boxes = {}
+local DefaultColour = Color( 1, 1, 1, 0 )
+
+local function MakeBox()
+	local Box = GUI.CreateItem()
+	Box:SetInheritsParentAlpha( false )
+	Box:SetInheritsParentStencilSettings( false )
+	Box:SetAnchor( GUIItem.Middle, GUIItem.Center )
+	Box:SetStencilFunc( GUIItem.NotEqual )
+	-- Use the "Set" technique to make sure overlapping boxes don't change the colour.
+	Box:SetBlendTechnique( GUIItem.Set )
+
+	Stencil:AddChild( Box )
+
+	return Box
+end
+
+local function UpdateWithValues()
+	Stencil:SetSize( Vector( _G.Width, _G.Height, 0 ) )
+
+	if _G.MinimapTexture then
+		Stencil:SetTexture( _G.MinimapTexture )
+	end
+
+	local RectColour = _G.HighlightColour or DefaultColour
+	local NumBoxes = _G.NumBoxes or 0
+
+	for i = 1, math.max( NumBoxes, #Boxes ) do
+		local X = _G[ "X"..i ]
+		local Y = _G[ "Y"..i ]
+		local W = _G[ "W"..i ]
+		local H = _G[ "H"..i ]
+
+		local Box = Boxes[ i ]
+		if not X or not Y or not W or not H or i > NumBoxes then
+			if Box then Box:SetIsVisible( false ) end
+		else
+			if not Box then
+				Box = MakeBox()
+				Boxes[ i ] = Box
+			end
+
+			Box:SetIsVisible( true )
+			Box:SetPosition( Vector( X, Y, 0 ) )
+			Box:SetSize( Vector( W, H, 0 ) )
+			Box:SetColor( RectColour )
+		end
+	end
+
+	_G.NeedsRefresh = false
+end
+
+function Initialise()
+	-- Stencil object is used to restrict the boxes to render inside the minimap texture.
+	Stencil = GUI.CreateItem()
+	Stencil:SetIsVisible( true )
+	Stencil:SetIsStencil( true )
+	Stencil:SetClearsStencilBuffer( true )
+
+	UpdateWithValues()
+end
+
+function Update( DeltaTime )
+	if _G.NeedsRefresh then
+		UpdateWithValues()
+	end
+end
+
+Initialise()

--- a/lua/shine/extensions/tweaks/minimap_view.lua
+++ b/lua/shine/extensions/tweaks/minimap_view.lua
@@ -58,7 +58,7 @@ local function UpdateWithValues()
 		end
 	end
 
-	_G.NeedsRefresh = false
+	_G.NeedsUpdate = false
 end
 
 function Initialise()
@@ -72,7 +72,7 @@ function Initialise()
 end
 
 function Update( DeltaTime )
-	if _G.NeedsRefresh then
+	if _G.NeedsUpdate then
 		UpdateWithValues()
 	end
 end

--- a/lua/shine/lib/gui.lua
+++ b/lua/shine/lib/gui.lua
@@ -1509,7 +1509,7 @@ Hook.Add( "OnMapLoad", "LoadGUIElements", function()
 	Shine.Hook.SetupGlobalHook( "Client.SetMouseVisible", "OnMouseVisibilityChange", "PassivePost" )
 
 	SetupRenderDeviceResetCheck()
-end )
+end, Shine.Hook.MAX_PRIORITY )
 
 Hook.CallAfterFileLoad( "lua/Commander_Client.lua", function()
 	local GetMouseIsOverUI = CommanderUI_GetMouseIsOverUI

--- a/lua/shine/lib/gui/base_control.lua
+++ b/lua/shine/lib/gui/base_control.lua
@@ -80,7 +80,9 @@ end
 ]]
 function ControlMeta:Initialise()
 	self.UseScheme = true
+	self.InheritsParentAlpha = false
 	self.PropagateAlphaInheritance = false
+	self.InheritsParentScaling = false
 	self.PropagateScaleInheritance = false
 	self.PropagateSkin = true
 	self.Stencilled = false

--- a/lua/shine/lib/gui/layout/units/default.lua
+++ b/lua/shine/lib/gui/layout/units/default.lua
@@ -217,6 +217,10 @@ do
 
 	local UnitVector = NewType( "UnitVector" )
 
+	function UnitVector.Uniform( Size )
+		return UnitVector( Size, Size )
+	end
+
 	function UnitVector:Init( X, Y )
 		self[ 1 ] = ToUnit( X )
 		self[ 2 ] = ToUnit( Y )

--- a/lua/shine/lib/gui/mixins/auto_sizable_text.lua
+++ b/lua/shine/lib/gui/mixins/auto_sizable_text.lua
@@ -5,9 +5,13 @@
 local AutoSizeText = {}
 local AxisSizeHandlers = {
 	function( self )
+		-- Apply any configured auto-font before getting the text size, layout may not have executed yet.
+		self:PreComputeWidth()
 		return self:GetCachedTextWidth()
 	end,
 	function( self )
+		-- Same here (yes, it's correct to call pre-compute width here, that triggers the auto-font).
+		self:PreComputeWidth()
 		return self:GetCachedTextHeight()
 	end
 }

--- a/lua/shine/lib/gui/objects/colour_picker.lua
+++ b/lua/shine/lib/gui/objects/colour_picker.lua
@@ -1,0 +1,471 @@
+--[[
+	Colour picker control, providing a means of selecting a colour using a standard HSV selector and/or RGB sliders.
+]]
+
+local Clamp = math.Clamp
+local Round = math.Round
+local StringTransformCase = string.TransformCase
+local StringCaseFormatType = string.CaseFormatType
+
+local SGUI = Shine.GUI
+local Controls = SGUI.Controls
+local Units = SGUI.Layout.Units
+
+local GetCursorPos = SGUI.GetCursorPos
+
+local SaturationValuePicker = SGUI:DefineControl( "SaturationValuePicker" )
+do
+	local SetSaturation = SGUI.AddProperty( SaturationValuePicker, "Saturation" )
+	local SetValue = SGUI.AddProperty( SaturationValuePicker, "Value" )
+
+	function SaturationValuePicker:Initialise()
+		self.BaseClass.Initialise( self )
+
+		local Background = self:MakeGUIItem()
+		self.Background = Background
+
+		local SaturationValueOverlay = self:MakeGUIItem()
+		SaturationValueOverlay:SetTexture( "ui/newMenu/saturationValueRange.dds" )
+		Background:AddChild( SaturationValueOverlay )
+		self.SaturationValueOverlay = SaturationValueOverlay
+
+		local CursorSize = Units.HighResScaled( 16 ):GetValue()
+		local Cursor = self:MakeGUIItem()
+		Cursor:SetTexture( "ui/newMenu/circle.dds" )
+		Cursor:SetSize( Vector2( CursorSize, CursorSize ) )
+		Cursor:SetHotSpot( 0.5, 0.5 )
+		Background:AddChild( Cursor )
+		self.Cursor = Cursor
+
+		self.Saturation = 0
+		self.Value = 1
+
+		self.CursorPos = Cursor:GetPosition()
+	end
+
+	function SaturationValuePicker:SetSize( Size )
+		if not self.BaseClass.SetSize( self, Size ) then return false end
+
+		self.SaturationValueOverlay:SetSize( Size )
+
+		self.CursorPos.x = Size.x * self.Saturation
+		self.CursorPos.y = Size.y * ( 1 - self.Value )
+		self.Cursor:SetPosition( self.CursorPos )
+
+		return true
+	end
+
+	function SaturationValuePicker:SetSaturation( Saturation )
+		Saturation = Clamp( Saturation, 0, 1 )
+
+		if not SetSaturation( self, Saturation ) then return false end
+
+		self.CursorPos.x = Saturation * self:GetSize().x
+		self.Cursor:SetPosition( self.CursorPos )
+
+		return true
+	end
+
+	function SaturationValuePicker:SetValue( Value )
+		Value = Clamp( Value, 0, 1 )
+
+		if not SetValue( self, Value ) then return false end
+
+		self.CursorPos.y = ( 1 - Value ) * self:GetSize().y
+		self.Cursor:SetPosition( self.CursorPos )
+
+		return true
+	end
+
+	function SaturationValuePicker:OnDraggingCursor( Saturation, Value )
+		-- To be overridden.
+	end
+
+	function SaturationValuePicker:OnChanged( Saturation, Value )
+		-- To be overridden.
+	end
+
+	function SaturationValuePicker:OnMouseDown( Key, DoubleClick )
+		if not self:GetIsVisible() then return end
+
+		if Key ~= InputKey.MouseButton0 then return end
+		if not self:MouseIn( self.Cursor, 1.25 ) then
+			if self:HasMouseEntered() then
+				self.ClickingBox = true
+				return true, self
+			end
+
+			return
+		end
+
+		local X, Y = GetCursorPos()
+
+		self.Dragging = true
+		self.DragStart = Vector2( X, Y )
+		self.StartingPos = Vector( self.CursorPos )
+
+		return true, self
+	end
+
+	function SaturationValuePicker:OnMouseMove( Down )
+		self.BaseClass.OnMouseMove( self, Down )
+
+		if not Down then return end
+		if not self.Dragging then return end
+
+		local X, Y = GetCursorPos()
+
+		local XDiff = X - self.DragStart.x
+		local YDiff = Y - self.DragStart.y
+		local Size = self:GetSize()
+
+		local NewSaturation = Clamp( ( self.StartingPos.x + XDiff ) / Size.x, 0, 1 )
+		local NewValue = 1 - Clamp( ( self.StartingPos.y + YDiff ) / Size.y, 0, 1 )
+
+		self:SetSaturation( NewSaturation )
+		self:SetValue( NewValue )
+		self:OnDraggingCursor( NewSaturation, NewValue )
+	end
+
+	function SaturationValuePicker:OnMouseUp( Key )
+		if Key ~= InputKey.MouseButton0 then return end
+
+		if self.ClickingBox then
+			self.ClickingBox = nil
+
+			local In, X, Y = self:MouseInCached()
+			if not In then return end
+
+			local Size = self:GetSize()
+			local Saturation = Clamp( X / Size.x, 0, 1 )
+			local Value = 1 - Clamp( Y / Size.y, 0, 1 )
+
+			self:SetSaturation( Saturation )
+			self:SetValue( Value )
+		else
+			self.Dragging = false
+		end
+
+		self:OnChanged( self.Saturation, self.Value )
+
+		return true
+	end
+end
+
+local ColourPicker = {}
+
+ColourPicker.Sound = "sound/NS2.fev/common/button_enter"
+
+local SetValue = SGUI.AddProperty( ColourPicker, "Value" )
+
+function ColourPicker:Initialise()
+	self.BaseClass.Initialise( self )
+
+	local Background = self:MakeGUIItem()
+	self.Background = Background
+
+	local Tree = SGUI:BuildTree( {
+		Parent = self,
+		{
+			Class = "Horizontal",
+			Type = "Layout",
+			Props = {
+				Padding = Units.Spacing.Uniform( Units.HighResScaled( 4 ) )
+			},
+			Children = {
+				{
+					ID = "ColourPreview",
+					Class = "Image",
+					Props = {
+						Fill = true
+					}
+				}
+			}
+		}
+	} )
+
+	self.ColourPreview = Tree.ColourPreview
+	self.Value = Colour( 1, 1, 1, 1 )
+end
+
+function ColourPicker:OnValueChanged( Value )
+	-- To be overridden.
+end
+
+function ColourPicker:SetValue( Value )
+	if not SetValue( self, Value ) then return false end
+
+	self.ColourPreview:SetColour( Value )
+
+	return true
+end
+
+function ColourPicker:DoClick()
+	if self.ColourPickerPopupClosedFrame == self:GetLastMouseDownFrameNumber() then return end
+
+	local R, G, B = self.Value.r, self.Value.g, self.Value.b
+	local Hue, Saturation, Value = SGUI.RGBToHSV( R, G, B )
+	local AgencyFBNormal = {
+		Family = "kAgencyFB",
+		Size = Units.HighResScaled( 27 )
+	}
+
+	local MaxSliderLabelWidth = Units.Max()
+	local SliderSize = Units.UnitVector(
+		Units.Percentage.ONE_HUNDRED - Units.HighResScaled( 48 + 8 ) - MaxSliderLabelWidth,
+		Units.HighResScaled( 32 )
+	)
+
+	local function MakeSlider( ID, StyleName, Margin )
+		local LabelKey = StringTransformCase(
+			ID,
+			StringCaseFormatType.UPPER_CAMEL,
+			StringCaseFormatType.UPPER_UNDERSCORE
+		).."_LABEL"
+
+		return {
+			Class = "Horizontal",
+			Type = "Layout",
+			Props = {
+				Fill = false,
+				AutoSize = Units.UnitVector( Units.Percentage.ONE_HUNDRED, Units.HighResScaled( 32 ) )
+			},
+			Children = {
+				{
+					Class = "Label",
+					Props = {
+						AutoFont = AgencyFBNormal,
+						DebugName = ID.."Label",
+						Margin = Units.Spacing( 0, 0, MaxSliderLabelWidth - Units.Auto() + Units.HighResScaled( 8 ), 0 ),
+						Text = Shine.Locale:GetPhrase( "Core", LabelKey )
+					},
+					OnBuilt = function( self, Label )
+						-- Align the sliders based on the largest label.
+						MaxSliderLabelWidth:AddValue( Units.Auto( Label ) )
+					end
+				},
+				{
+					ID = ID,
+					Class = "Slider",
+					Props = {
+						AutoFont = AgencyFBNormal,
+						Decimals = 0,
+						AutoSize = SliderSize,
+						StyleName = StyleName,
+						Margin = Margin
+					}
+				}
+			}
+		}
+	end
+
+	local Tree = SGUI:BuildTree( {
+		{
+			ID = "Popup",
+			Class = "Column",
+			Props = {
+				InheritsParentAlpha = true,
+				PropagateAlphaInheritance = true,
+				Padding = Units.Spacing.Uniform( Units.HighResScaled( 8 ) ),
+				Size = Vector2( Units.HighResScaled( 320 + 56 ):GetValue(), Units.HighResScaled( 320 + 128 ):GetValue() )
+			},
+			Children = {
+				{
+					Type = "Layout",
+					Class = "Horizontal",
+					Props = {
+						Fill = true,
+						Margin = Units.Spacing( 0, 0, 0, Units.HighResScaled( 8 ) )
+					},
+					Children = {
+						{
+							ID = "SaturationValuePicker",
+							Class = SaturationValuePicker,
+							Props = {
+								BackgroundColour = Colour( SGUI.HSVToRGB( Hue, 1, 1 ) ),
+								Saturation = Saturation,
+								Value = Value,
+								Fill = true
+							}
+						},
+						{
+							ID = "HueSlider",
+							Class = "Slider",
+							Props = {
+								AutoSize = Units.UnitVector( Units.HighResScaled( 32 ), Units.Percentage.ONE_HUNDRED ),
+								Vertical = true,
+								HandleThickness = Units.HighResScaled( 5 ):GetValue(),
+								StyleName = "HuePicker",
+								Decimals = 6,
+								TextIsVisible = false,
+								Margin = Units.Spacing( Units.HighResScaled( 8 ), 0, 0, 0 )
+							}
+						}
+					}
+				},
+				MakeSlider( "RedSlider", "RedPicker", Units.Spacing( 0, 0, 0, Units.HighResScaled( 4 ) ) ),
+				MakeSlider( "GreenSlider", "GreenPicker", Units.Spacing( 0, 0, 0, Units.HighResScaled( 4 ) ) ),
+				MakeSlider( "BlueSlider", "BluePicker" )
+			}
+		}
+	} )
+
+	self.ColourPickerPopup = Tree.Popup
+
+	Tree.HueSlider:SetBounds( 0, 1 )
+	Tree.HueSlider:SetValue( Hue, true )
+
+	Tree.RedSlider:SetBounds( 0, 255 )
+	Tree.RedSlider:SetValue( Round( self.Value.r * 255 ), true )
+	Tree.RedSlider:InvalidateParent()
+
+	Tree.GreenSlider:SetBounds( 0, 255 )
+	Tree.GreenSlider:SetValue( Round( self.Value.g * 255 ), true )
+	Tree.GreenSlider:InvalidateParent()
+
+	Tree.BlueSlider:SetBounds( 0, 255 )
+	Tree.BlueSlider:SetValue( Round( self.Value.b * 255 ), true )
+	Tree.BlueSlider:InvalidateParent()
+
+	local PopupSize = Tree.Popup:GetSize()
+	local ScreenWidth, ScreenHeight = SGUI.GetScreenSize()
+	local Pos = self:GetScreenPos()
+	Pos.x = Clamp( Pos.x + self:GetSize().x, 0, ScreenWidth - PopupSize.x )
+	Pos.y = Clamp( Pos.y, 0, ScreenHeight - PopupSize.y )
+
+	Tree.Popup:SetPos( Pos )
+	Tree.Popup:SetBoxShadow( {
+		BlurRadius = Units.HighResScaled( 8 ):GetValue(),
+		Colour = Colour( 0, 0, 0, 0.9 )
+	} )
+	Tree.Popup:ApplyTransition( {
+		Type = "AlphaMultiplier",
+		StartValue = 0,
+		EndValue = 1,
+		Duration = 0.15
+	} )
+
+	local OldOnMouseDown = Tree.Popup.OnMouseDown
+	function Tree.Popup:OnMouseDown( Key, DoubleClick )
+		local Handled, Child = OldOnMouseDown( self, Key, DoubleClick )
+		if not Handled then
+			-- Close if clicking outside the popup.
+			self:Destroy()
+		end
+		return Handled, Child
+	end
+
+	local OldPlayerKeyPress = Tree.Popup.PlayerKeyPress
+	function Tree.Popup:PlayerKeyPress( Key, Down )
+		local Handled = OldPlayerKeyPress( self, Key, Down )
+		if not Handled and Key == InputKey.Escape then
+			Handled = true
+			self:Destroy()
+		end
+		return Handled
+	end
+
+	Tree.Popup:CallOnRemove( function()
+		self.ColourPickerPopupClosedFrame = SGUI.FrameNumber()
+		self.ColourPickerPopup = nil
+	end )
+
+	local function RefreshColour()
+		Tree.SaturationValuePicker:SetBackgroundColour( Colour( SGUI.HSVToRGB( Hue, 1, 1 ) ) )
+
+		local NewColour = Colour( R, G, B )
+		self:SetValue( NewColour )
+		self:OnValueChanged( NewColour )
+	end
+
+	local function RefreshRGB()
+		R, G, B = SGUI.HSVToRGB( Hue, Saturation, Value )
+		Tree.RedSlider:SetValue( Round( R * 255 ), true )
+		Tree.GreenSlider:SetValue( Round( G * 255 ), true )
+		Tree.BlueSlider:SetValue( Round( B * 255 ), true )
+
+		RefreshColour()
+	end
+
+	local function RefreshHSV()
+		Hue, Saturation, Value = SGUI.RGBToHSV( R, G, B )
+
+		Tree.HueSlider:SetValue( Hue, true )
+		Tree.SaturationValuePicker:SetSaturation( Saturation )
+		Tree.SaturationValuePicker:SetValue( Value )
+
+		RefreshColour()
+	end
+
+	function Tree.SaturationValuePicker:OnChanged( NewSaturation, NewValue )
+		Saturation = NewSaturation
+		Value = NewValue
+		RefreshRGB()
+	end
+	function Tree.SaturationValuePicker.OnDraggingCursor( Picker, NewSaturation, NewValue )
+		self.ColourPreview:SetColour( Colour( SGUI.HSVToRGB( Hue, NewSaturation, NewValue ) ) )
+	end
+
+	local function UpdatePreview( NewColour )
+		local H, S, V = SGUI.RGBToHSV( NewColour.r, NewColour.g, NewColour.b )
+		Tree.SaturationValuePicker:SetBackgroundColour( Colour( SGUI.HSVToRGB( H, 1, 1 ) ) )
+		self.ColourPreview:SetColour( NewColour )
+	end
+
+	function Tree.HueSlider:OnSlide( NewHue )
+		R, G, B = SGUI.HSVToRGB( NewHue, Saturation, Value )
+		UpdatePreview( Colour( R, G, B ) )
+	end
+
+	function Tree.HueSlider:OnValueChanged( Value )
+		Hue = Value
+		RefreshRGB()
+	end
+
+	function Tree.RedSlider:OnValueChanged( NewRed )
+		R = NewRed / 255
+		RefreshHSV()
+	end
+	function Tree.RedSlider:OnSlide( NewRed )
+		UpdatePreview( Colour( NewRed / 255, G, B ) )
+	end
+
+	function Tree.GreenSlider:OnValueChanged( NewGreen )
+		G = NewGreen / 255
+		RefreshHSV()
+	end
+	function Tree.GreenSlider:OnSlide( NewGreen )
+		UpdatePreview( Colour( R, NewGreen / 255, B ) )
+	end
+
+	function Tree.BlueSlider:OnValueChanged( NewBlue )
+		B = NewBlue / 255
+		RefreshHSV()
+	end
+	function Tree.BlueSlider:OnSlide( NewBlue )
+		UpdatePreview( Colour( R, G, NewBlue / 255 ) )
+	end
+
+	Tree.Popup:InvalidateLayout( true )
+end
+
+function ColourPicker:DestroyPopup()
+	if SGUI.IsValid( self.ColourPickerPopup ) then
+		self.ColourPickerPopup:Destroy()
+		self.ColourPickerPopup = nil
+	end
+end
+
+function ColourPicker:OnEffectiveVisibilityChanged( IsEffectivelyVisible, UpdatedControl )
+	if not IsEffectivelyVisible then
+		self:DestroyPopup()
+	end
+end
+
+function ColourPicker:Cleanup()
+	self:DestroyPopup()
+	return self.BaseClass.Cleanup( self )
+end
+
+SGUI:AddMixin( ColourPicker, "Clickable" )
+SGUI:Register( "ColourPicker", ColourPicker )

--- a/lua/shine/lib/gui/objects/colour_picker.lua
+++ b/lua/shine/lib/gui/objects/colour_picker.lua
@@ -403,12 +403,20 @@ function ColourPicker:DoClick()
 		RefreshRGB()
 	end
 	function Tree.SaturationValuePicker.OnDraggingCursor( Picker, NewSaturation, NewValue )
-		self.ColourPreview:SetColour( Colour( SGUI.HSVToRGB( Hue, NewSaturation, NewValue ) ) )
+		local NewR, NewG, NewB = SGUI.HSVToRGB( Hue, NewSaturation, NewValue )
+		Tree.RedSlider:SetValue( Round( NewR * 255 ), true )
+		Tree.GreenSlider:SetValue( Round( NewG * 255 ), true )
+		Tree.BlueSlider:SetValue( Round( NewB * 255 ), true )
+		self.ColourPreview:SetColour( Colour( NewR, NewG, NewB ) )
 	end
 
 	local function UpdatePreview( NewColour )
 		local H, S, V = SGUI.RGBToHSV( NewColour.r, NewColour.g, NewColour.b )
+		Tree.HueSlider:SetValue( H, true )
 		Tree.SaturationValuePicker:SetBackgroundColour( Colour( SGUI.HSVToRGB( H, 1, 1 ) ) )
+		Tree.RedSlider:SetValue( Round( NewColour.r * 255 ), true )
+		Tree.GreenSlider:SetValue( Round( NewColour.g * 255 ), true )
+		Tree.BlueSlider:SetValue( Round( NewColour.b * 255 ), true )
 		self.ColourPreview:SetColour( NewColour )
 	end
 

--- a/lua/shine/lib/gui/skins/default.lua
+++ b/lua/shine/lib/gui/skins/default.lua
@@ -130,6 +130,11 @@ local Skin = {
 			Font = Fonts.kAgencyFB_Small
 		}
 	},
+	ColourPicker = {
+		Default = {
+			BackgroundColour = DarkButton
+		}
+	},
 	Dropdown = {
 		Default = table.ShallowMerge( DefaultButton, {
 			Padding = DropdownPadding,
@@ -283,7 +288,7 @@ local Skin = {
 			HandleColour = ButtonHighlight,
 			LineColour = ButtonHighlight,
 			TextColour = BrightText,
-			LineHeightMultiplier = 0.15,
+			LineThicknessMultiplier = 0.15,
 			States = {
 				Disabled = {
 					DarkLineColour = SGUI.ColourWithAlpha( SliderDarkLineColour, 0.5 ),
@@ -292,6 +297,25 @@ local Skin = {
 					TextColour = SGUI.ColourWithAlpha( BrightText, 0.5 )
 				}
 			}
+		},
+		HuePicker = {
+			DarkLineVisible = false,
+			LineTexture = "ui/newMenu/hueRange.dds",
+			LineThicknessMultiplier = 0.75,
+			HandleColour = Colour( 1, 1, 1, 1 ),
+			LineColour = Colour( 1, 1, 1, 1 )
+		},
+		RedPicker = {
+			HandleColour = BrightText,
+			LineColour = Colour( 1, 0, 0 )
+		},
+		GreenPicker = {
+			HandleColour = BrightText,
+			LineColour = Colour( 0, 1, 0 )
+		},
+		BluePicker = {
+			HandleColour = BrightText,
+			LineColour = Colour( 0, 0.3, 1 )
 		}
 	},
 	Switch = {

--- a/lua/shine/lib/gui/skins/default_light.lua
+++ b/lua/shine/lib/gui/skins/default_light.lua
@@ -146,6 +146,11 @@ local Skin = {
 			Font = Fonts.kAgencyFB_Small
 		}
 	},
+	ColourPicker = {
+		Default = {
+			BackgroundColour = DarkButton
+		}
+	},
 	Dropdown = {
 		Default = table.ShallowMerge( DefaultButton, {
 			Padding = DropdownPadding,
@@ -310,7 +315,7 @@ local Skin = {
 			HandleColour = OrangeButtonHighlight,
 			LineColour = OrangeButtonHighlight,
 			TextColour = BrightText,
-			LineHeightMultiplier = 0.15,
+			LineThicknessMultiplier = 0.15,
 			States = {
 				Disabled = {
 					DarkLineColour = SGUI.ColourWithAlpha( SliderDarkLineColour, 0.5 ),
@@ -319,6 +324,25 @@ local Skin = {
 					TextColour = SGUI.ColourWithAlpha( BrightText, 0.5 )
 				}
 			}
+		},
+		HuePicker = {
+			DarkLineVisible = false,
+			LineTexture = "ui/newMenu/hueRange.dds",
+			LineThicknessMultiplier = 0.75,
+			HandleColour = Colour( 0.2, 0.2, 0.2, 1 ),
+			LineColour = Colour( 1, 1, 1, 1 )
+		},
+		RedPicker = {
+			HandleColour = BrightText,
+			LineColour = Colour( 1, 0, 0 )
+		},
+		GreenPicker = {
+			HandleColour = BrightText,
+			LineColour = Colour( 0, 1, 0 )
+		},
+		BluePicker = {
+			HandleColour = BrightText,
+			LineColour = Colour( 0, 0.3, 1 )
 		}
 	},
 	Switch = {

--- a/lua/shine/lib/gui/util/pipeline.lua
+++ b/lua/shine/lib/gui/util/pipeline.lua
@@ -6,6 +6,7 @@ local Shine = Shine
 local SGUI = Shine.GUI
 local Hook = Shine.Hook
 
+local assert = assert
 local BitLShift = bit.lshift
 local Ceil = math.ceil
 local IsType = Shine.IsType
@@ -15,9 +16,22 @@ local ipairs = ipairs
 local setmetatable = setmetatable
 local StringFormat = string.format
 local TableAdd = table.Add
+local TableNew = require "table.new"
 local xpcall = xpcall
 
 local RenderPipeline = {}
+
+-- Provides a JIT friendly way to pass a method as a callback.
+local BoundMethodCallback = Shine.TypeDef()
+function BoundMethodCallback:Init( Context, Method )
+	self.Context = Context
+	self.Method = Method
+	return self
+end
+
+function BoundMethodCallback:__call( Arg1, Arg2 )
+	return self.Method( self.Context, Arg1, Arg2 )
+end
 
 local TextureInput = {}
 function TextureInput:ResolveInputValue( Context )
@@ -56,9 +70,7 @@ function PipelineTexture:SetPipeline( Pipeline, Width, Height )
 
 	if Pipeline then
 		-- If the texture data is lost, re-render this texture from its original pipeline.
-		Hook.Add( "OnRenderDeviceReset", self, function()
-			self:Refresh()
-		end )
+		Hook.Add( "OnRenderDeviceReset", self, BoundMethodCallback( self, self.Refresh ) )
 	else
 		Hook.Remove( "OnRenderDeviceReset", self )
 	end
@@ -69,11 +81,6 @@ local function DestroyGUIView( self )
 		Client.DestroyGUIView( self.GUIView )
 		Hook.Remove( "Think", self.GUIView )
 		self.GUIView = nil
-	end
-
-	if self.TemporaryCopyTexture then
-		self.TemporaryCopyTexture:Free()
-		self.TemporaryCopyTexture = nil
 	end
 end
 
@@ -86,23 +93,11 @@ local function CancelTextureRefresh( self )
 	end
 end
 
---[[
-	Re-renders the given texture, executing its original render pipeline and copying the result to the texture name
-	currently reserved by this texture.
-]]
-function PipelineTexture:Refresh()
-	local Pipeline = self.Pipeline
-	if not Pipeline then return end
-
-	CancelTextureRefresh( self )
-	DestroyGUIView( self )
-
-	Shine.Logger:Debug( "Refreshing %s...", self )
-
-	self.RefreshContext = RenderPipeline.Execute( self.Pipeline, self.Width, self.Height, function( OutputTexture )
+do
+	local function OnRefreshed( self, OutputTexture, Pipeline )
 		self.RefreshContext = nil
 
-		if self.Pipeline ~= Pipeline or self.GUIView or self.IsFree then
+		if self.Pipeline ~= Pipeline or self.GUIView ~= OutputTexture.GUIView or self.IsFree then
 			-- Somehow wasn't cancelled when freed or rendered elsewhere, ignore this texture.
 			Shine.Logger:Debug(
 				"Discarding refreshed texture %s as %s is not in a valid state to be refreshed.",
@@ -113,52 +108,34 @@ function PipelineTexture:Refresh()
 			return
 		end
 
-		self:CopyFrom( OutputTexture )
-	end )
-end
+		assert( OutputTexture == self, "Pipeline didn't re-render to the same output texture!" )
 
---[[
-	Copies the data from the given texture into this one, destroying the other texture once the copy operation is
-	complete.
-]]
-function PipelineTexture:CopyFrom( OtherTexture )
-	-- If the texture's free, ignore any request to copy data.
-	if self.IsFree then
-		Shine.Logger:Debug(
-			"Ignoring request to copy texture %s into %s as the target texture is not currently allocated.",
-			OtherTexture,
-			self
-		)
-		return
+		if self.OnRefreshComplete then
+			self:OnRefreshComplete( Pipeline )
+			self.OnRefreshComplete = nil
+		end
 	end
 
-	-- Don't auto-render this again, it's for internal use only here to copy back to this texture.
-	OtherTexture:SetPipeline( nil )
+	--[[
+		Re-renders the given texture, executing its original render pipeline again.
+	]]
+	function PipelineTexture:Refresh( OnRefreshComplete )
+		local Pipeline = self.Pipeline
+		if not Pipeline then return end
 
-	-- Use the copy view to copy from the temporary texture back to the texture that's allocated here.
-	-- This avoids needing to notify the external borrowers of this texture, the texture simply gets refreshed for them.
-	local GUIView = Client.CreateGUIView( self.Width, self.Height )
-	GUIView:Load( "lua/shine/lib/gui/views/copy.lua" )
-	GUIView:SetGlobal( "SourceTexture", OtherTexture:GetName() )
-	GUIView:SetGlobal( "Width", self.Width )
-	GUIView:SetGlobal( "Height", self.Height )
-	GUIView:SetGlobal( "NeedsUpdate", 1 )
-	GUIView:SetTargetTexture( self.Name )
-	GUIView:SetRenderCondition( GUIView.RenderOnce )
+		CancelTextureRefresh( self )
 
-	self.GUIView = GUIView
-	self.TemporaryCopyTexture = OtherTexture
+		self.OnRefreshComplete = OnRefreshComplete
 
-	Shine.Logger:Debug( "Copying %s to %s...", OtherTexture, self )
+		Shine.Logger:Debug( "Refreshing %s...", self )
 
-	Hook.Add( "Think", GUIView, function()
-		if GUIView:GetRenderCondition() == GUIView.RenderNever then
-			Shine.Logger:Debug( "Finished copying %s to %s.", OtherTexture, self )
-			OtherTexture:Free()
-			self.TemporaryCopyTexture = nil
-			Hook.Remove( "Think", GUIView )
-		end
-	end )
+		self.RefreshContext = RenderPipeline.Execute(
+			Pipeline,
+			self.Width,
+			self.Height,
+			BoundMethodCallback( self, OnRefreshed )
+		)
+	end
 end
 
 function PipelineTexture:Free()
@@ -212,7 +189,7 @@ function PiplineTexturePool:AllocateTexture( GUIView )
 end
 
 -- Wraps a list of textures, allows nodes to return multiple textures to be held as the current texture.
--- Note that lists used outside of pipelines should be freed as a unit, do not free individual textures.
+-- Note that lists used outside of pipelines should be freed and refreshed as a unit, do not free individual textures.
 local TextureList = Shine.TypeDef()
 function TextureList:Init( Textures )
 	self.Textures = Textures
@@ -233,19 +210,8 @@ end
 
 TextureList.SetPipeline = PipelineTexture.SetPipeline
 
-function TextureList:Refresh()
-	if not self.Pipeline then return end
-
-	CancelTextureRefresh( self )
-
-	-- Destroy the original GUIView on every texture in this list.
-	for Index, Texture in self:Iterate() do
-		DestroyGUIView( Texture )
-	end
-
-	Shine.Logger:Debug( "Refreshing %s...", self )
-
-	self.RefreshContext = RenderPipeline.Execute( self.Pipeline, self.Width, self.Height, function( OutputTexture )
+do
+	local function OnRefreshed( self, OutputTexture )
 		self.RefreshContext = nil
 
 		if not self.Pipeline then
@@ -253,12 +219,29 @@ function TextureList:Refresh()
 			return
 		end
 
-		-- The refreshed output should be an identical list, so each texture gets copied from the associated texture
-		-- in the new list.
+		-- The refreshed output should be an identical list, pointing at the same textures as before.
 		for Index, Texture in self:Iterate() do
-			Texture:CopyFrom( OutputTexture:Get( Index ) )
+			assert(
+				Texture == OutputTexture:Get( Index ),
+				"Pipeline didn't re-render texture in list to the same output texture!"
+			)
 		end
-	end )
+	end
+
+	function TextureList:Refresh()
+		if not self.Pipeline then return end
+
+		CancelTextureRefresh( self )
+
+		Shine.Logger:Debug( "Refreshing %s...", self )
+
+		self.RefreshContext = RenderPipeline.Execute(
+			self.Pipeline,
+			self.Width,
+			self.Height,
+			BoundMethodCallback( self, OnRefreshed )
+		)
+	end
 end
 
 function TextureList:Free()
@@ -275,6 +258,14 @@ function TextureList:__tostring()
 	return StringFormat( "TextureList[%s]", Shine.Stream( self.Textures ):Concat( ", " ) )
 end
 
+--[[
+	A node that performs a single rendering operation to an output texture.
+
+	Note that the final GUIViewNode in a pipeline will retain its output texture to allow for re-rendering. Thus,
+	a GUIViewNode should only be added to a single pipeline.
+
+	Re-use the definition and/or use the Copy() method if the same node is required in multiple distinct pipelines.
+]]
 local GUIViewNode = Shine.TypeDef()
 function GUIViewNode:Init( Params )
 	self.View = Params.View
@@ -282,7 +273,14 @@ function GUIViewNode:Init( Params )
 	return self
 end
 
-function GUIViewNode:WithInputs( Inputs )
+function GUIViewNode:Copy()
+	return GUIViewNode( {
+		View = self.View,
+		Input = TableAdd( {}, self.Input )
+	} )
+end
+
+function GUIViewNode:CopyWithInputs( Inputs )
 	return GUIViewNode( {
 		View = self.View,
 		Input = TableAdd( TableAdd( {}, self.Input ), Inputs )
@@ -290,13 +288,31 @@ function GUIViewNode:WithInputs( Inputs )
 end
 
 function GUIViewNode:OnStart( Context )
-	Shine.Logger:Debug( "Loading GUIView with script %s and size (%s, %s)", self.View, Context.Width, Context.Height )
+	local RootPipeline = Context:GetRootPipeline()
+	local IsOutputNode = RootPipeline:IsOutputNode( self )
 
-	local GUIView = Client.CreateGUIView( Context.Width, Context.Height )
-	GUIView:Load( self.View )
+	local GUIView
+	local UsingPreviousTexture
+	if IsOutputNode and self.OutputTexture then
+		-- If this is an output node that previously rendered, re-use its output texture.
+		-- Note that GUIViewNodes aren't permitted to change their size or script, but they can change any other
+		-- parameter when re-rendering.
+		GUIView = assert( self.OutputTexture.GUIView, "Output texture was freed during rendering!" )
+		UsingPreviousTexture = true
+		Shine.Logger:Debug( "Re-using previous output texture for output node %s: %s", self, self.OutputTexture )
+	else
+		Shine.Logger:Debug(
+			"Loading GUIView with script %s and size (%s, %s)",
+			self.View,
+			Context.Width,
+			Context.Height
+		)
+		GUIView = Client.CreateGUIView( Context.Width, Context.Height )
+		GUIView:Load( self.View )
+	end
+
 	GUIView:SetGlobal( "Width", Context.Width )
 	GUIView:SetGlobal( "Height", Context.Height )
-	GUIView:SetRenderCondition( GUIView.RenderOnce )
 
 	for i = 1, #self.Input do
 		local Input = self.Input[ i ]
@@ -313,26 +329,44 @@ function GUIViewNode:OnStart( Context )
 	end
 
 	GUIView:SetGlobal( "NeedsUpdate", 1 )
+	GUIView:SetRenderCondition( GUIView.RenderOnce )
 
-	local TargetTexture = Context:AllocateTexture( GUIView )
-	Context:SetVariable( self, "OutputTexture", TargetTexture )
-	GUIView:SetTargetTexture( TargetTexture:GetName() )
+	if not UsingPreviousTexture then
+		local TargetTexture = Context:AllocateTexture( GUIView )
+		GUIView:SetTargetTexture( TargetTexture:GetName() )
+
+		if IsOutputNode then
+			-- If this is an output node (i.e. its output texture is going to be returned by the pipeline), then
+			-- hold onto it here so the pipeline can re-render to the same texture later.
+			self.OutputTexture = TargetTexture
+		else
+			-- Otherwise just store it temporarily in the context.
+			Context:SetVariable( self, "OutputTexture", TargetTexture )
+		end
+	end
 
 	Context:SetVariable( self, "GUIView", GUIView )
 end
 
 function GUIViewNode:Terminate( Context )
-	-- Free the node's temporary texture, this will also destroy the associated GUIView.
+	-- Free the node's temporary texture if it has one, this will also destroy the associated GUIView.
 	local OutputTexture = Context:GetVariable( self, "OutputTexture" )
-	OutputTexture:Free()
+	if OutputTexture then
+		OutputTexture:Free()
+	end
 end
 
 function GUIViewNode:Think( Context )
 	local GUIView = Context:GetVariable( self, "GUIView" )
 
 	if GUIView:GetRenderCondition() == GUIView.RenderNever then
-		return Context:GetVariable( self, "OutputTexture" )
+		return self.OutputTexture or Context:GetVariable( self, "OutputTexture" )
 	end
+end
+
+function GUIViewNode:IsOutputNode( Node )
+	-- This method is only called on the last node in a pipeline, so self is guaranteed to be an output node.
+	return Node == self
 end
 
 function GUIViewNode:OnFinish( Context )
@@ -352,12 +386,36 @@ end
 	Each pipeline executes within an isolated scope, with any textures it creates not affecting its parent pipeline.
 	Only the final output texture is passed back up to a parent pipeline to be passed along to the next node or returned
 	as the final output of the parent.
+
+	Pipelines should not be modified once they have been created. Create a new pipeline if additional nodes are
+	required.
 ]]
 local PipelineNode = Shine.TypeDef()
 function PipelineNode:Init( Nodes )
-	Shine.AssertAtLevel( #Nodes > 0, "Pipelines must have at least one node!", 3 )
 	self.Nodes = Nodes
+	self.NumNodes = #Nodes
+	Shine.AssertAtLevel( self.NumNodes > 0, "Pipelines must have at least one node!", 3 )
 	return self
+end
+
+function PipelineNode:Copy()
+	local CopiedNodes = TableNew( self.NumNodes, 0 )
+	for i = 1, self.NumNodes do
+		CopiedNodes[ i ] = self.Nodes[ i ]:Copy()
+	end
+	return PipelineNode( CopiedNodes )
+end
+
+function PipelineNode:CopyWithAdditionalNodes( Nodes )
+	local NumNewNodes = #Nodes
+	local CopiedNodes = TableNew( self.NumNodes + NumNewNodes, 0 )
+	for i = 1, self.NumNodes do
+		CopiedNodes[ i ] = self.Nodes[ i ]:Copy()
+	end
+	for i = 1, NumNewNodes do
+		CopiedNodes[ self.NumNodes + i ] = Nodes[ i ]
+	end
+	return PipelineNode( CopiedNodes )
 end
 
 function PipelineNode:OnStart( Context )
@@ -408,6 +466,10 @@ function PipelineNode:Think( Context )
 	end
 end
 
+function PipelineNode:IsOutputNode( Node )
+	return self.Nodes[ self.NumNodes ]:IsOutputNode( Node )
+end
+
 function PipelineNode:OnFinish( Context, OutputTexture )
 	Context:RemoveNestedContext( self )
 	-- Need to borrow the output texture here to ensure that, if this node is not the final node, its output is cleaned
@@ -426,6 +488,8 @@ end
 	it avoids needing to render the same thing more than once.
 
 	Note that a pipeline here could be a single GUIViewNode, a pipeline, or even another fork node.
+
+	As with pipeline nodes, fork nodes should not be modified after they have been created.
 ]]
 local ForkNode = Shine.TypeDef()
 function ForkNode:Init( Pipelines )
@@ -435,8 +499,16 @@ function ForkNode:Init( Pipelines )
 	return self
 end
 
+function ForkNode:Copy()
+	local CopiedPipelines = TableNew( self.NumPipelines, 0 )
+	for i = 1, self.NumPipelines do
+		CopiedPipelines[ i ] = self.Pipelines[ i ]:Copy()
+	end
+	return ForkNode( CopiedPipelines )
+end
+
 function ForkNode:OnStart( Context )
-	local ActivePipelines = {}
+	local ActivePipelines = TableNew( self.NumPipelines, 0 )
 	-- Start with all pipelines active.
 	for i = 1, self.NumPipelines do
 		local Pipeline = self.Pipelines[ i ]
@@ -444,7 +516,7 @@ function ForkNode:OnStart( Context )
 		Pipeline:OnStart( Context )
 	end
 	Context:SetVariable( self, "ActivePipelines", ActivePipelines )
-	Context:SetVariable( self, "OutputTextures", {} )
+	Context:SetVariable( self, "OutputTextures", TableNew( self.NumPipelines, 0 ) )
 end
 
 function ForkNode:Terminate( Context )
@@ -485,6 +557,16 @@ function ForkNode:Think( Context )
 	end
 end
 
+function ForkNode:IsOutputNode( Node )
+	-- Fork nodes have multiple branches, thus there's multiple output nodes to consider here.
+	for i = 1, self.NumPipelines do
+		if self.Pipelines[ i ]:IsOutputNode( Node ) then
+			return true
+		end
+	end
+	return false
+end
+
 function ForkNode:OnFinish( Context, OutputTextures )
 	for i = 1, self.NumPipelines do
 		self.Pipelines[ i ]:OnFinish( Context, OutputTextures:Get( i ) )
@@ -509,7 +591,9 @@ local PipelineContext = Shine.TypeDef()
 function PipelineContext:Init( Pipeline, Width, Height, Parent )
 	PipelineID = PipelineID + 1
 	self.ID = PipelineID
+	self.Pipeline = Pipeline
 	self.Nodes = Pipeline.Nodes
+	self.NumNodes = Pipeline.NumNodes
 	self.Width = Width
 	self.Height = Height
 	self.Callbacks = {}
@@ -517,9 +601,17 @@ function PipelineContext:Init( Pipeline, Width, Height, Parent )
 	return self:Reset()
 end
 
+function PipelineContext:GetRootPipeline()
+	local Root = self
+	while Root.Parent do
+		Root = Root.Parent
+	end
+	return Root.Pipeline
+end
+
 function PipelineContext:Reset()
-	self.NestedContexts = {}
-	for i = 1, #self.Nodes do
+	self.NestedContexts = TableNew( 0, self.NumNodes )
+	for i = 1, self.NumNodes do
 		-- Use this context for all of the pipeline nodes by default. Nodes can optionally assign themselves a new
 		-- nested context if they need it.
 		self.NestedContexts[ self.Nodes[ i ] ] = self
@@ -544,12 +636,13 @@ function PipelineContext:Terminate()
 		self.CurrentNode:Terminate( self )
 	end
 
-	if self.CurrentTexture then
+	if self.CurrentTexture and not self.CurrentTexture.Pipeline then
 		-- Directly free the current texture, ignoring reference counts. Freeing is idempotent and nothing should be
-		-- retained after termination.
+		-- retained after termination except the final output texture(s).
 		self.CurrentTexture:Free()
-		self.CurrentTexture = nil
 	end
+
+	self.CurrentTexture = nil
 end
 
 function PipelineContext:Restart()
@@ -642,7 +735,7 @@ end
 function PipelineContext:AddCallback( Callback )
 	if self.Finished then
 		-- Call without xpcall here as this is within the context of the caller so will only break them if they error.
-		Callback( self.CurrentTexture )
+		Callback( self.CurrentTexture, self.Pipeline )
 		return
 	end
 	self.Callbacks[ #self.Callbacks + 1 ] = Callback
@@ -675,7 +768,18 @@ function PipelineContext:OnExecutionCompleted( FinalOutputTexture )
 
 	for i = 1, #self.Callbacks do
 		-- Avoid errors in one callback suppressing the others.
-		xpcall( self.Callbacks[ i ], OnError, FinalOutputTexture )
+		xpcall( self.Callbacks[ i ], OnError, FinalOutputTexture, self.Pipeline )
+	end
+end
+
+function PipelineContext:Think()
+	local OutputTexture = self.Pipeline:Think( self )
+	if OutputTexture then
+		self:RemoveHooks()
+		-- Attach the pipeline and parameters to the output texture to allow it to re-render itself if texture data
+		-- is lost later.
+		OutputTexture:SetPipeline( self.Pipeline, self.Width, self.Height )
+		self:OnExecutionCompleted( OutputTexture )
 	end
 end
 
@@ -695,20 +799,95 @@ local function NextPowerOf2( Value )
 end
 
 --[[
+	A helper function to build a pipeline that renders a given node, then blurs it by the given blur radius.
+
+	Input:
+		- Width - the texture width (should be large enough to contain the node's content, plus the blur radius).
+		- Height - the texture height (should be large enough to contain the node's content, plus the blur radius).
+		- BlurRadius - the blur radius in pixels.
+
+	Output: A PipelineNode that can be used to render the given node with blur applied.
+]]
+function RenderPipeline.ApplyBlurToNode( Params )
+	local Width = Params.Width
+	local Height = Params.Height
+	local BlurRadius = Params.BlurRadius
+
+	return PipelineNode( {
+		-- First render the node whose output will be blurred.
+		Params.NodeToBlur,
+		-- Then blur along the y-axis using the given blur radius.
+		GUIViewNode {
+			View = "lua/shine/lib/gui/views/content.lua",
+			Input = ItemSerialiser.SerialiseObjects( {
+				{
+					X = 0,
+					Y = 0,
+					Width = Width,
+					Height = Height,
+					Colour = Colour( 1, 1, 1, 1 ),
+					Shader = "shaders/GUI/menu/gaussianBlurY.surface_shader",
+					ShaderParams = {
+						{ Key = "blurRadius", Value = BlurRadius },
+						{ Key = "rcpFrameY", Value = 1 / Height }
+					},
+					Texture = TextureInput
+				}
+			} )
+		},
+		-- Finally, blur along the x-axis. The final output is a texture containing a blurred version of the original
+		-- node's output.
+		GUIViewNode {
+			View = "lua/shine/lib/gui/views/content.lua",
+			Input = ItemSerialiser.SerialiseObjects( {
+				{
+					X = 0,
+					Y = 0,
+					Width = Width,
+					Height = Height,
+					Colour = Colour( 1, 1, 1, 1 ),
+					Shader = "shaders/GUI/menu/gaussianBlurX.surface_shader",
+					ShaderParams = {
+						{ Key = "blurRadius", Value = BlurRadius },
+						{ Key = "rcpFrameX", Value = 1 / Width }
+					},
+					Texture = TextureInput
+				}
+			} )
+		}
+	} )
+end
+
+--[[
 	A helper function to build a pipeline that renders a box shadow with the given size, blur radius and colour.
+
+	Input:
+		- Width - the box width (will be used to determine the texture width).
+		- Height - the box height (will be used to determine the texture height).
+		- BlurRadius - the blur radius in pixels (will be used to determine the texture size).
+		- Colour - the colour of the box to render as a shadow.
+
+	Outputs:
+		1. A PipelineNode that can be used to render the specified box shadow.
+		2. The width of the texture that should be output by the pipeline (large enough to contain the box and the blur
+		radius).
+		3. The height of the texture that should be output by the pipeline (large enough to contain the box and the blur
+		radius).
 ]]
 function RenderPipeline.BuildBoxShadowPipeline( Params )
 	local Width = Params.Width
 	local Height = Params.Height
 	local BlurRadius = Params.BlurRadius
-	local ShadowColour = Params.Colour
 
 	local TextureWidth = NextPowerOf2( Width + BlurRadius * 2 )
 	local TextureHeight = NextPowerOf2( Height + BlurRadius * 2 )
 
-	return PipelineNode( {
-		-- First render a box in the middle of the texture with the specified colour.
-		GUIViewNode {
+	return RenderPipeline.ApplyBlurToNode( {
+		Width = TextureWidth,
+		Height = TextureHeight,
+		BlurRadius = BlurRadius,
+		-- Render a box in the middle of the texture with the specified colour.
+		NodeToBlur = GUIViewNode {
 			View = "lua/shine/lib/gui/views/content.lua",
 			Input = ItemSerialiser.SerialiseObjects( {
 				{
@@ -716,71 +895,35 @@ function RenderPipeline.BuildBoxShadowPipeline( Params )
 					Y = TextureHeight * 0.5 - Height * 0.5,
 					Width = Width,
 					Height = Height,
-					Colour = ShadowColour
-				}
-			} )
-		},
-		-- Then blur the box along the y-axis using the given blur radius.
-		GUIViewNode {
-			View = "lua/shine/lib/gui/views/content.lua",
-			Input = ItemSerialiser.SerialiseObjects( {
-				{
-					X = 0,
-					Y = 0,
-					Width = TextureWidth,
-					Height = TextureHeight,
-					Colour = Colour( 1, 1, 1, 1 ),
-					Shader = "shaders/GUI/menu/gaussianBlurY.surface_shader",
-					ShaderParams = {
-						{ Key = "blurRadius", Value = BlurRadius },
-						{ Key = "rcpFrameY", Value = 1 / TextureHeight }
-					},
-					Texture = TextureInput
-				}
-			} )
-		},
-		-- Finally, blur the box along the x-axis. The final output is a texture containing a blurred box shadow.
-		GUIViewNode {
-			View = "lua/shine/lib/gui/views/content.lua",
-			Input = ItemSerialiser.SerialiseObjects( {
-				{
-					X = 0,
-					Y = 0,
-					Width = TextureWidth,
-					Height = TextureHeight,
-					Colour = Colour( 1, 1, 1, 1 ),
-					Shader = "shaders/GUI/menu/gaussianBlurX.surface_shader",
-					ShaderParams = {
-						{ Key = "blurRadius", Value = BlurRadius },
-						{ Key = "rcpFrameX", Value = 1 / TextureWidth }
-					},
-					Texture = TextureInput
+					Colour = Params.Colour
 				}
 			} )
 		}
 	} ), TextureWidth, TextureHeight
 end
 
+--[[
+	Executes the given pipeline, allocating textures with the given width and height at each step.
+
+	Inputs:
+		1. The pipeline to execute.
+		2. The desired width of the output texture.
+		3. The desired height of the output texture.
+		4. A callback that will be invoked with the final output texture on completion of the pipeline.
+
+	Output: A context object that can be used to add additional callbacks, or to terminate/restart rendering.
+	Note that once rendering is complete, this context object should be discarded. To re-render the pipeline after
+	completion, use the Refresh() method on the output texture.
+]]
 function RenderPipeline.Execute( Pipeline, Width, Height, OnExecutionCompleted )
 	local Context = PipelineContext( Pipeline, Width, Height )
 	Context:AddCallback( OnExecutionCompleted )
 	Context:Start()
 
-	Hook.Add( "Think", Context, function( DeltaTime )
-		local OutputTexture = Pipeline:Think( Context )
-		if OutputTexture then
-			Context:RemoveHooks()
-			-- Attach the pipeline and parameters to the output texture to allow it to re-render itself if texture data
-			-- is lost later.
-			OutputTexture:SetPipeline( Pipeline, Width, Height )
-			Context:OnExecutionCompleted( OutputTexture )
-		end
-	end )
+	Hook.Add( "Think", Context, BoundMethodCallback( Context, Context.Think ) )
 
 	-- If the render device is lost mid-render, restart the pipeline from scratch, discarding any existing textures.
-	Hook.Add( "OnRenderDeviceReset", Context, function()
-		Context:Restart()
-	end )
+	Hook.Add( "OnRenderDeviceReset", Context, BoundMethodCallback( Context, Context.Restart ) )
 
 	return Context
 end


### PR DESCRIPTION
This is an old branch I've had lying around for years. It implements fully automatic location highlighting on the main minimap for marines and aliens that works on any map.

It uses the location entities to determine how to highlight the current location, which for the most part creates a reasonable result (barring a few places where triggers weren't quite lined up with the playable space, though in such cases it's a useful debug tool for mappers (admittedly it's a bit late for that now though)).

![minimap_highlight_marine](https://github.com/Person8880/Shine/assets/2347788/1371db73-6786-40e2-bce5-744c725736a2)
![minimap_highlight_alien](https://github.com/Person8880/Shine/assets/2347788/dad1c265-f942-4c1b-83d8-bf8e5b06a80a)
![minimap_highlight_hostile](https://github.com/Person8880/Shine/assets/2347788/dd2c3c43-90e5-4b51-a11b-bb9e44f2f7e1)
