### PR TITLE
Fix pregame attack prediction

### DIFF
--- a/lua/shine/cl_init.lua
+++ b/lua/shine/cl_init.lua
@@ -2,7 +2,6 @@
 	Shine client side startup.
 ]]
 
-local include = Script.Load
 local StringFormat = string.format
 
 local Scripts = {

--- a/lua/shine/core/shared/base_plugin/adminmenu.lua
+++ b/lua/shine/core/shared/base_plugin/adminmenu.lua
@@ -2,7 +2,7 @@
 	Admin menu module.
 ]]
 
-if Server then return end
+if Server or Predict then return end
 
 local Shine = Shine
 

--- a/lua/shine/core/shared/base_plugin/adminmenu.lua
+++ b/lua/shine/core/shared/base_plugin/adminmenu.lua
@@ -2,7 +2,7 @@
 	Admin menu module.
 ]]
 
-if Server or Predict then return end
+if not Client then return end
 
 local Shine = Shine
 

--- a/lua/shine/core/shared/base_plugin/commands.lua
+++ b/lua/shine/core/shared/base_plugin/commands.lua
@@ -2,6 +2,8 @@
 	Commands module.
 ]]
 
+if Predict then return end
+
 local Shine = Shine
 
 local rawget = rawget

--- a/lua/shine/core/shared/base_plugin/messaging.lua
+++ b/lua/shine/core/shared/base_plugin/messaging.lua
@@ -2,6 +2,8 @@
 	Messaging module.
 ]]
 
+if Predict then return end
+
 local ChatAPI = require "shine/core/shared/chat/chat_api"
 
 local Shine = Shine

--- a/lua/shine/core/shared/base_plugin/timers.lua
+++ b/lua/shine/core/shared/base_plugin/timers.lua
@@ -2,6 +2,8 @@
 	Timer module.
 ]]
 
+if Predict then return end
+
 local pairs = pairs
 local rawget = rawget
 local setmetatable = setmetatable

--- a/lua/shine/core/shared/config.lua
+++ b/lua/shine/core/shared/config.lua
@@ -362,6 +362,12 @@ do
 	local tonumber = tonumber
 	local unpack = unpack
 
+	local Print = Print
+	if Predict then
+		-- Suppress output from the prediction VM to avoid double-printing.
+		Print = function() end
+	end
+
 	local ValidationContext = Shine.TypeDef()
 	function ValidationContext:Init( MessagePrefix, Config )
 		self.Path = {}

--- a/lua/shine/core/shared/extensions.lua
+++ b/lua/shine/core/shared/extensions.lua
@@ -232,15 +232,15 @@ do
 		return true
 	end
 
-	local function WarnAboutInconsistentCanLoad( self, Name, Plugin, VMName, SharedPluginCanLoad )
+	local function WarnAboutInconsistentCanLoad( Name, Plugin, VMName, SharedPluginCanLoad )
 		if not Plugin.IsShared or not SharedPluginCanLoad then return end
 
 		Print(
-			"[Shine] [Warn] Plugin %s has been prevented from loading on the %s, "..
+			"[Shine] [Warn] Plugin '%s' has been prevented from loading on the %s, "..
 			"but not in shared.lua. If the %s does not prevent loading the plugin "..
 			"then clients will be disconnected with invalid data. Use shared.lua "..
 			"to declare EnabledGamemodes/DisabledGamemodes (or a shared CanPluginLoad hook) to avoid this.",
-			Name, VMName, VMName == "client" and "server" or "client"
+			Name, VMName, VMName == "server" and "client" or "server"
 		)
 	end
 
@@ -299,7 +299,7 @@ do
 
 			local CanLoad, FailureReason = self:CanPluginLoad( Plugin )
 			if not CanLoad then
-				WarnAboutInconsistentCanLoad( self, Name, Plugin, "client", SharedPluginCanLoad )
+				WarnAboutInconsistentCanLoad( Name, Plugin, "client", SharedPluginCanLoad )
 				self.Plugins[ Name ] = nil
 				return false, FailureReason
 			end
@@ -326,8 +326,7 @@ do
 
 			local CanLoad, FailureReason = self:CanPluginLoad( Plugin )
 			if not CanLoad then
-				-- Note that prediction VM doesn't have to register every network message, so it's OK to be inconsistent
-				-- with other VMs here.
+				WarnAboutInconsistentCanLoad( Name, Plugin, "predict VM", SharedPluginCanLoad )
 				self.Plugins[ Name ] = nil
 				return false, FailureReason
 			end
@@ -361,7 +360,7 @@ do
 
 		local CanLoad, FailureReason = self:CanPluginLoad( Plugin )
 		if not CanLoad then
-			WarnAboutInconsistentCanLoad( self, Name, Plugin, "server", SharedPluginCanLoad )
+			WarnAboutInconsistentCanLoad( Name, Plugin, "server", SharedPluginCanLoad )
 			self.Plugins[ Name ] = nil
 			return false, FailureReason
 		end

--- a/lua/shine/core/shared/extensions.lua
+++ b/lua/shine/core/shared/extensions.lua
@@ -963,6 +963,7 @@ if Server then
 	-- plugin state, an entity is required.
 	Hook.Add( "MapPostLoad", "ShinePluginsInfoEntity", function()
 		local PluginsEntity = Server.CreateEntity( ShinePluginsInfoEntity.kMapName )
+		assert( PluginsEntity, "Could not create plugin info entity!" )
 
 		Hook.Add( "OnPluginLoad", PluginsEntity, function( Name )
 			if not PredictPlugins[ Name ] then return end

--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -645,7 +645,7 @@ function Hook.ReplaceLocalFunction( TargetFunc, UpvalueName, Replacement, Differ
 	return Value
 end
 
-do
+if not Predict then
 	--[[
 		Event hooks.
 	]]
@@ -720,7 +720,7 @@ do
 end
 
 do
-	local Environment = Server or Client
+	local Environment = Server or Client or Predict
 	local OriginalHookNWMessage = Environment.HookNetworkMessage
 
 	local function CallEventIfHooked( Event, Name, Arg )
@@ -753,6 +753,16 @@ do
 
 		return OriginalRegisterNetworkMessage( Name )
 	end
+end
+
+if Predict then
+	Hook.CallAfterFileLoad( "lua/Player.lua", function()
+		SetupClassHook( "Player", "OnProcessMove", "OnProcessMove", "PassivePre", { OverrideWithoutWarning = true } )
+	end )
+	Hook.CallAfterFileLoad( "lua/Spectator.lua", function()
+		SetupClassHook( "Spectator", "OnProcessMove", "OnProcessMove", "PassivePre", { OverrideWithoutWarning = true } )
+	end )
+	return
 end
 
 -- Note that it's important to override the initial registration, rather than re-register the message, as the

--- a/lua/shine/core/shared/logging.lua
+++ b/lua/shine/core/shared/logging.lua
@@ -2,30 +2,12 @@
 	Error report handling.
 ]]
 
-local DebugFile = "config://shine/DebugLog.txt"
-
-local ErrorQueue = {}
-local Reported = {}
-
-local URL = "http://51.68.206.223/shine/errorreport.php"
-
-local BuildNumber = Shared.GetBuildNumber()
-local OS = jit and jit.os or "Unknown"
-
-local IsType = Shine.IsType
-local pcall = pcall
 local StringFormat = string.format
-local StringHexToNumber = string.HexToNumber
-local TableConcat = table.concat
-local TableEmpty = table.Empty
-local TableInsert = table.insert
-local tonumber = tonumber
-local tostring = tostring
 
 do
 	local Date = os.date
 	local Writer
-	if Client then
+	if Client or Predict then
 		Writer = function( Text )
 			Print( "%s[Shine] %s", Date( "[%H:%M:%S]" ), Text )
 		end
@@ -38,137 +20,166 @@ do
 	Shine.Logger = Shine.Objects.Logger( Shine.Objects.Logger.LogLevel.INFO, Writer )
 end
 
-local function IsDedicatedServer()
-	if Server then
-		return Server.IsDedicated()
+if Predict then
+	function Shine:AddErrorReport()
+		-- Ignored, predict VM can't send HTTP requests.
 	end
 
-	if IsType( GetGameInfoEntity, "function" ) then
-		local GameInfo = GetGameInfoEntity()
-		if GameInfo and IsType( GameInfo.GetIsDedicated, "function" ) and not GameInfo:GetIsDedicated() then
-			return false
+	function Shine:DebugLog()
+		-- Ignored, predict VM shouldn't be logging to a separate file.
+	end
+else
+	local DebugFile = "config://shine/DebugLog.txt"
+
+	local ErrorQueue = {}
+	local Reported = {}
+
+	local URL = "http://51.68.206.223/shine/errorreport.php"
+
+	local BuildNumber = Shared.GetBuildNumber()
+	local OS = jit and jit.os or "Unknown"
+
+	local IsType = Shine.IsType
+	local pcall = pcall
+	local StringHexToNumber = string.HexToNumber
+	local TableConcat = table.concat
+	local TableEmpty = table.Empty
+	local TableInsert = table.insert
+	local tonumber = tonumber
+	local tostring = tostring
+
+	local function IsDedicatedServer()
+		if Server then
+			return Server.IsDedicated()
 		end
+
+		if IsType( GetGameInfoEntity, "function" ) then
+			local GameInfo = GetGameInfoEntity()
+			if GameInfo and IsType( GameInfo.GetIsDedicated, "function" ) and not GameInfo:GetIsDedicated() then
+				return false
+			end
+		end
+
+		return true
 	end
 
-	return true
-end
+	-- Force disable error reporting in listen servers as they tend to be used for development which creates noisy error
+	-- reports. If an error is truly a problem it will show up on dedicated servers.
+	local function IsErrorReportEnabled()
+		-- Be a bit paranoid here, errors would disrupt the entire reporting system.
+		local Success, IsDedicatedOrErr = pcall( IsDedicatedServer )
+		if not Success then return true end
 
--- Force disable error reporting in listen servers as they tend to be used for development which creates noisy error
--- reports. If an error is truly a problem it will show up on dedicated servers.
-local function IsErrorReportEnabled()
-	-- Be a bit paranoid here, errors would disrupt the entire reporting system.
-	local Success, IsDedicatedOrErr = pcall( IsDedicatedServer )
-	if not Success then return true end
+		return IsDedicatedOrErr
+	end
 
-	return IsDedicatedOrErr
-end
+	local function ReportErrors()
+		if not Shine.Config.ReportErrors then return end
+		if not IsErrorReportEnabled() then return end
+		if #ErrorQueue == 0 then return end
 
-local function ReportErrors()
-	if not Shine.Config.ReportErrors then return end
-	if not IsErrorReportEnabled() then return end
-	if #ErrorQueue == 0 then return end
-
-	TableInsert(
-		ErrorQueue,
-		1,
-		StringFormat(
-			"Operating system: %s. Gamemode: %s. Build number: %s.",
-			OS,
-			Shine.GetGamemode(),
-			BuildNumber
+		TableInsert(
+			ErrorQueue,
+			1,
+			StringFormat(
+				"Operating system: %s. Gamemode: %s. Build number: %s.",
+				OS,
+				Shine.GetGamemode(),
+				BuildNumber
+			)
 		)
-	)
 
-	if Server then
-		local ModCount = Server.GetNumActiveMods()
-		local Mods = {}
-		for i = 1, ModCount do
-			Mods[ i ] = tostring( StringHexToNumber( Server.GetActiveModId( i ) ) )
+		if Server then
+			local ModCount = Server.GetNumActiveMods()
+			local Mods = {}
+			for i = 1, ModCount do
+				Mods[ i ] = tostring( StringHexToNumber( Server.GetActiveModId( i ) ) )
+			end
+
+			TableInsert( ErrorQueue, 2, "Installed mods: "..TableConcat( Mods, ", " ) )
 		end
 
-		TableInsert( ErrorQueue, 2, "Installed mods: "..TableConcat( Mods, ", " ) )
+		local PostData = TableConcat( ErrorQueue, "\n" )
+
+		Shared.SendHTTPRequest( URL, "POST", { error = PostData, blehstuffcake = "enihs" } )
+
+		TableEmpty( ErrorQueue )
 	end
 
-	local PostData = TableConcat( ErrorQueue, "\n" )
-
-	Shared.SendHTTPRequest( URL, "POST", { error = PostData, blehstuffcake = "enihs" } )
-
-	TableEmpty( ErrorQueue )
-end
-
-if Server then
-	Shine.Hook.Add( "EndGame", "ReportQueuedErrors", ReportErrors )
-end
-
-local ErrorReportTimer
-
---[[
-	Adds an error to be reported.
-
-	Inputs:
-		1. The base error message, this should be what the error function from xpcall receives,
-		or a string that defines the error so we don't repeat report it in a session.
-		2. Extra information string.
-		3. Should the extra string be formatted?
-		4. Args to add to the formatting of the extra string.
-]]
-function Shine:AddErrorReport( BaseError, Extra, Format, ... )
-	if not self.Config.ReportErrors then return end
-	if not IsErrorReportEnabled() then return end
-	if Reported[ BaseError ] then return end
-
-	Reported[ BaseError ] = true
-
-	local String
-
-	if Extra then
-		local ExtraString = Format and StringFormat( Extra, ... ) or Extra
-
-		String = StringFormat( "%s\n%s", BaseError, ExtraString )
-	else
-		String = BaseError
+	if Server then
+		Shine.Hook.Add( "EndGame", "ReportQueuedErrors", ReportErrors )
 	end
 
-	ErrorQueue[ #ErrorQueue + 1 ] = String
+	local ErrorReportTimer
 
-	-- We cannot send error reports on disconnect/map change anymore due to HTTP requests being cancelled,
-	-- thus we need to send errors as soon as possible after they occur to avoid them being lost.
-	-- We debounce to ensure we catch a sequence of errors in a single request.
-	ErrorReportTimer = ErrorReportTimer or Shine.Timer.Simple( 1, function()
-		ErrorReportTimer = nil
-		ReportErrors()
-	end )
-	ErrorReportTimer:Debounce()
-end
+	--[[
+		Adds an error to be reported.
 
---[[
-	Logs debug/error messages from hooks and timers.
-]]
-function Shine:DebugLog( String, Format, ... )
-	if not self.Config.DebugLogging then return end
+		Inputs:
+			1. The base error message, this should be what the error function from xpcall receives,
+			or a string that defines the error so we don't repeat report it in a session.
+			2. Extra information string.
+			3. Should the extra string be formatted?
+			4. Args to add to the formatting of the extra string.
+	]]
+	function Shine:AddErrorReport( BaseError, Extra, Format, ... )
+		if not self.Config.ReportErrors then return end
+		if not IsErrorReportEnabled() then return end
+		if Reported[ BaseError ] then return end
 
-	String = Format and StringFormat( String, ... ) or String
+		Reported[ BaseError ] = true
 
-	local File, Err = io.open( DebugFile, "r" )
+		local String
 
-	local Data = ""
+		if Extra then
+			local ExtraString = Format and StringFormat( Extra, ... ) or Extra
 
-	if File then
-		Data = File:read( "*all" )
+			String = StringFormat( "%s\n%s", BaseError, ExtraString )
+		else
+			String = BaseError
+		end
+
+		ErrorQueue[ #ErrorQueue + 1 ] = String
+
+		-- We cannot send error reports on disconnect/map change anymore due to HTTP requests being cancelled,
+		-- thus we need to send errors as soon as possible after they occur to avoid them being lost.
+		-- We debounce to ensure we catch a sequence of errors in a single request.
+		ErrorReportTimer = ErrorReportTimer or Shine.Timer.Simple( 1, function()
+			ErrorReportTimer = nil
+			ReportErrors()
+		end )
+		ErrorReportTimer:Debounce()
+	end
+
+	--[[
+		Logs debug/error messages from hooks and timers.
+	]]
+	function Shine:DebugLog( String, Format, ... )
+		if not self.Config.DebugLogging then return end
+
+		String = Format and StringFormat( String, ... ) or String
+
+		local File, Err = io.open( DebugFile, "r" )
+
+		local Data = ""
+
+		if File then
+			Data = File:read( "*all" )
+			File:close()
+		end
+
+		--If the file gets too big, empty it and start again.
+		if #Data > 51200 then
+			Data = ""
+		end
+
+		File, Err = io.open( DebugFile, "w+" )
+
+		if not File then return end
+
+		File:write( Data, String, "\n" )
 		File:close()
 	end
-
-	--If the file gets too big, empty it and start again.
-	if #Data > 51200 then
-		Data = ""
-	end
-
-	File, Err = io.open( DebugFile, "w+" )
-
-	if not File then return end
-
-	File:write( Data, String, "\n" )
-	File:close()
 end
 
 function Shine:DebugPrint( String, Format, ... )

--- a/lua/shine/core/shared/logging.lua
+++ b/lua/shine/core/shared/logging.lua
@@ -8,8 +8,9 @@ do
 	local Date = os.date
 	local Writer
 	if Client or Predict then
+		local Tag = Predict and " [Predict]" or ""
 		Writer = function( Text )
-			Print( "%s[Shine] %s", Date( "[%H:%M:%S]" ), Text )
+			Print( "%s[Shine]%s %s", Date( "[%H:%M:%S]" ), Tag, Text )
 		end
 	else
 		Writer = function( Text )

--- a/lua/shine/core/shared/misc.lua
+++ b/lua/shine/core/shared/misc.lua
@@ -2,6 +2,30 @@
 	Misc. stuff...
 ]]
 
+do
+	local HookNetworkMessage
+	if Server then
+		HookNetworkMessage = Server.HookNetworkMessage
+	elseif Client then
+		HookNetworkMessage = Client.HookNetworkMessage
+	elseif Predict then
+		HookNetworkMessage = Predict.HookNetworkMessage
+	end
+
+	local NetworkMessageErrorHandler = Shine.BuildErrorHandler( "Network message callback error" )
+
+	--[[
+		Hooks a network message and catches any errors thrown by the callback, allowing them to be reported.
+	]]
+	function Shine.HookNetworkMessage( Name, Callback )
+		return HookNetworkMessage( Name, function( ... )
+			xpcall( Callback, NetworkMessageErrorHandler, ... )
+		end )
+	end
+end
+
+if Predict then return end
+
 Shine.NotificationType = table.AsEnum( { "INFO", "WARNING", "ERROR" }, function( Index ) return Index end )
 
 Shared.RegisterNetworkMessage( "Shine_ClientConfirmConnect", {} )
@@ -12,20 +36,6 @@ do
 	-- Use the real thing, don't rely on a global other mods want to change which then breaks us...
 	function Shine.SendNetworkMessage( ... )
 		return SendNetMessage( ... )
-	end
-end
-
-do
-	local HookNetworkMessage = Server and Server.HookNetworkMessage or Client.HookNetworkMessage
-	local NetworkMessageErrorHandler = Shine.BuildErrorHandler( "Network message callback error" )
-
-	--[[
-		Hooks a network message and catches any errors thrown by the callback, allowing them to be reported.
-	]]
-	function Shine.HookNetworkMessage( Name, Callback )
-		return HookNetworkMessage( Name, function( ... )
-			xpcall( Callback, NetworkMessageErrorHandler, ... )
-		end )
 	end
 end
 

--- a/lua/shine/extensions/pregame/predict.lua
+++ b/lua/shine/extensions/pregame/predict.lua
@@ -1,0 +1,8 @@
+--[[
+	Shine pregame plugin prediction VM.
+]]
+
+-- OnFirstThink isn't called in the prediction VM as there's no update event, so need to set this up at load time.
+Shine.Hook.CallAfterFileLoad( "lua/Player.lua", function()
+	Shine.Hook.SetupClassHook( "Player", "GetCanAttack", "CheckPlayerCanAttack", "ActivePre" )
+end )

--- a/lua/shine/extensions/pregame/shared.lua
+++ b/lua/shine/extensions/pregame/shared.lua
@@ -13,7 +13,14 @@ Plugin.EnabledGamemodes = {
 
 Plugin.ScreenTextID = 2
 
+function Plugin:OnFirstThink()
+	Shine.Hook.SetupClassHook( "Player", "GetCanAttack", "CheckPlayerCanAttack", "ActivePre" )
+end
+
 function Plugin:SetupDataTable()
+	-- Default to true to avoid breaking attacks for everyone...
+	self:AddDTVar( "boolean", "AllowAttack", true )
+
 	self:AddNetworkMessage( "StartDelay", { StartTime = "integer" }, "Client" )
 
 	local MessageTypes = {
@@ -50,6 +57,11 @@ function Plugin:SetupDataTable()
 			"WaitingForMinPlayers"
 		}
 	} )
+end
+
+function Plugin:CheckPlayerCanAttack()
+	-- This is applied on both the client and prediction VMs (server handles this separately).
+	if not self.dt.AllowAttack then return false end
 end
 
 return Plugin

--- a/lua/shine/lib/datatables.lua
+++ b/lua/shine/lib/datatables.lua
@@ -22,11 +22,14 @@
 ]]
 
 local Shine = Shine
+local Hook = Shine.Hook
 
 local Floor = math.floor
 local pairs = pairs
+local rawget = rawget
 local rawset = rawset
 local StringExplode = string.Explode
+local TableGetKeys = table.GetKeys
 local tonumber = tonumber
 local type = type
 
@@ -44,6 +47,14 @@ end
 function DataTableMeta:__SetChangeCallback( Table, Func )
 	rawset( self, "__OnChange", Func )
 	rawset( self, "__Host", Table )
+end
+
+local function DefineDataTableEntity( Name )
+	class( Name )( Entity )
+
+	local DataTableClass = _G[ Name ]
+	DataTableClass.kMapName = Name
+	return DataTableClass
 end
 
 if Server then
@@ -92,7 +103,7 @@ if Server then
 	end
 
 	function DataTableMeta:__newindex( Key, Value )
-		local FieldType = self.__Values[ Key ]
+		local FieldType = rawget( self, "__Values" )[ Key ]
 		if not FieldType then return end
 
 		local Cached = RealData[ self ][ Key ]
@@ -110,34 +121,40 @@ if Server then
 	end
 
 	function DataTableMeta:__SendChange( Key, Value )
-		if self.__Access and self.__Access[ Key ] then
-			local Clients = Shine:GetClientsWithAccess( self.__Access[ Key ] )
+		local Access = rawget( self, "__Access" )
+		local Name = rawget( self, "__Name" )
+
+		if Access and Access[ Key ] then
+			local Clients = Shine:GetClientsWithAccess( Access[ Key ] )
 
 			for i = 1, #Clients do
 				local Client = Clients[ i ]
-
 				if Client then
-					Shine.SendNetworkMessage( Client, self.__Name..Key,
-						{ [ Key ] = Value }, true )
+					Shine.SendNetworkMessage( Client, Name..Key, { [ Key ] = Value }, true )
 				end
 			end
 
 			return
 		end
 
-		Shine.SendNetworkMessage( self.__Name..Key, { [ Key ] = Value }, true )
+		Shine.SendNetworkMessage( Name..Key, { [ Key ] = Value }, true )
+
+		-- If there's a predicted entity, update its network variable too.
+		local DTEntity = rawget( self, "__Entity" )
+		if DTEntity then
+			DTEntity[ Key ] = Value
+		end
 	end
 
 	function DataTableMeta:__SendAll()
-		if self.__Access then
+		local Access = rawget( self, "__Access" )
+		if Access then
 			for Key, Value in pairs( RealData[ self ] ) do
 				self:__SendChange( Key, Value )
 			end
-
 			return
 		end
-
-		Shine.SendNetworkMessage( self.__Name, RealData[ self ], true )
+		Shine.SendNetworkMessage( rawget( self, "__Name" ), RealData[ self ], true )
 	end
 
 	--[[
@@ -148,7 +165,7 @@ if Server then
 		Inputs: Message name, message values, default values, access requirement if applicable.
 		Output: Datatable object.
 	]]
-	function Shine:CreateDataTable( Name, Values, Defaults, Access )
+	function Shine:CreateDataTable( Name, Values, Defaults, Access, Predicted )
 		local Register = Registered[ Name ]
 
 		if Register then
@@ -159,29 +176,64 @@ if Server then
 			return Register
 		end
 
-		Shared.RegisterNetworkMessage( Name, Values )
-
-		for Key, Type in pairs( Values ) do
-			Shared.RegisterNetworkMessage( Name..Key, { [ Key ] = Type } )
-
-			local FirstWord = StringExplode( Type, " ", true )[ 1 ]
-
-			Values[ Key ] = FirstWord
-		end
-
 		local DT = {
 			__Name = Name,
-			__Values = Values,
 			__Access = Access
 		}
 
 		RealData[ DT ] = {}
 
 		local Data = RealData[ DT ]
-
 		for Key, Default in pairs( Defaults ) do
 			Data[ Key ] = Default
 		end
+
+		if Predicted then
+			-- Prediction VM can't receive network messages, it can only see entities. Thus the datatable needs to be
+			-- represented by an entity as well as network messages.
+			local DataTableClass = DefineDataTableEntity( Name )
+			local Keys = TableGetKeys( Values )
+			function DataTableClass:OnCreate()
+				Entity.OnCreate( self )
+
+				-- This is a global utility entity, so always network it.
+				self:SetPropagate( Entity.Propagate_Always )
+
+				-- Initialise the datatable values on creation, future updates are handled by __newindex above.
+				for i = 1, #Keys do
+					local Value = Data[ Keys[ i ] ]
+					if Value ~= nil then
+						self[ Keys[ i ] ] = Value
+					end
+				end
+			end
+
+			Shared.LinkClassToMap( Name, DataTableClass.kMapName, Values )
+
+			Hook.Add( "MapPostLoad", function()
+				local EntityName = DataTableClass.kMapName
+				local DTEntity = Server.CreateEntity( EntityName )
+				assert( DTEntity, "Failed to create datatable entity!" )
+				rawset( DT, "__Entity", DTEntity )
+			end )
+
+			Hook.CallAfterFileLoad( "lua/NS2Gamerules.lua", function()
+				-- Protect the entity from being destroyed whenever the gamerules resets the game world.
+				NS2Gamerules.resetProtectedEntities[ #NS2Gamerules.resetProtectedEntities + 1 ] = Name
+			end )
+		end
+
+		Shared.RegisterNetworkMessage( Name, Values )
+
+		local ValueTypeNames = {}
+		for Key, Type in pairs( Values ) do
+			Shared.RegisterNetworkMessage( Name..Key, { [ Key ] = Type } )
+
+			local FirstWord = StringExplode( Type, " ", true )[ 1 ]
+			ValueTypeNames[ Key ] = FirstWord
+		end
+
+		DT.__Values = ValueTypeNames
 
 		Registered[ Name ] = DT
 
@@ -189,17 +241,16 @@ if Server then
 	end
 
 	-- Obey permissions...
-	Shine.Hook.Add( "ClientConnect", "DataTablesUpdate", function( Client )
+	Hook.Add( "ClientConnect", "DataTablesUpdate", function( Client )
 		for Table, Data in pairs( RealData ) do
-			if not Table.__Access then
-				Shine.SendNetworkMessage( Client, Table.__Name, Data, true )
+			local Access = rawget( Table, "__Access" )
+			local Name = rawget( Table, "__Name" )
+			if not Access then
+				Shine.SendNetworkMessage( Client, Name, Data, true )
 			else
-				local Access = Table.__Access
-
 				for Key, Value in pairs( Data ) do
 					if not Access[ Key ] or Shine:HasAccess( Client, Access[ Key ] ) then
-						Shine.SendNetworkMessage( Client, Table.__Name..Key,
-							{ [ Key ] = Value }, true )
+						Shine.SendNetworkMessage( Client, Name..Key, { [ Key ] = Value }, true )
 					end
 				end
 			end
@@ -221,14 +272,19 @@ function DataTableMeta:ProcessComplete( Data )
 	end
 end
 
+local function OnDataUpdated( self, Key, Value )
+	local OldValue = RealData[ self ][ Key ]
+	RealData[ self ][ Key ] = Value
+
+	local OnChange = rawget( self, "__OnChange" )
+	if OnChange then
+		OnChange( rawget( self, "__Host" ), Key, OldValue, Value )
+	end
+end
+
 -- Processes a partial network message.
 function DataTableMeta:ProcessPartial( Key, Data )
-	local Old = RealData[ self ][ Key ]
-	RealData[ self ][ Key ] = Data[ Key ]
-
-	if self.__OnChange then
-		self.__OnChange( self.__Host, Key, Old, Data[ Key ] )
-	end
+	return OnDataUpdated( self, Key, Data[ Key ] )
 end
 
 --[[
@@ -236,7 +292,7 @@ end
 
 	The client side version can only read values, it cannot write.
 ]]
-function Shine:CreateDataTable( Name, Values, Defaults, Access )
+function Shine:CreateDataTable( Name, Values, Defaults, Access, Predicted )
 	local Register = Registered[ Name ]
 
 	if Register then
@@ -260,6 +316,40 @@ function Shine:CreateDataTable( Name, Values, Defaults, Access )
 	RealData[ DT ] = {}
 
 	local Data = RealData[ DT ]
+
+	if Predicted then
+		local DataTableClass = DefineDataTableEntity( Name )
+		local Keys = TableGetKeys( Values )
+		local NumKeys = #Keys
+		function DataTableClass:OnCreate()
+			Entity.OnCreate( self )
+
+			self:SetPropagate( Entity.Propagate_Always )
+
+			if Predict then
+				local LastSeenState = {}
+				for i = 1, #Keys do
+					local Key = Keys[ i ]
+					LastSeenState[ Key ] = self[ Key ]
+				end
+
+				-- Prediction VM can only "think" in OnProcessMove and doesn't fire field watcher callbacks...
+				Hook.Add( "OnProcessMove", self, function()
+					for i = 1, NumKeys do
+						local Key = Keys[ i ]
+						local LastState = LastSeenState[ Key ]
+						local NewState = self[ Key ]
+						if LastState ~= NewState then
+							LastSeenState[ Key ] = NewState
+							OnDataUpdated( DT, Key, NewState )
+						end
+					end
+				end )
+			end
+		end
+
+		Shared.LinkClassToMap( Name, DataTableClass.kMapName, Values )
+	end
 
 	for Key, Type in pairs( Values ) do
 		if not Access[ Key ] then

--- a/lua/shine/lib/datatables.lua
+++ b/lua/shine/lib/datatables.lua
@@ -358,7 +358,7 @@ function Shine:CreateDataTable( Name, Values, Defaults, Access, Predicted )
 				local LastSeenState = {}
 				for i = 1, #Keys do
 					local Key = Keys[ i ]
-					LastSeenState[ Key ] = self[ Key ]
+					LastSeenState[ Key ] = Data[ Key ]
 				end
 
 				-- Prediction VM can only "think" in OnProcessMove and doesn't fire field watcher callbacks...

--- a/lua/shine/lib/datatables.lua
+++ b/lua/shine/lib/datatables.lua
@@ -110,18 +110,15 @@ if Server then
 		local FieldType = rawget( self, "__Values" )[ Key ]
 		if not FieldType then return end
 
-		local Cached = RealData[ self ][ Key ]
-		if Cached == Value then return end
-
 		local CoercedValue = TypeCheck( FieldType, Value )
 		if CoercedValue == nil then
 			error( StringFormat( "Invalid value provided for datatable field %s (expected %s, got %s)",
 				Key, FieldType, type( Value ) ), 2 )
+		elseif CoercedValue ~= RealData[ self ][ Key ] then
+			RealData[ self ][ Key ] = CoercedValue
+
+			self:__SendChange( Key, CoercedValue )
 		end
-
-		RealData[ self ][ Key ] = CoercedValue
-
-		self:__SendChange( Key, CoercedValue )
 	end
 
 	function DataTableMeta:__SendChange( Key, Value )

--- a/lua/shine/lib/objects/logger.lua
+++ b/lua/shine/lib/objects/logger.lua
@@ -4,6 +4,8 @@
 	Allows setting various levels of logging, and only writing messages at or below the set level.
 ]]
 
+local CodeGen = require "shine/lib/codegen"
+
 local select = select
 local StringFormat = string.format
 
@@ -26,6 +28,55 @@ function Logger:Init( Level, Writer )
 	return self:SetLevel( Level )
 end
 
+local function IsEnabled() return true end
+local function IsDisabled() return false end
+
+local function ExecuteAction( self, Action, ... )
+	return Action( self, ... )
+end
+
+local function DoNothing() end
+
+local LogMethodNames = {}
+local IsEnabledMethodNames = {}
+local IfEnabledMethodNames = {}
+
+local NumLogLevels = #Logger.LogLevel
+for i = 1, NumLogLevels do
+	local LevelName = Logger.LogLevel[ i ]
+	local NiceLevelName = LevelName:sub( 1, 1 )..LevelName:sub( 2 ):lower()
+
+	LogMethodNames[ i ] = NiceLevelName
+	IsEnabledMethodNames[ i ] = StringFormat( "Is%sEnabled", NiceLevelName )
+	IfEnabledMethodNames[ i ] = StringFormat( "If%sEnabled", NiceLevelName )
+
+	-- Generate var-arg functions for this level, this helps avoid trace aborts where logging is involved.
+	local Callers = CodeGen.MakeFunctionGenerator( {
+		Template = [[local NiceLevelName, StringFormat = ...
+		return function( self, Message{Arguments} )
+			return self.Writer( StringFormat( "[%s] %s", NiceLevelName, StringFormat( Message{Arguments} ) ) )
+		end]],
+		ChunkName = function( NumArguments )
+			return StringFormat(
+				"@lua/shine/lib/objects/logger.lua/%sWith%sArg%s",
+				NiceLevelName,
+				NumArguments,
+				NumArguments == 1 and "" or "s"
+			)
+		end,
+		InitialSize = 16,
+		Args = { NiceLevelName, StringFormat }
+	} )
+	-- This is a special case, no string.format call is required on the message here.
+	Callers[ 0 ] = function( self, Message )
+		return self.Writer( StringFormat( "[%s] %s", NiceLevelName, Message ) )
+	end
+
+	Logger[ NiceLevelName ] = function( self, Message, ... )
+		return Callers[ select( "#", ... ) ]( self, Message, ... )
+	end
+end
+
 function Logger:SetLevel( Level )
 	local ProvidedLevel = Level
 	if Shine.IsType( Level, "string" ) then
@@ -36,31 +87,21 @@ function Logger:SetLevel( Level )
 
 	self.Level = Level
 
+	-- For every level enabled, set the methods to log and execute actions.
+	for i = 1, Level do
+		self[ IsEnabledMethodNames[ i ] ] = IsEnabled
+		self[ IfEnabledMethodNames[ i ] ] = ExecuteAction
+		self[ LogMethodNames[ i ] ] = Logger[ LogMethodNames[ i ] ]
+	end
+
+	-- For all levels above the enabled level, set the methods to do nothing.
+	for i = Level + 1, NumLogLevels do
+		self[ IsEnabledMethodNames[ i ] ] = IsDisabled
+		self[ IfEnabledMethodNames[ i ] ] = DoNothing
+		self[ LogMethodNames[ i ] ] = DoNothing
+	end
+
 	return self
-end
-
-for i = 1, #Logger.LogLevel do
-	local LevelName = Logger.LogLevel[ i ]
-	local NiceLevelName = LevelName:sub( 1, 1 )..LevelName:sub( 2 ):lower()
-
-	local function IsLevelEnabled( self )
-		return self.Level >= i
-	end
-
-	Logger[ NiceLevelName ] = function( self, Message, ... )
-		if not IsLevelEnabled( self ) then return end
-
-		local Text = select( "#", ... ) > 0 and StringFormat( Message, ... ) or Message
-		self.Writer( StringFormat( "[%s] %s", NiceLevelName, Text ) )
-	end
-
-	Logger[ "Is"..NiceLevelName.."Enabled" ] = IsLevelEnabled
-
-	Logger[ "If"..NiceLevelName.."Enabled" ] = function( self, Action, ... )
-		if not IsLevelEnabled( self ) then return end
-
-		return Action( self, ... )
-	end
 end
 
 Shine.Objects.Logger = Logger

--- a/lua/shine/predict_init.lua
+++ b/lua/shine/predict_init.lua
@@ -7,7 +7,6 @@ local StringFormat = string.format
 
 -- Load the minimal scripts required to enable extensions, nothing other than game logic is required in this VM.
 local Scripts = {
-	"lib/timer.lua",
 	"core/shared/misc.lua",
 	"core/shared/logging.lua",
 	"core/shared/config.lua",

--- a/lua/shine/predict_init.lua
+++ b/lua/shine/predict_init.lua
@@ -2,16 +2,11 @@
 	Shine prediction VM startup.
 ]]
 
-local include = Script.Load
-local StringFormat = string.format
-
 -- Load the minimal scripts required to enable extensions, nothing other than game logic is required in this VM.
-local Scripts = {
+Shine.LoadScripts( {
 	"core/shared/misc.lua",
 	"core/shared/logging.lua",
 	"core/shared/config.lua",
 	"lib/datatables.lua",
 	"core/shared/extensions.lua"
-}
-
-Shine.LoadScripts( Scripts )
+} )

--- a/lua/shine/predict_init.lua
+++ b/lua/shine/predict_init.lua
@@ -1,0 +1,18 @@
+--[[
+	Shine prediction VM startup.
+]]
+
+local include = Script.Load
+local StringFormat = string.format
+
+-- Load the minimal scripts required to enable extensions, nothing other than game logic is required in this VM.
+local Scripts = {
+	"lib/timer.lua",
+	"core/shared/misc.lua",
+	"core/shared/logging.lua",
+	"core/shared/config.lua",
+	"lib/datatables.lua",
+	"core/shared/extensions.lua"
+}
+
+Shine.LoadScripts( Scripts )

--- a/lua/shine/predict_init.lua
+++ b/lua/shine/predict_init.lua
@@ -10,3 +10,15 @@ Shine.LoadScripts( {
 	"lib/datatables.lua",
 	"core/shared/extensions.lua"
 } )
+
+-- Sync the log level with the configured level for the client, if possible.
+local Data, Err = Shine.LoadJSONFile( "config://shine/cl_config.json" )
+if Data then
+	local ConfigLogLevel = Data.LogLevel
+	if Shine.IsType( ConfigLogLevel, "string" ) then
+		local LogLevel = Shine.Objects.Logger.LogLevel[ ConfigLogLevel:upper() ]
+		if LogLevel then
+			Shine.Logger:SetLevel( LogLevel )
+		end
+	end
+end

--- a/lua/shine/startup.lua
+++ b/lua/shine/startup.lua
@@ -2,8 +2,6 @@
 	Shine entry system startup file.
 ]]
 
-if Predict then return end
-
 local Trace = debug.traceback()
 
 if Trace:find( "Main.lua" ) or Trace:find( "Loading.lua" ) then return end
@@ -68,6 +66,8 @@ if Server then
 	InitScript = "lua/shine/init.lua"
 elseif Client then
 	InitScript = "lua/shine/cl_init.lua"
+elseif Predict then
+	InitScript = "lua/shine/predict_init.lua"
 end
 
 -- Load core scripts upfront to allow hooking into network messages and other such
@@ -85,5 +85,10 @@ Shine.LoadScripts( {
 	"core/shared/hook.lua"
 } )
 
--- This function is totally not inspired by Shine's hook system :P
-ModLoader.SetupFileHook( "lua/ConfigFileUtility.lua", InitScript, "pre" )
+if Predict then
+	-- In the prediction VM, everything needed is already loaded at this point, so can immediately load the init script.
+	Script.Load( InitScript )
+else
+	-- This function is totally not inspired by Shine's hook system :P
+	ModLoader.SetupFileHook( "lua/ConfigFileUtility.lua", InitScript, "pre" )
+end

--- a/test/lib/objects/logger.lua
+++ b/test/lib/objects/logger.lua
@@ -26,13 +26,13 @@ UnitTest:Test( "Message is logged when level is higher", function( Assert )
 	end
 
 	local Instance = Logger( LogLevel.INFO, Writer )
-	Instance:Error( "Error" )
+	Instance:Error( "Error: %s", "test" )
 	Instance:Warn( "Warn" )
-	Instance:Info( "Info" )
+	Instance:Info( "Info: %d", 123 )
 	Instance:Debug( "Debug" )
 	Instance:Trace( "Trace" )
 
-	Assert:ArrayEquals( { "[Error] Error", "[Warn] Warn", "[Info] Info" }, Text )
+	Assert:ArrayEquals( { "[Error] Error: test", "[Warn] Warn", "[Info] Info: 123" }, Text )
 end )
 
 UnitTest:Test( "Is<X>Enabled", function( Assert )


### PR DESCRIPTION
These changes fix #704 by enabling plugins to run within the prediction VM in a limited manner, receiving data table updates from the server which can be used to drive predicted logic.

Note the following limitations:
- Network messages don't get received by the prediction VM despite it having a function to hook them. Thus only data table variables can be used for networking.
- Only plugins that have a `predict.lua` file will be loaded in the prediction VM.
- No `Think` hook exists in the prediction VM (as it has no update event), use `OnProcessMove` instead.