### PR TITLE
Fix a few minor bugs, add option to mute chat sounds

### DIFF
--- a/locale/shine/extensions/improvedchat/enGB.json
+++ b/locale/shine/extensions/improvedchat/enGB.json
@@ -2,6 +2,8 @@
 	"CLIENT_CONFIG_TAB": "Chat",
 	"ANIMATE_MESSAGES_DESCRIPTION": "Animate messages.",
 	"ANIMATE_MESSAGES_TOOLTIP": "Sets whether to move and fade messages into view.",
+	"PLAY_CHAT_SOUND_DESCRIPTION": "Play message sounds.",
+	"PLAY_CHAT_SOUND_TOOLTIP": "Sets whether to play a sound when a new chat message is received.",
 	"BACKGROUND_OPACITY_DESCRIPTION": "Message background opacity (%):",
 	"TEXT_SHADOW_OPACITY_DESCRIPTION": "Text shadow opacity (%):",
 	"MAX_VISIBLE_MESSAGES_DESCRIPTION": "Max messages before fading out:",

--- a/lua/shine/core/shared/base_plugin/networking.lua
+++ b/lua/shine/core/shared/base_plugin/networking.lua
@@ -76,8 +76,8 @@ do
 		Call this function inside shared.lua -> Plugin:SetupDataTable().
 	]]
 	function NetworkingModule:AddNetworkMessage( Name, Params, Receiver )
-		-- Prediction VM should only register messages intended for it to handle.
-		if Predict and Receiver ~= "Predict" and Receiver ~= "Client+Predict" then return end
+		-- Prediction VM should not register network messages, they don't work correctly.
+		if Predict then return end
 
 		self.__NetworkMessages = rawget( self, "__NetworkMessages" ) or {}
 
@@ -106,12 +106,8 @@ do
 			Server.HookNetworkMessage( MessageName, function( Client, Data )
 				xpcall( CallReceiver, NetworkReceiveError, self, Client, Data )
 			end )
-		elseif Client and ( Receiver == "Client" or Receiver == "Client+Predict" ) then
+		elseif Client and Receiver == "Client" then
 			Client.HookNetworkMessage( MessageName, function( Data )
-				xpcall( CallReceiver, NetworkReceiveError, self, Data )
-			end )
-		elseif Predict and ( Receiver == "Predict" or Receiver == "Client+Predict" ) then
-			Predict.HookNetworkMessage( MessageName, function( Data )
 				xpcall( CallReceiver, NetworkReceiveError, self, Data )
 			end )
 		end
@@ -298,7 +294,7 @@ elseif Client then
 		Shine.SendNetworkMessage( MessageName, Data, Reliable )
 	end
 else
-	-- Prediction VM can't send network messages, it can only receive them.
+	-- Prediction VM can't send or receive network messages.
 	function NetworkingModule:SendNetworkMessage( Name )
 		error(
 			StringFormat(

--- a/lua/shine/core/shared/extensions.lua
+++ b/lua/shine/core/shared/extensions.lua
@@ -985,11 +985,13 @@ do
 	end
 end
 
-Shared.RegisterNetworkMessage( "Shine_PluginSync", ClientPlugins )
-Shared.RegisterNetworkMessage( "Shine_PluginEnable", {
-	Plugin = "string (25)",
-	Enabled = "boolean"
-} )
+if not Predict then
+	Shared.RegisterNetworkMessage( "Shine_PluginSync", ClientPlugins )
+	Shared.RegisterNetworkMessage( "Shine_PluginEnable", {
+		Plugin = "string (25)",
+		Enabled = "boolean"
+	} )
+end
 
 local OfficialExtensions
 

--- a/lua/shine/core/shared/hook.lua
+++ b/lua/shine/core/shared/hook.lua
@@ -719,8 +719,18 @@ do
 	Event.Hook( "MapPostLoad", MapPostLoad )
 end
 
+if Predict then
+	Hook.CallAfterFileLoad( "lua/Player.lua", function()
+		SetupClassHook( "Player", "OnProcessMove", "OnProcessMove", "PassivePre", { OverrideWithoutWarning = true } )
+	end )
+	Hook.CallAfterFileLoad( "lua/Spectator.lua", function()
+		SetupClassHook( "Spectator", "OnProcessMove", "OnProcessMove", "PassivePre", { OverrideWithoutWarning = true } )
+	end )
+	return
+end
+
 do
-	local Environment = Server or Client or Predict
+	local Environment = Server or Client
 	local OriginalHookNWMessage = Environment.HookNetworkMessage
 
 	local function CallEventIfHooked( Event, Name, Arg )
@@ -753,16 +763,6 @@ do
 
 		return OriginalRegisterNetworkMessage( Name )
 	end
-end
-
-if Predict then
-	Hook.CallAfterFileLoad( "lua/Player.lua", function()
-		SetupClassHook( "Player", "OnProcessMove", "OnProcessMove", "PassivePre", { OverrideWithoutWarning = true } )
-	end )
-	Hook.CallAfterFileLoad( "lua/Spectator.lua", function()
-		SetupClassHook( "Spectator", "OnProcessMove", "OnProcessMove", "PassivePre", { OverrideWithoutWarning = true } )
-	end )
-	return
 end
 
 -- Note that it's important to override the initial registration, rather than re-register the message, as the

--- a/lua/shine/core/shared/misc.lua
+++ b/lua/shine/core/shared/misc.lua
@@ -9,7 +9,8 @@ do
 	elseif Client then
 		HookNetworkMessage = Client.HookNetworkMessage
 	elseif Predict then
-		HookNetworkMessage = Predict.HookNetworkMessage
+		-- Do nothing on the prediction VM as network messages don't work correctly.
+		HookNetworkMessage = function() end
 	end
 
 	local NetworkMessageErrorHandler = Shine.BuildErrorHandler( "Network message callback error" )

--- a/lua/shine/extensions/improvedchat/client.lua
+++ b/lua/shine/extensions/improvedchat/client.lua
@@ -1179,9 +1179,9 @@ do
 		end
 
 		if self.GUIChat:AddRichTextMessage( MessageData.Message ) then
-			if self.Config.PlayChatSound then
+			if not MessageData.SuppressSound and self.Config.PlayChatSound then
 				local Player = Client.GetLocalPlayer()
-				if Player and not MessageData.SuppressSound and Player.GetChatSound then
+				if Player and Player.GetChatSound then
 					StartSoundEffect( Player:GetChatSound() )
 				end
 			end

--- a/lua/shine/extensions/improvedchat/client.lua
+++ b/lua/shine/extensions/improvedchat/client.lua
@@ -21,6 +21,7 @@ local Max = math.max
 local OSDate = os.date
 local Round = math.Round
 local RoundTo = math.RoundTo
+local StringEndsWith = string.EndsWith
 local StringFormat = string.format
 local StringFind = string.find
 local StringMatch = string.match
@@ -64,6 +65,9 @@ Plugin.DefaultConfig = {
 	-- UPWARDS - new messages at the bottom and move up as more messages appear.
 	-- DOWNWARDS - the vanilla method, new messages are added below older ones (in case anyone actually likes this).
 	MessageDisplayType = Plugin.MessageDisplayType.UPWARDS,
+
+	-- Whether to play a sound when a chat message is received.
+	PlayChatSound = true,
 
 	-- The alpha multiplier to apply to the text shadow on chat messages.
 	TextShadowOpacity = 1
@@ -561,7 +565,19 @@ do
 	end
 end
 
+function Plugin:CanStartSoundEffect( EffectName )
+	-- This is a fairly crude suppression, it assumes that the only places calling StartSoundEffect() with a sound
+	-- ending with "/chat" are associated with the chat system itself. This is true in the vanilla game, but may not be
+	-- elsewhere. Unfortunately, the vanilla code embeds sound effects deep within local functions that are hard to
+	-- reach, so this is the only foolproof detection method.
+	if not self.Config.PlayChatSound and IsType( EffectName, "string" ) and StringEndsWith( EffectName, "/chat" ) then
+		return false
+	end
+end
+
 function Plugin:OnFirstThink()
+	Shine.Hook.SetupGlobalHook( "StartSoundEffect", "CanStartSoundEffect", "Halt" )
+
 	SGUI.NotificationManager.RegisterHint( CHAT_CONFIG_HINT_NAME, {
 		MaxTimes = 1,
 		MessageSupplier = function()
@@ -1163,9 +1179,11 @@ do
 		end
 
 		if self.GUIChat:AddRichTextMessage( MessageData.Message ) then
-			local Player = Client.GetLocalPlayer()
-			if Player and not MessageData.SuppressSound and Player.GetChatSound then
-				StartSoundEffect( Player:GetChatSound() )
+			if self.Config.PlayChatSound then
+				local Player = Client.GetLocalPlayer()
+				if Player and not MessageData.SuppressSound and Player.GetChatSound then
+					StartSoundEffect( Player:GetChatSound() )
+				end
 			end
 
 			Hook.Call( "OnRichTextChatMessageDisplayed", MessageData )
@@ -1330,6 +1348,18 @@ Plugin.ClientConfigSettings = {
 		Type = "Boolean",
 		CommandMessage = function( Value )
 			return StringFormat( "Chat messages %s.", Value and "will now animate" or "will no longer animate" )
+		end,
+		Tooltip = true
+	},
+	{
+		ConfigKey = "PlayChatSound",
+		Command = "sh_chat_playchatsound",
+		Type = "Boolean",
+		CommandMessage = function( Value )
+			return StringFormat(
+				"A sound %s.",
+				Value and "will now be played for new chat messages" or "will no longer be played for new chat messages"
+			)
 		end,
 		Tooltip = true
 	},

--- a/lua/shine/lib/datatables.lua
+++ b/lua/shine/lib/datatables.lua
@@ -326,7 +326,9 @@ function Shine:CreateDataTable( Name, Values, Defaults, Access, Predicted )
 		return Register
 	end
 
-	Shared.RegisterNetworkMessage( Name, Values )
+	if not Predict then
+		Shared.RegisterNetworkMessage( Name, Values )
+	end
 
 	local DT = {
 		__Name = Name,
@@ -388,18 +390,22 @@ function Shine:CreateDataTable( Name, Values, Defaults, Access, Predicted )
 			Data[ Key ] = Defaults[ Key ]
 		end
 
-		local ID = GetFieldNetworkMessageName( Name, Key )
+		if not Predict then
+			local ID = GetFieldNetworkMessageName( Name, Key )
 
-		Shared.RegisterNetworkMessage( ID, { [ Key ] = Type } )
+			Shared.RegisterNetworkMessage( ID, { [ Key ] = Type } )
 
-		Shine.HookNetworkMessage( ID, function( Data )
-			return DT:ProcessPartial( Key, Data )
-		end )
+			Shine.HookNetworkMessage( ID, function( Data )
+				return DT:ProcessPartial( Key, Data )
+			end )
+		end
 	end
 
-	Shine.HookNetworkMessage( Name, function( Data )
-		return DT:ProcessComplete( Data )
-	end )
+	if not Predict then
+		Shine.HookNetworkMessage( Name, function( Data )
+			return DT:ProcessComplete( Data )
+		end )
+	end
 
 	Registered[ Name ] = DT
 

--- a/lua/shine/lib/debug.lua
+++ b/lua/shine/lib/debug.lua
@@ -504,7 +504,7 @@ do
 		__PrintAsString = true
 	} )
 
-	local MAX_STACK_LEVELS_BEFORE_STACK_OVERFLOW = 50
+	local MAX_STACK_LEVELS_BEFORE_STACK_OVERFLOW = 250
 	local INFO_MASK = "Snl"
 	function Shine.StackDump( Level )
 		Level = Level or 1

--- a/lua/shine/lib/gui/font_manager.lua
+++ b/lua/shine/lib/gui/font_manager.lua
@@ -255,7 +255,12 @@ Shine.Hook.Add( "OnMapLoad", "CalculateFontSizes", function()
 			local MaxHeight = 0
 			for j = 1, #Chars do
 				local Char = Chars[ j ]
-				if GetCanFontRenderString( Font, Char ) then
+
+				-- If this errors, the font is invalid and won't be usable, so don't both looking further.
+				local Success, CanRender = pcall( GetCanFontRenderString, Font, Char )
+				if not Success then return end
+
+				if CanRender then
 					local Size = CalculateTextSize( Font, Char )
 					MaxHeight = Max( MaxHeight, Size.y )
 

--- a/lua/shine/lib/query.lua
+++ b/lua/shine/lib/query.lua
@@ -5,6 +5,7 @@
 local HTTPRequest = Shared.SendHTTPRequest
 local IsType = Shine.IsType
 local Time = Shared.GetSystemTimeReal
+local Timer = Shine.Timer
 local xpcall = xpcall
 
 do
@@ -17,10 +18,12 @@ do
 	local BaseURL = "http://51.68.206.223/shine/serverquery.php"
 
 	local QueryCache = {}
-	local function CallbackFailed( CacheKey, Callback )
-		QueryCache[ CacheKey ] = { Data = {}, ExpireTime = Time() + 10 }
+	local function CallbackFailed( CacheKey, Callbacks )
+		QueryCache[ CacheKey ] = { ExpireTime = Time() + 10 }
 
-		xpcall( Callback, OnError )
+		for i = 1, #Callbacks do
+			xpcall( Callbacks[ i ][ 1 ], OnError )
+		end
 	end
 
 	local function CacheResult( CacheKey, Data )
@@ -41,129 +44,217 @@ do
 
 		if Cache and Cache.ExpireTime > Time() then
 			local Data = Cache.Data
+			-- Delay by a tick/frame to retain the asynchronous nature of the callback (avoids logic running before the
+			-- function returns here).
+			Timer.Simple( 0, function()
+				if not Data then
+					xpcall( Callback, OnError )
+				else
+					Wrapper( Data, Callback )
+				end
+			end )
 
-			if not Data[ 1 ] then
-				Callback()
-
-				return
-			end
-
-			Wrapper( Data, Callback )
-
-			return
+			return true
 		end
 
-		local Params = {
-			servers = Encode( {
-				{ ip = IP, port = tostring( Port ) }
-			} )
-		}
+		if not Cache then
+			Cache = { ExpireTime = 0 }
+			QueryCache[ CacheKey ] = Cache
+		end
 
-		HTTPRequest( BaseURL, "POST", Params, function( Body )
-			if not Body or #Body == 0 then
-				CallbackFailed( CacheKey, Callback )
+		-- De-duplicate all attempts to query this IP + port until a response is received.
+		Cache.Callbacks = Cache.Callbacks or {}
+		Cache.Callbacks[ #Cache.Callbacks + 1 ] = { Callback, Wrapper }
 
-				return
+		if #Cache.Callbacks == 1 then
+			local Params = {
+				servers = Encode( {
+					{ ip = IP, port = tostring( Port ) }
+				} )
+			}
+
+			local function OnFailure()
+				CallbackFailed( CacheKey, Cache.Callbacks )
 			end
 
-			local Data = Decode( Body )
+			Shine.TimedHTTPRequest( BaseURL, "POST", Params, function( Body )
+				local Data = Body and Decode( Body )
+				if not IsType( Data, "table" ) or #Data == 0 then
+					OnFailure()
+					return
+				end
 
-			if not IsType( Data, "table" ) or #Data == 0 then
-				CallbackFailed( CacheKey, Callback )
+				CacheResult( CacheKey, Data )
 
-				return
-			end
+				for i = 1, #Cache.Callbacks do
+					local CallbackData = Cache.Callbacks[ i ]
+					local QueuedCallback = CallbackData[ 1 ]
+					local Wrapper = CallbackData[ 2 ]
+					Wrapper( Data, QueuedCallback )
+				end
+			end, OnFailure )
+		end
 
-			CacheResult( CacheKey, Data )
-
-			Wrapper( Data, Callback )
-		end )
+		return false
 	end
 
 	--[[
 		Query the state of a single server.
+
+		Callback should have the following signature:
+		function( NumPlayers, MaxPlayers )
+			-- NumPlayers is the number of players on the server.
+			-- MaxPlayers is the maximum number of players on the server (not accounting for reserved slots).
+		end
+
+		If the server status cannot be retrieved, the callback will be invoked with no arguments.
+
+		Returns true if data has been previously retrieved and not yet expired, false if a new request was made.
 	]]
 	function Shine.QueryServerPopulation( IP, Port, Callback )
-		QueryServer( IP, Port, Callback, PopulationWrapper )
+		Shine.TypeCheck( IP, "string", 1, "QueryServerPopulation" )
+		Shine.TypeCheck( Port, { "number", "string" }, 2, "QueryServerPopulation" )
+		Shine.AssertAtLevel( Shine.IsCallable( Callback ), "Callback must be callable!", 3 )
+
+		return QueryServer( IP, Port, Callback, PopulationWrapper )
 	end
 
 	--[[
 		Queries for the entire server data of a single server.
+
+		Callback should have the following signature:
+		function( Data )
+			-- Data is a table with the following fields:
+			-- "numberOfPlayers" - number of players on the server.
+			-- "maxPlayers" - max players on the server (not accounting for reserved slots).
+			-- "serverTags" - a "|" delimited string containing the tags for the server.
+			-- Additional fields may be present, but should not be relied upon.
+		end
+
+		If the server status cannot be retrieved, the callback will be invoked with no arguments.
+
+		Returns true if data has been previously retrieved and not yet expired, false if a new request was made.
 	]]
 	function Shine.QueryServer( IP, Port, Callback )
-		QueryServer( IP, Port, Callback, FullDataWrapper )
+		Shine.TypeCheck( IP, "string", 1, "QueryServer" )
+		Shine.TypeCheck( Port, { "number", "string" }, 2, "QueryServer" )
+		Shine.AssertAtLevel( Shine.IsCallable( Callback ), "Callback must be callable!", 3 )
+
+		return QueryServer( IP, Port, Callback, FullDataWrapper )
 	end
 end
 
 local OnError = Shine.BuildErrorHandler( "HTTP request callback error" )
-local Timer = Shine.Timer
-
 local DefaultTimeout = 5
 
 --[[
-	Performs a HTTP request that will call a timeout function
-	if it takes too long to respond.
+	Performs a HTTP request that will call a timeout function if it takes too long to respond.
 
 	Inputs:
 		1. URL.
 		2. Protocol, i.e "GET" or "POST".
 		3. Params table for "POST".
-		4. OnSuccess callback to run.
-		5. OnTimeout callback to run.
+		4. OnResponse callback to run (called on success, or if a network error occurs).
+		5. OnTimeout callback to run (called if no response or error is returned within the given timeout).
 		6. Optional timeout time, otherwise the timeout time is 5 seconds.
 ]]
-function Shine.TimedHTTPRequest( URL, Protocol, Params, OnSuccess, OnTimeout, Timeout )
-	local NeedParams = true
+function Shine.TimedHTTPRequest( URL, Protocol, Params, OnResponse, OnTimeout, Timeout )
+	Shine.TypeCheck( URL, "string", 1, "TimedHTTPRequest" )
+	Shine.TypeCheck( Protocol, "string", 2, "TimedHTTPRequest" )
+
+	local NumParams = 6
 
 	if Protocol ~= "POST" and not IsType( Params, "table" ) then
 		Timeout = OnTimeout
-		OnTimeout = OnSuccess
-		OnSuccess = Params
-		NeedParams = false
+		OnTimeout = OnResponse
+		OnResponse = Params
+		Params = nil
+		NumParams = 5
+	else
+		Shine.TypeCheck( Params, "table", 3, "TimedHTTPRequest" )
 	end
 
 	Timeout = Timeout or DefaultTimeout
 
-	local TimeoutTime = Time() + Timeout
+	Shine.AssertAtLevel( Shine.IsCallable( OnResponse ), "Response callback must be callable!", 3 )
+	Shine.AssertAtLevel( Shine.IsCallable( OnTimeout ), "Timeout callback must be callable!", 3 )
+	Shine.TypeCheck( Timeout, "number", NumParams, "TimedHTTPRequest" )
+
 	local Succeeded
+	local TimeoutTimer
 
 	local function Callback( Data, ... )
-		if Time() > TimeoutTime then
-			return
-		end
+		if Succeeded ~= nil then return end
 
 		Succeeded = true
 
-		xpcall( OnSuccess, OnError, Data, ... )
+		if TimeoutTimer then
+			TimeoutTimer:Destroy()
+			TimeoutTimer = nil
+		end
+
+		xpcall( OnResponse, OnError, Data, ... )
 	end
 
-	if NeedParams then
+	if Params then
 		HTTPRequest( URL, Protocol, Params, Callback )
 	else
 		HTTPRequest( URL, Protocol, Callback )
 	end
 
-	Timer.Simple( Timeout, function()
-		if not Succeeded then
-			xpcall( OnTimeout, OnError )
-		end
+	TimeoutTimer = Timer.Simple( Timeout, function()
+		if Succeeded ~= nil then return end
+
+		Succeeded = false
+
+		xpcall( OnTimeout, OnError )
 	end )
 end
 
 --[[
-	Sends a request to a given URL, accounting for timeouts and retrying up to the given
-	number of max attempts.
+	Sends a request to a given URL, accounting for timeouts and retrying up to the given number of max attempts.
+
+	Callbacks should be a table (or other indexable object) providing the following functions:
+	{
+		OnSuccess = function( Body, Err, ErrCode )
+			-- Called when the request is completed, passed the response body. If the request fails due to a network
+			-- error, the body will be an empty string, and a network error message and network error code will be
+			-- provided. This is not ideal, but is maintained for backwards compatibility.
+		end,
+		OnTimeout = function( AttemptNumber )
+			-- Called when the request times out on a given attempt (optional).
+		end,
+		OnFailure = function()
+			-- Called when all attempts have failed due to timeouts (optional).
+		end
+	}
 ]]
 function Shine.HTTPRequestWithRetry( URL, Protocol, Params, Callbacks, MaxAttempts, Timeout )
-	local NeedParams = true
+	Shine.TypeCheck( URL, "string", 1, "HTTPRequestWithRetry" )
+	Shine.TypeCheck( Protocol, "string", 2, "HTTPRequestWithRetry" )
+
+	local NumParams = 6
+
 	if Protocol ~= "POST" and not IsType( Callbacks, "table" ) then
 		Timeout = MaxAttempts
 		MaxAttempts = Callbacks
 		Callbacks = Params
-		NeedParams = false
+		Params = nil
+		NumParams = 5
+	else
+		Shine.TypeCheck( Params, "table", 3, "HTTPRequestWithRetry" )
 	end
 
 	MaxAttempts = MaxAttempts or 3
+
+	Shine.TypeCheck( MaxAttempts, "number", NumParams - 1, "HTTPRequestWithRetry" )
+	if Timeout then Shine.TypeCheck( Timeout, "number", NumParams, "HTTPRequestWithRetry" ) end
+
+	local OnTimeoutCallback = Callbacks.OnTimeout
+	local OnFailureCallback = Callbacks.OnFailure
+	local OnSuccessCallback = Callbacks.OnSuccess
+
+	Shine.AssertAtLevel( Shine.IsCallable( OnSuccessCallback ), "OnSuccess callback must be callable!", 3 )
 
 	local Attempts = 0
 	local Submit
@@ -171,12 +262,14 @@ function Shine.HTTPRequestWithRetry( URL, Protocol, Params, Callbacks, MaxAttemp
 	local function OnTimeout()
 		Attempts = Attempts + 1
 
-		if Callbacks.OnTimeout then
-			Callbacks.OnTimeout( Attempts )
+		if Shine.IsCallable( OnTimeoutCallback ) then
+			OnTimeoutCallback( Attempts )
 		end
 
 		if Attempts >= MaxAttempts then
-			Callbacks.OnFailure()
+			if Shine.IsCallable( OnFailureCallback ) then
+				OnFailureCallback()
+			end
 			return
 		end
 
@@ -184,14 +277,13 @@ function Shine.HTTPRequestWithRetry( URL, Protocol, Params, Callbacks, MaxAttemp
 	end
 
 	Submit = function()
-		if NeedParams then
-			Shine.TimedHTTPRequest( URL, Protocol, Params, Callbacks.OnSuccess, OnTimeout, Timeout )
-		else
-			Shine.TimedHTTPRequest( URL, Protocol, Callbacks.OnSuccess, OnTimeout, Timeout )
+		if Params then
+			return Shine.TimedHTTPRequest( URL, Protocol, Params, OnSuccessCallback, OnTimeout, Timeout )
 		end
+		return Shine.TimedHTTPRequest( URL, Protocol, OnSuccessCallback, OnTimeout, Timeout )
 	end
 
-	Submit()
+	return Submit()
 end
 
 Script.Load( "lua/shine/lib/external_apis.lua" )

--- a/lua/shine/predict_init.lua
+++ b/lua/shine/predict_init.lua
@@ -2,6 +2,18 @@
 	Shine prediction VM startup.
 ]]
 
+Shine.Hook.CallAfterFileLoad( "lua/DebugUtility.lua", function()
+	local OldLog = _G.Log
+	if Shine.IsType( OldLog, "function" ) then
+		local pcall = pcall
+		function Log( FormatString, ... )
+			-- Suppress errors in log output to stop prediction VM stutter. The game has some broken log statements
+			-- that were never tested.
+			pcall( OldLog, FormatString, ... )
+		end
+	end
+end )
+
 -- Load the minimal scripts required to enable extensions, nothing other than game logic is required in this VM.
 Shine.LoadScripts( {
 	"core/shared/misc.lua",


### PR DESCRIPTION
#### Improved Chat
* Added an option to control whether a sound is played when a chat message is displayed.

#### Misc
* Improved type checking in HTTP request functions.
* Fixed race condition that could cause `Shine.TimedHTTPRequest` to invoke both the response and timeout callbacks.
* The `OnFailure` callback for `Shine.HTTPRequestWithRetry` is now optional.
* Server population query functions now de-duplicate requests when cached data is unavailable and catch errors when invoking a callback with a cached failure response.
* Fixed error stack traces being cut off early due to overly sensitive stack overflow detection.
* Fixed corrupt/invalid font files causing errors at startup when pre-calculating font sizes.
* Fixed issues with predict VM logging and removed all network message interactions (these changes have been released already in a hotfix, except for the removal of message registration).