### PR TITLE
Fix webpage UI never loading the provided URL

### DIFF
--- a/lua/shine/core/shared/webpage.lua
+++ b/lua/shine/core/shared/webpage.lua
@@ -214,8 +214,7 @@ function Shine:OpenWebpage( URL, TitleText )
 
 	local Webpage = Window:Add( "Webpage" )
 	Webpage:SetPos( Vector2( BarPadding, TitleBarH * 2 + BarPadding * 2 ) )
-	-- Replace the initial data-URL to avoid being able to go back to it.
-	Webpage:LoadURL( URL, WebpageWidth, WebpageHeight, true )
+	Webpage:LoadURL( URL, WebpageWidth, WebpageHeight )
 
 	WebpageControls:SetWebpage( Webpage )
 

--- a/lua/shine/lib/gui/objects/webpage.lua
+++ b/lua/shine/lib/gui/objects/webpage.lua
@@ -104,14 +104,15 @@ function Webpage:LoadURL( URL, W, H, Replace )
 		self.WebView:HookJSAlert( function( WebView, AlertText )
 			xpcall( self.OnJSAlert, OnAlertError, self, WebView, AlertText )
 		end )
+
+		self.HasSetInitialURL = false
 	end
 
-	if Replace then
+	if Replace and self.HasSetInitialURL then
 		-- Overwrite the current URL with the given URL to avoid it showing up in the history.
-		-- This is mainly useful for the initial URL load, as the first URL loaded is a basic data-URL with an empty
-		-- HTML body which doesn't make sense to navigate back to.
 		self:ExecuteJS( StringFormat( [[location.replace( "%s" );]], EscapeStringForJavaScript( URL ) ) )
 	else
+		self.HasSetInitialURL = true
 		self.WebView:LoadUrl( URL )
 	end
 


### PR DESCRIPTION
#### MOTD

* Fixed webpages not loading after recent behaviour changes to the game's web browser in a Steam update.

#### API

* Fixed `Shine:OpenWebpage` not loading the provided URL.
* Fixed the `Replace` argument on `WebPage:LoadURL()` not working if provided on the first call to load a URL.